### PR TITLE
Added link to nested README for build deps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Use ``make`` to check that you are using correct
 `reStructuredText <https://docutils.sourceforge.io/rst.html>`__ or
 `Markdown <https://pandoc.org/MANUAL.html#pandocs-markdown>`__ syntax,
 and double-check the generated ``draft-*.html`` file before filing a Pull Request.
-
+See `here <protocol/README.rst>`__ for the project dependencies.
 
 NU5 ZIPs
 --------


### PR DESCRIPTION
Currently, the main README documents the build process to generate the PDFs and html files for the ZIPs/Protocol specs, however, following the README doesn't work as is (the build deps aren't documented). To fix this, we need to link to the nested README in `protocol/README` to install dependencies and then build the documents.