### PR TITLE
Updates to issue bundle hash personalizations

### DIFF
--- a/zip-0227.html
+++ b/zip-0227.html
@@ -514,7 +514,7 @@ T.5b: issuanceValidatingKey   (32 bytes)</pre>
 T.5a.ii : assetDescription        (field encoding bytes)
 T.5a.iii: flagsIssuance           (1 byte)</pre>
                     <p>The personalization field of this hash is set to:</p>
-                    <pre>"ZTxIdIssActHash"</pre>
+                    <pre>"ZTxIdIssActHash_" (1 underscore character)</pre>
                     <section id="t-5a-i-issue-notes-digest"><h5><span class="section-heading">T.5a.i: issue_notes_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-issue-notes-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>A BLAKE2b-256 hash of Note information for all Notes belonging to the Issuance Action. For each Note, the following elements are included in the hash:</p>
                         <pre>T.5a.i.1: recipient                    (field encoding bytes)
@@ -523,7 +523,7 @@ T.5a.i.3: assetBase                    (field encoding bytes)
 T.5a.i.4: rho                          (field encoding bytes)
 T.5a.i.5: rseed                        (field encoding bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
-                        <pre>"ZTxIdIANoteHash"</pre>
+                        <pre>"ZTxIdIANoteHash_" (1 underscore character)</pre>
                         <section id="t-5a-i-1-recipient"><h6><span class="section-heading">T.5a.i.1: recipient</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-1-recipient"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-25" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">22</a>.</p>
                         </section>

--- a/zip-0227.rst
+++ b/zip-0227.rst
@@ -369,7 +369,7 @@ A BLAKE2b-256 hash of Issue Action information for all Issuance Actions belongin
 
 The personalization field of this hash is set to::
 
-  "ZTxIdIssActHash"
+  "ZTxIdIssActHash_" (1 underscore character)
 
 T.5a.i: issue_notes_digest
 ''''''''''''''''''''''''''
@@ -383,7 +383,7 @@ A BLAKE2b-256 hash of Note information for all Notes belonging to the Issuance A
 
 The personalization field of this hash is set to::
 
-  "ZTxIdIANoteHash"
+  "ZTxIdIANoteHash_" (1 underscore character)
 
 T.5a.i.1: recipient
 ...................


### PR DESCRIPTION
A few of the issue bundle hash personalizations were 15 characters long instead of the required 16. This is being fixed here.