### PR TITLE
Removed redundant terminology in ZIP226, building on ZIP227

### DIFF
--- a/zip-0226.html
+++ b/zip-0226.html
@@ -27,62 +27,51 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>The key word "MUST" in this document is to be interpreted as described in RFC 2119 <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a>.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">2</a>.</p>
             <p>The terms "Orchard" and "Action" in this document are to be interpreted as described in ZIP 224 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0224">4</a>.</p>
+            <p>The terms "Asset", "Custom Asset" and "Wrapped Asset" in this document are to be interpreted as described in ZIP 227 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0227">6</a>.</p>
             <p>We define the following additional terms:</p>
             <ul>
-                <li>Asset: A type of note that can be transferred on the Zcash block chain, identified by the
-                    <span class="math">\(\mathsf{AssetId}\)</span>
-                 parameter.
-                    <ul>
-                        <li>ZEC is the default (and currently the only defined) Asset for the Zcash mainnet.</li>
-                        <li>TAZ is the default (and currently the only defined) Asset for the Zcash testnet.</li>
-                        <li>We use the term "Custom Asset" to refer to any Asset other than ZEC and TAZ.</li>
-                    </ul>
-                </li>
-                <li>Native Asset: a Custom Asset with issuance defined on the Zcash block chain.</li>
-                <li>Wrapped Asset: a Custom Asset with native issuance defined outside the Zcash block chain.</li>
                 <li>Split Input: an Action input used to ensure that the output note of that Action is of a validly issued
                     <span class="math">\(\mathsf{AssetBase}\)</span>
-                 when there is no corresponding real input note, in situations where the number of outputs are larger than the number of inputs. See formal definition in <a href="#split-notes">Split Notes</a>.</li>
+                 (see <a id="footnote-reference-5" class="footnote_reference" href="#zip-0227-assetidentifier">7</a>) when there is no corresponding real input note, in situations where the number of outputs are larger than the number of inputs. See formal definition in <a href="#split-notes">Split Notes</a>.</li>
                 <li>Split Action: an Action that contains a Split Input.</li>
             </ul>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>ZIP 226 and ZIP 227 propose in conjunction the Zcash Shielded Assets (ZSA) protocol — a set of protocol features that enable the creation, transfer, and burn of Custom Assets on the Zcash chain.</p>
-            <p>Creation of such Assets is defined in ZIP 227 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0227">6</a>. Transfer and burn of such Assets is defined in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">5</a>. The ZSA protocol is proposed to be instantiated by a modification to the Orchard protocol, as specified in these ZIPs (although it has been designed with adaption to possible future shielded protocols in mind).</p>
+            <p>The ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">6</a>. The ZSA protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of custom Assets on the Zcash chain. The creation of such Assets is defined in ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">6</a>, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226). While the proposed ZSA protocol is a modification to the Orchard protocol, it has been designed with adaption to possible future shielded protocols in mind.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>None of the currently deployed Zcash transfer protocols support Custom Assets. Enabling multi-asset support on the Zcash chain will open the door for a host of applications, and enhance the ecosystem with application developers and Asset custody institutions for issuance and bridging purposes.</p>
+            <p>None of the currently deployed Zcash transfer protocols support Custom Assets. Enabling multi-asset support on the Zcash chain will open the door for a host of applications, and enhance the ecosystem with application developers and Asset custody institutions for issuance and bridging purposes. This ZIP builds on the issuance mechanism introduced in ZIP 227 <a id="footnote-reference-8" class="footnote_reference" href="#zip-0227">6</a>.</p>
         </section>
         <section id="overview"><h2><span class="section-heading">Overview</span><span class="section-anchor"> <a rel="bookmark" href="#overview"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>In order to be able to represent different Assets, we need to define a data field that uniquely represents the Asset in question, which we call the Asset Identifier
                 <span class="math">\(\mathsf{AssetId}\)</span>
             . This Asset Identifier maps to an Asset Base
                 <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
-             that is stored in Orchard-based ZSA notes. These terms are formally defined in ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">6</a>.</p>
-            <p>The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description <a id="footnote-reference-7" class="footnote_reference" href="#protocol-actions">14</a> is preserved across Assets (see the Orchard Binding Signature <a id="footnote-reference-8" class="footnote_reference" href="#protocol-binding">16</a>), and by extension the balance of an Orchard transaction. That is, the sum of all the
+             that is stored in Orchard-based ZSA notes. These terms are formally defined in ZIP 227 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">6</a>.</p>
+            <p>The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description <a id="footnote-reference-10" class="footnote_reference" href="#protocol-actions">15</a> is preserved across Assets (see the Orchard Binding Signature <a id="footnote-reference-11" class="footnote_reference" href="#protocol-binding">17</a>), and by extension the balance of an Orchard transaction. That is, the sum of all the
                 <span class="math">\(\mathsf{value^{net}}\)</span>
              from each Action Description, computed as
                 <span class="math">\(\mathsf{value^{old}-value^{new}}\)</span>
             , must be balanced <strong>only with respect to the same Asset Identifier</strong>. This is especially important since we will allow different Action Descriptions to transfer notes of different Asset Identifiers, where the overall balance is checked without revealing which (or how many distinct) Assets are being transferred.</p>
-            <p>As was initially proposed by Jack Grigg and Daira Hopwood <a id="footnote-reference-9" class="footnote_reference" href="#initial-zsa-issue">29</a> <a id="footnote-reference-10" class="footnote_reference" href="#generalized-value-commitments">30</a>, we propose to make this happen by changing the value base point,
+            <p>As was initially proposed by Jack Grigg and Daira Hopwood <a id="footnote-reference-12" class="footnote_reference" href="#initial-zsa-issue">30</a> <a id="footnote-reference-13" class="footnote_reference" href="#generalized-value-commitments">31</a>, we propose to make this happen by changing the value base point,
                 <span class="math">\(\mathcal{V}^{\mathsf{Orchard}}\)</span>
             , in the Homomorphic Pedersen Commitment that derives the value commitment,
                 <span class="math">\(\mathsf{cv^{net}}\)</span>
             , of the <em>net value</em> in an Orchard Action.</p>
             <p>Because in a single transaction all value commitments are balanced, there must be as many different value base points as there are Asset Identifiers for a given shielded protocol used in a transaction. We propose to make the Asset Base
                 <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
-             an auxiliary input to the proof for each Action statement <a id="footnote-reference-11" class="footnote_reference" href="#protocol-actionstatement">26</a>, represented already as a point on the Pallas curve. The circuit then should check that the same
+             an auxiliary input to the proof for each Action statement <a id="footnote-reference-14" class="footnote_reference" href="#protocol-actionstatement">27</a>, represented already as a point on the Pallas curve. The circuit then should check that the same
                 <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
-             is used in the old note commitment and the new note commitment <a id="footnote-reference-12" class="footnote_reference" href="#protocol-concretesinsemillacommit">23</a>, <strong>and</strong> as the base point
+             is used in the old note commitment and the new note commitment <a id="footnote-reference-15" class="footnote_reference" href="#protocol-concretesinsemillacommit">24</a>, <strong>and</strong> as the base point
                 <span class="math">\(\mathcal{V}^\mathsf{Orchard}\)</span>
-             in the value commitment <a id="footnote-reference-13" class="footnote_reference" href="#protocol-concretevaluecommit">24</a>. This ensures (1) that the input and output notes are of the same
+             in the value commitment <a id="footnote-reference-16" class="footnote_reference" href="#protocol-concretevaluecommit">25</a>. This ensures (1) that the input and output notes are of the same
                 <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
             , and (2) that only Actions with the same Asset Base will balance out in the Orchard binding signature.</p>
-            <p>In order to ensure the security of the transfers, and as we will explain below, we are redefining input dummy notes <a id="footnote-reference-14" class="footnote_reference" href="#protocol-dummynotes">25</a> for Custom Assets, as we need to enforce that the
+            <p>In order to ensure the security of the transfers, and as we will explain below, we are redefining input dummy notes <a id="footnote-reference-17" class="footnote_reference" href="#protocol-dummynotes">26</a> for Custom Assets, as we need to enforce that the
                 <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
              of the output note of that Split Action is the output of a valid
                 <span class="math">\(\mathsf{ZSAValueBase^{Orchard}}\)</span>
-             computation defined in ZIP 227 <a id="footnote-reference-15" class="footnote_reference" href="#zip-0227">6</a>.</p>
+             computation defined in ZIP 227 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0227">6</a>.</p>
             <p>Finally, in this ZIP we also describe the <em>burn</em> mechanism, which is a direct extension of the transfer mechanism. The burn process uses a similar mechanism to what is used in Orchard to unshield ZEC, by using the
                 <span class="math">\(\mathsf{valueBalance}\)</span>
              of the Asset in question. Burning Assets is useful for many purposes, including bridging of Wrapped Assets and removing supply of Assets.</p>
@@ -96,7 +85,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{AssetId}\)</span>
                 , the Asset Digest, and the Asset Base (
                     <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
-                 for the Orchard-based ZSA protocol) are derived as defined in ZIP 227 <a id="footnote-reference-16" class="footnote_reference" href="#zip-0227">6</a>.</p>
+                 for the Orchard-based ZSA protocol) are derived as defined in ZIP 227 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0227">6</a>.</p>
                 <p>This
                     <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
                  will be the base point of the value commitment for the specific Custom Asset. Note that the
@@ -105,7 +94,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathcal{V}^\mathsf{Orchard}\)</span>
                 .</p>
                 <section id="rationale-for-asset-identifiers"><h4><span class="section-heading">Rationale for Asset Identifiers</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-asset-identifiers"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In future network and protocol upgrades, the same Asset description string can be carried on, potentially mapping into a different shielded pool. In that case, nodes should know how to transform the Asset Identifier, the Asset Digest, and the Asset Base from one shielded pool to another, while ensuring there are no balance violations <a id="footnote-reference-17" class="footnote_reference" href="#zip-0209">3</a>.</p>
+                    <p>In future network and protocol upgrades, the same Asset description string can be carried on, potentially mapping into a different shielded pool. In that case, nodes should know how to transform the Asset Identifier, the Asset Digest, and the Asset Base from one shielded pool to another, while ensuring there are no balance violations <a id="footnote-reference-20" class="footnote_reference" href="#zip-0209">3</a>.</p>
                 </section>
             </section>
             <section id="note-structure-commitment"><h3><span class="section-heading">Note Structure &amp; Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#note-structure-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -114,7 +103,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  be the type of a ZSA note, i.e.
                     <span class="math">\(\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}*\)</span>
                 .</p>
-                <p>A ZSA note differs from an Orchard note <a id="footnote-reference-18" class="footnote_reference" href="#protocol-notes">12</a> by additionally including the Asset Base,
+                <p>A ZSA note differs from an Orchard note <a id="footnote-reference-21" class="footnote_reference" href="#protocol-notes">13</a> by additionally including the Asset Base,
                     <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
                 . So a ZSA note is a tuple
                     <span class="math">\((\mathsf{g_d, pk_d, v, \rho, \psi, \mathsf{AssetBase}^{\mathsf{Orchard}}})\)</span>
@@ -122,7 +111,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <ul>
                     <li>
                         <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}} : \mathbb{P}*\)</span>
-                     is the unique element of the Pallas group <a id="footnote-reference-19" class="footnote_reference" href="#protocol-pallasandvesta">20</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-20" class="footnote_reference" href="#zip-0227">6</a>, a valid non-bottom group element that is not the identity. The byte representation of the Asset Base is defined as
+                     is the unique element of the Pallas group <a id="footnote-reference-22" class="footnote_reference" href="#protocol-pallasandvesta">21</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0227">6</a>, a valid non-bottom group element that is not the identity. The byte representation of the Asset Base is defined as
                         <span class="math">\(\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase}^{\mathsf{Orchard}})\)</span>
                     .</li>
                 </ul>
@@ -132,9 +121,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <div class="math">\(\mathsf{NoteCommit}^{\mathsf{OrchardZSA}} : \mathsf{NoteCommit}^{\mathsf{Orchard}}.\mathsf{Trapdoor} \times \mathbb{B}^{[\ell_{\mathbb{P}}]} \times \mathbb{B}^{[\ell_{\mathbb{P}}]} \times \{0 .. 2^{\ell_{\mathsf{value}}} - 1\} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{P}* \to \mathsf{NoteCommit}^{\mathsf{Orchard}}.\mathsf{Output}\)</div>
                 <p>where
                     <span class="math">\(\mathbb{P}, \ell_{\mathbb{P}}, q_{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-21" class="footnote_reference" href="#protocol-pallasandvesta">20</a>, and
+                 are as defined for the Pallas curve <a id="footnote-reference-24" class="footnote_reference" href="#protocol-pallasandvesta">21</a>, and
                     <span class="math">\(\mathsf{NoteCommit}^{\mathsf{Orchard}}.\mathsf{Trapdoor}, \mathsf{Orchard}.\mathsf{Output}\)</span>
-                 are as defined in the Zcash protocol specification <a id="footnote-reference-22" class="footnote_reference" href="#protocol-abstractcommit">15</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-23" class="footnote_reference" href="#protocol-concretesinsemillacommit">23</a> as follows:</p>
+                 are as defined in the Zcash protocol specification <a id="footnote-reference-25" class="footnote_reference" href="#protocol-abstractcommit">16</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-26" class="footnote_reference" href="#protocol-concretesinsemillacommit">24</a> as follows:</p>
                 <div class="math">\(\begin{align}
 \mathsf{NoteCommit^{OrchardZSA}_{rcm}(g_{d}*, pk_{d}*, v, \rho, \psi, \mathsf{AssetBase}^{\mathsf{Orchard}})}
 :=\begin{cases}
@@ -152,21 +141,21 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{repr}_{\mathbb{P}}\)</span>
                  and
                     <span class="math">\(\mathsf{GroupHash}^{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-24" class="footnote_reference" href="#protocol-pallasandvesta">20</a>,
+                 are as defined for the Pallas curve <a id="footnote-reference-27" class="footnote_reference" href="#protocol-pallasandvesta">21</a>,
                     <span class="math">\(\ell^{\mathsf{Orchard}}_{\mathsf{base}}\)</span>
-                 is as defined in §5.3 <a id="footnote-reference-25" class="footnote_reference" href="#protocol-constants">19</a>, and
+                 is as defined in §5.3 <a id="footnote-reference-28" class="footnote_reference" href="#protocol-constants">20</a>, and
                     <span class="math">\(\mathsf{I2LEBSP}\)</span>
-                 is as defined in §5.1 <a id="footnote-reference-26" class="footnote_reference" href="#protocol-endian">18</a> of the Zcash protocol specification.</p>
-                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-27" class="footnote_reference" href="#protocol-commitmentsandnullifiers">17</a>.</p>
-                <p>The ZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-28" class="footnote_reference" href="#protocol-notept">13</a>. It consists of</p>
+                 is as defined in §5.1 <a id="footnote-reference-29" class="footnote_reference" href="#protocol-endian">19</a> of the Zcash protocol specification.</p>
+                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-30" class="footnote_reference" href="#protocol-commitmentsandnullifiers">18</a>.</p>
+                <p>The ZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-31" class="footnote_reference" href="#protocol-notept">14</a>. It consists of</p>
                 <div class="math">\((\mathsf{leadByte} : \mathbb{B}^{\mathbb{Y}}, \mathsf{d} : \mathbb{B}^{[\ell_{\mathsf{d}}]}, \mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}, \mathsf{rseed} : \mathbb{B}^{\mathbb{Y}[32]}, \mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}, \mathsf{memo} : \mathbb{B}^{\mathbb{Y}[512]})\)</div>
                 <section id="rationale-for-note-commitment"><h4><span class="section-heading">Rationale for Note Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-note-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>In the ZSA protocol, the instance of the note commitment scheme,
                         <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\)</span>
                     , differs from the Orchard note commitment
                         <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm}}\)</span>
-                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-29" class="footnote_reference" href="#protocol-concretesinsemillacommit">23</a> allows us to add the Asset Base as a final recursive step, and hence keep a single instance of the Sinsemilla hash function in the circuit for the note commitment verification.</p>
-                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-30" class="footnote_reference" href="#protocol-concretesinsemillahash">22</a>. ZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
+                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-32" class="footnote_reference" href="#protocol-concretesinsemillacommit">24</a> allows us to add the Asset Base as a final recursive step, and hence keep a single instance of the Sinsemilla hash function in the circuit for the note commitment verification.</p>
+                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretesinsemillahash">23</a>. ZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
                     <div class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}(repr_{\mathbb{P}}(g_d), repr_{\mathbb{P}}(pk_d), v, \rho, \psi, \mathsf{AssetBase}^{\mathsf{Orchard}})} \in \mathsf{NoteCommit^{Orchard}.Output}\)</div>
                     <p>This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and ZSA notes.</p>
                 </section>
@@ -185,15 +174,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  respectively,</p>
                 <p id="asset-base">
                     <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}_{\mathsf{AssetId}}\)</span>
-                 is defined in ZIP 227 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0227">6</a>, and</p>
+                 is defined in ZIP 227 <a id="footnote-reference-34" class="footnote_reference" href="#zip-0227">6</a>, and</p>
                 <p>
                     <span class="math">\(\mathcal{R}^{\mathsf{Orchard}}:=\mathsf{GroupHash^{\mathbb{P}}}\texttt{("z.cash:Orchard-cv", "r")}\)</span>
                 , as in the Orchard protocol.</p>
                 <p>We define
                     <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}_{\mathsf{ZEC}} :=\mathcal{V}^{\mathsf{Orchard}}\)</span>
-                 so that the value commitment for ZEC notes is computed identically to the Orchard protocol deployed in NU5 <a id="footnote-reference-32" class="footnote_reference" href="#zip-0224">4</a>.</p>
+                 so that the value commitment for ZEC notes is computed identically to the Orchard protocol deployed in NU5 <a id="footnote-reference-35" class="footnote_reference" href="#zip-0224">4</a>.</p>
                 <section id="rationale-for-value-commitment"><h4><span class="section-heading">Rationale for Value Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-value-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretevaluecommit">24</a> to perform the value commitment, with fixed base points
+                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-36" class="footnote_reference" href="#protocol-concretevaluecommit">25</a> to perform the value commitment, with fixed base points
                         <span class="math">\(\mathcal{V}^{\mathsf{Orchard}}\)</span>
                      and
                         <span class="math">\(\mathcal{R}^{\mathsf{Orchard}}\)</span>
@@ -202,7 +191,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="value-balance-verification"><h3><span class="section-heading">Value Balance Verification</span><span class="section-anchor"> <a rel="bookmark" href="#value-balance-verification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In order to verify the balance of the different Assets, the verifier MUST perform exactly the same process as for the Orchard protocol <a id="footnote-reference-34" class="footnote_reference" href="#protocol-binding">16</a>.</p>
+                <p>In order to verify the balance of the different Assets, the verifier MUST perform exactly the same process as for the Orchard protocol <a id="footnote-reference-37" class="footnote_reference" href="#protocol-binding">17</a>.</p>
                 <p>For a total of
                     <span class="math">\(n\)</span>
                  Actions in a transfer, the prover MUST still sign the <cite>SIGHASH</cite> of the transaction using the binding signature key
@@ -235,14 +224,14 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <li>The Split Input note could be an already spent note containing the same Asset Base (note that by zeroing the value in the circuit, we prevent double spending).</li>
                 </ol>
                 <section id="rationale-for-split-notes"><h4><span class="section-heading">Rationale for Split Notes</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-split-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-35" class="footnote_reference" href="#protocol-dummynotes">25</a> to the Actions that have not been assigned input notes.</p>
+                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-38" class="footnote_reference" href="#protocol-dummynotes">26</a> to the Actions that have not been assigned input notes.</p>
                     <p>The Orchard technique requires modification for the ZSA protocol with multiple Asset Identifiers, as the output note of the split Actions <em>cannot</em> contain <em>any</em> Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.</p>
                     <p>Therefore, for Custom Assets we enforce that <em>every</em> input note to an ZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the <code>split_flag</code> boolean). This ensures that the value base points of all output notes of a transfer are actual outputs of a GroupHash, as they originate in the Issuance protocol which is publicly verified.</p>
                     <p>Note that the Orchard dummy note functionality remains in use for ZEC notes, and the Split Input technique is used in order to support Custom Assets.</p>
                 </section>
             </section>
             <section id="circuit-statement"><h3><span class="section-heading">Circuit Statement</span><span class="section-anchor"> <a rel="bookmark" href="#circuit-statement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Every <em>ZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-36" class="footnote_reference" href="#protocol-actionstatement">26</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
+                <p>Every <em>ZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-39" class="footnote_reference" href="#protocol-actionstatement">27</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
                 <section id="asset-base-equality"><h4><span class="section-heading">Asset Base Equality</span><span class="section-anchor"> <a rel="bookmark" href="#asset-base-equality"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>The following constraints must be added to ensure that the input and output note are of the same
                         <span class="math">\(\mathsf{AssetBase}\)</span>
@@ -251,12 +240,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <li>The Asset Base,
                             <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}_{\mathsf{AssetId}}\)</span>
                         , for the note is witnessed once, as an auxiliary input.</li>
-                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-37" class="footnote_reference" href="#protocol-actionstatement">26</a>,
+                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-40" class="footnote_reference" href="#protocol-actionstatement">27</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{old}}(repr_{\mathbb{P}}(g_d^{old}), repr_{\mathbb{P}}(pk_d^{old}), v^{old}, \rho^{old}, \psi^{old})}\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{old}}(repr_{\mathbb{P}}(g_d^{old}), repr_{\mathbb{P}}(pk_d^{old}), v^{old}, \rho^{old}, \psi^{old}, \mathsf{AssetBase}^{\mathsf{Orchard}}_{\mathsf{AssetId}})}\)</span>
                         .</li>
-                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-38" class="footnote_reference" href="#protocol-actionstatement">26</a>,
+                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-41" class="footnote_reference" href="#protocol-actionstatement">27</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{new}}(repr_{\mathbb{P}}(g_d^{new}), repr_{\mathbb{P}}(pk_d^{new}), v^{new}, \rho^{new}, \psi^{new})}\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{new}}(repr_{\mathbb{P}}(g_d^{new}), repr_{\mathbb{P}}(pk_d^{new}), v^{new}, \rho^{new}, \psi^{new}, \mathsf{AssetBase}^{\mathsf{Orchard}}_{\mathsf{AssetId}})}\)</span>
@@ -356,7 +345,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                 </section>
                 <section id="backwards-compatibility-with-zec-notes"><h4><span class="section-heading">Backwards Compatibility with ZEC Notes</span><span class="section-anchor"> <a rel="bookmark" href="#backwards-compatibility-with-zec-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-39" class="footnote_reference" href="#protocol-abstractcommit">15</a>. If the note is a ZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
+                    <p>The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-42" class="footnote_reference" href="#protocol-abstractcommit">16</a>. If the note is a ZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
                 </section>
             </section>
         </section>
@@ -401,7 +390,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="zsa-transaction-structure"><h2><span class="section-heading">ZSA Transaction Structure</span><span class="section-anchor"> <a rel="bookmark" href="#zsa-transaction-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction format closely follows the version 5 transaction format described in the Zcash specification <a id="footnote-reference-40" class="footnote_reference" href="#protocol-transactionstructure">27</a>. The Common Transaction Fields, Transparent Transaction Fields, and Sapling Transaction Fields remain the same as in the version 5 transaction format. We make some modifications to the Orchard Transaction Fields and the Orchard Action Descriptions, which we detail in the first and second tables below respectively. We also add ZSA Burn Fields to the transaction format, which we detail in the first table below. For brevity, we omit the descriptions from the table below unless they differ from the descriptions in §7.1 of the Zcash specification <a id="footnote-reference-41" class="footnote_reference" href="#protocol-transactionstructure">27</a>.</p>
+            <p>The transaction format closely follows the version 5 transaction format described in the Zcash specification <a id="footnote-reference-43" class="footnote_reference" href="#protocol-transactionstructure">28</a>. The Common Transaction Fields, Transparent Transaction Fields, and Sapling Transaction Fields remain the same as in the version 5 transaction format. We make some modifications to the Orchard Transaction Fields and the Orchard Action Descriptions, which we detail in the first and second tables below respectively. We also add ZSA Burn Fields to the transaction format, which we detail in the first table below. For brevity, we omit the descriptions from the table below unless they differ from the descriptions in §7.1 of the Zcash specification <a id="footnote-reference-44" class="footnote_reference" href="#protocol-transactionstructure">28</a>.</p>
             <table>
                 <thead>
                     <tr>
@@ -487,7 +476,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </tbody>
             </table>
             <section id="zsa-orchard-action-description-encoding"><h3><span class="section-heading">ZSA Orchard Action Description Encoding</span><span class="section-anchor"> <a rel="bookmark" href="#zsa-orchard-action-description-encoding"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The ZSA Orchard Action size differs from the Orchard Action size by 32 bytes. This means that the size goes from 820 bytes in the Orchard Action to 852 bytes in the ZSA Orchard Action. We omit the descriptions from the table below since they are identical to the descriptions in §7.5 of the Zcash specification <a id="footnote-reference-42" class="footnote_reference" href="#protocol-actionencodingandconsensus">28</a>. A ZSA Orchard Action description is encoded in a transaction as an instance of an <code>ZSAOrchardAction</code> type:</p>
+                <p>The ZSA Orchard Action size differs from the Orchard Action size by 32 bytes. This means that the size goes from 820 bytes in the Orchard Action to 852 bytes in the ZSA Orchard Action. We omit the descriptions from the table below since they are identical to the descriptions in §7.5 of the Zcash specification <a id="footnote-reference-45" class="footnote_reference" href="#protocol-actionencodingandconsensus">29</a>. A ZSA Orchard Action description is encoded in a transaction as an instance of an <code>ZSAOrchardAction</code> type:</p>
                 <table>
                     <thead>
                         <tr>
@@ -576,7 +565,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-43" class="footnote_reference" href="#zip-0244">10</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-46" class="footnote_reference" href="#zip-0244">11</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values</p>
                 <pre>T.1: header_digest       (32-byte hash output)
@@ -584,7 +573,7 @@ T.2: transparent_digest  (32-byte hash output)
 T.3: sapling_digest      (32-byte hash output)
 T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
 T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-44" class="footnote_reference" href="#zip-0244">10</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-47" class="footnote_reference" href="#zip-0244">11</a>.</p>
                 <section id="t-4-orchard-digest"><h4><span class="section-heading">T.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>When Orchard Actions are present in the transaction, this digest is a BLAKE2b-256 hash of the following values</p>
                     <pre>T.4a: orchard_actions_compact_digest      (32-byte hash output)          [UPDATED FOR ZSA]
@@ -594,7 +583,7 @@ T.4d: flagsOrchard                        (1 byte)
 T.4e: valueBalanceOrchard                 (64-bit signed little-endian)
 T.4f: anchorOrchard                       (32 bytes)</pre>
                     <section id="t-4a-orchard-actions-compact-digest"><h5><span class="section-heading">T.4a: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-45" class="footnote_reference" href="#zip-0307">11</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-48" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                         <pre>T.4a.i  : nullifier            (field encoding bytes)
 T.4a.ii : cmx                  (field encoding bytes)
 T.4a.iii: ephemeralKey         (field encoding bytes)
@@ -609,7 +598,7 @@ T.4a.iv : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR 
                         <pre>"ZTxIdOrcActMHash"</pre>
                     </section>
                     <section id="t-4c-orchard-actions-noncompact-digest"><h5><span class="section-heading">T.4c: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4c-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-46" class="footnote_reference" href="#zip-0307">11</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-49" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                         <pre>T.4d.i  : cv                    (field encoding bytes)
 T.4d.ii : rk                    (field encoding bytes)
 T.4d.iii: encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
@@ -619,12 +608,12 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
                     </section>
                 </section>
                 <section id="t-5-issuance-digest"><h4><span class="section-heading">T.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-47" class="footnote_reference" href="#zip-0227-txiddigest">7</a>.</p>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0227-txiddigest">8</a>.</p>
                 </section>
             </section>
         </section>
         <section id="signature-digest-and-authorizing-data-commitment"><h2><span class="section-heading">Signature Digest and Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest-and-authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-48" class="footnote_reference" href="#zip-0227-sigdigest">8</a> <a id="footnote-reference-49" class="footnote_reference" href="#zip-0227-authcommitment">9</a>.</p>
+            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0227-sigdigest">9</a> <a id="footnote-reference-52" class="footnote_reference" href="#zip-0227-authcommitment">10</a>.</p>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
@@ -640,7 +629,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-50" class="footnote_reference" href="#zip-0317b">31</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-53" class="footnote_reference" href="#zip-0317b">32</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and ZSA notes. As we specify above, there are three main reasons we can do this: - Note commitments for ZEC notes will remain the same, while note commitments for Custom Assets will be computed taking into account the
@@ -713,10 +702,18 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0227-txiddigest" class="footnote">
+            <table id="zip-0227-assetidentifier" class="footnote">
                 <tbody>
                     <tr>
                         <th>7</th>
+                        <td><a href="zip-0227.html#specification-asset-identifier">ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0227-txiddigest" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>8</th>
                         <td><a href="zip-0227.html#txid-digest-issuance">ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance</a></td>
                     </tr>
                 </tbody>
@@ -724,7 +721,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="zip-0227-sigdigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>8</th>
+                        <th>9</th>
                         <td><a href="zip-0227.html#signature-digest">ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest</a></td>
                     </tr>
                 </tbody>
@@ -732,7 +729,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="zip-0227-authcommitment" class="footnote">
                 <tbody>
                     <tr>
-                        <th>9</th>
+                        <th>10</th>
                         <td><a href="zip-0227.html#authorizing-data-commitment">ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
@@ -740,7 +737,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>10</th>
+                        <th>11</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -748,7 +745,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="zip-0307" class="footnote">
                 <tbody>
                     <tr>
-                        <th>11</th>
+                        <th>12</th>
                         <td><a href="zip-0307">ZIP 307: Light Client Protocol for Payment Detection</a></td>
                     </tr>
                 </tbody>
@@ -756,7 +753,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-notes" class="footnote">
                 <tbody>
                     <tr>
-                        <th>12</th>
+                        <th>13</th>
                         <td><a href="protocol/protocol.pdf#notes">Zcash Protocol Specification, Version 2022.3.8. Section 3.2: Notes</a></td>
                     </tr>
                 </tbody>
@@ -764,7 +761,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-notept" class="footnote">
                 <tbody>
                     <tr>
-                        <th>13</th>
+                        <th>14</th>
                         <td><a href="protocol/protocol.pdf#notept">Zcash Protocol Specification, Version 2022.3.8. Section 5.5: Encodings of Note Plaintexts and Memo Fields</a></td>
                     </tr>
                 </tbody>
@@ -772,7 +769,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-actions" class="footnote">
                 <tbody>
                     <tr>
-                        <th>14</th>
+                        <th>15</th>
                         <td><a href="protocol/protocol.pdf#actions">Zcash Protocol Specification, Version 2022.3.8. Section 3.7: Action Transfers and their Descriptions</a></td>
                     </tr>
                 </tbody>
@@ -780,7 +777,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-abstractcommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>15</th>
+                        <th>16</th>
                         <td><a href="protocol/protocol.pdf#abstractcommit">Zcash Protocol Specification, Version 2022.3.8. Section 4.1.8: Commitment</a></td>
                     </tr>
                 </tbody>
@@ -788,7 +785,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-binding" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>17</th>
                         <td><a href="protocol/protocol.pdf#orchardbalance">Zcash Protocol Specification, Version 2022.3.8. Section 4.14: Balance and Binding Signature (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -796,7 +793,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-commitmentsandnullifiers" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
+                        <th>18</th>
                         <td><a href="protocol/protocol.pdf#commitmentsandnullifiers">Zcash Protocol Specification, Version 2022.3.8. Section 4.16: Note Commitments and Nullifiers</a></td>
                     </tr>
                 </tbody>
@@ -804,7 +801,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-endian" class="footnote">
                 <tbody>
                     <tr>
-                        <th>18</th>
+                        <th>19</th>
                         <td><a href="protocol/protocol.pdf#endian">Zcash Protocol Specification, Version 2022.3.8. Section 5.1: Integers, Bit Sequences, and Endianness</a></td>
                     </tr>
                 </tbody>
@@ -812,7 +809,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-constants" class="footnote">
                 <tbody>
                     <tr>
-                        <th>19</th>
+                        <th>20</th>
                         <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2022.3.8. Section 5.3: Constants</a></td>
                     </tr>
                 </tbody>
@@ -820,7 +817,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-pallasandvesta" class="footnote">
                 <tbody>
                     <tr>
-                        <th>20</th>
+                        <th>21</th>
                         <td><a href="protocol/protocol.pdf#pallasandvesta">Zcash Protocol Specification, Version 2022.3.8. Section 5.4.9.6: Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
@@ -828,7 +825,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="pasta-evidence" class="footnote">
                 <tbody>
                     <tr>
-                        <th>21</th>
+                        <th>22</th>
                         <td><a href="https://github.com/zcash/pasta">Pallas/Vesta supporting evidence</a></td>
                     </tr>
                 </tbody>
@@ -836,7 +833,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-concretesinsemillahash" class="footnote">
                 <tbody>
                     <tr>
-                        <th>22</th>
+                        <th>23</th>
                         <td><a href="protocol/protocol.pdf#concretesinsemillahash">Zcash Protocol Specification, Version 2022.3.8. Section 5.4.1.9: Sinsemilla hash function</a></td>
                     </tr>
                 </tbody>
@@ -844,7 +841,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-concretesinsemillacommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>23</th>
+                        <th>24</th>
                         <td><a href="protocol/protocol.pdf#concretesinsemillacommit">Zcash Protocol Specification, Version 2022.3.8. Section 5.4.8.4: Sinsemilla commitments</a></td>
                     </tr>
                 </tbody>
@@ -852,7 +849,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-concretevaluecommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>24</th>
+                        <th>25</th>
                         <td><a href="protocol/protocol.pdf#concretevaluecommit">Zcash Protocol Specification, Version 2022.3.8. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -860,7 +857,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-dummynotes" class="footnote">
                 <tbody>
                     <tr>
-                        <th>25</th>
+                        <th>26</th>
                         <td><a href="protocol/protocol.pdf#">Zcash Protocol Specification, Version 2022.3.8. Section 4.8.3: Dummy Notes (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -868,7 +865,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-actionstatement" class="footnote">
                 <tbody>
                     <tr>
-                        <th>26</th>
+                        <th>27</th>
                         <td><a href="protocol/protocol.pdf#actionstatement">Zcash Protocol Specification, Version 2022.3.8. Section 4.17.4: Action Statement (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -876,7 +873,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-transactionstructure" class="footnote">
                 <tbody>
                     <tr>
-                        <th>27</th>
+                        <th>28</th>
                         <td><a href="protocol/protocol.pdf#txnencodingandconsensus">Zcash Protocol Specification, Version 2022.3.8. Section 7.1: Transaction Encoding and Consensus (Transaction Version 5)</a></td>
                     </tr>
                 </tbody>
@@ -884,7 +881,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="protocol-actionencodingandconsensus" class="footnote">
                 <tbody>
                     <tr>
-                        <th>28</th>
+                        <th>29</th>
                         <td><a href="protocol/protocol.pdf#actionencodingandconsensus">Zcash Protocol Specification, Version 2022.3.8. Section 7.5: Action Description Encoding and Consensus</a></td>
                     </tr>
                 </tbody>
@@ -892,7 +889,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="initial-zsa-issue" class="footnote">
                 <tbody>
                     <tr>
-                        <th>29</th>
+                        <th>30</th>
                         <td><a href="https://github.com/str4d/zips/blob/zip-udas/drafts/zip-user-defined-assets.rst">User-Defined Assets and Wrapped Assets</a></td>
                     </tr>
                 </tbody>
@@ -900,7 +897,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="generalized-value-commitments" class="footnote">
                 <tbody>
                     <tr>
-                        <th>30</th>
+                        <th>31</th>
                         <td><a href="https://github.com/zcash/zcash/issues/2277#issuecomment-321106819">Comment on Generalized Value Commitments</a></td>
                     </tr>
                 </tbody>
@@ -908,7 +905,7 @@ T.4d.iv : outCiphertext         (field encoding bytes)</pre>
             <table id="zip-0317b" class="footnote">
                 <tbody>
                     <tr>
-                        <th>31</th>
+                        <th>32</th>
                         <td><a href="https://github.com/zcash/zips/pull/667">ZIP 317: Proportional Transfer Fee Mechanism - Pull Request #667 for ZSA Protocol ZIPs</a></td>
                     </tr>
                 </tbody>

--- a/zip-0226.rst
+++ b/zip-0226.rst
@@ -37,8 +37,8 @@ We define the following additional terms:
 Abstract
 ========
 
-The ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The ZSA protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of custom Assets on the Zcash chain. The creation of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
-While the proposed ZSA protocol is a modification to the Orchard protocol, it has been designed with adaption to possible future shielded protocols in mind.
+The ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The ZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
+While the proposed ZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.
 
 Motivation
 ==========

--- a/zip-0226.rst
+++ b/zip-0226.rst
@@ -25,40 +25,26 @@ The key word "MUST" in this document is to be interpreted as described in RFC 21
 
 The term "network upgrade" in this document is to be interpreted as described in ZIP 200 [#zip-0200]_.
 
-The terms "Orchard" and "Action" in this document are to be interpreted as described in
-ZIP 224 [#zip-0224]_.
+The terms "Orchard" and "Action" in this document are to be interpreted as described in ZIP 224 [#zip-0224]_.
+
+The terms "Asset", "Custom Asset" and "Wrapped Asset" in this document are to be interpreted as described in ZIP 227 [#zip-0227]_.
 
 We define the following additional terms:
 
-- Asset: A type of note that can be transferred on the Zcash block chain, identified by the :math:`\mathsf{AssetId}` parameter.
-
-  - ZEC is the default (and currently the only defined) Asset for the Zcash mainnet.
-  - TAZ is the default (and currently the only defined) Asset for the Zcash testnet.
-  - We use the term "Custom Asset" to refer to any Asset other than ZEC and TAZ.
-
-- Native Asset: a Custom Asset with issuance defined on the Zcash block chain.
-- Wrapped Asset: a Custom Asset with native issuance defined outside the Zcash block chain.
-- Split Input: an Action input used to ensure that the output note of that Action is of a validly issued :math:`\mathsf{AssetBase}` when there is no corresponding real input note, in situations where the number of outputs are larger than the number of inputs. See formal definition in `Split Notes`_.
+- Split Input: an Action input used to ensure that the output note of that Action is of a validly issued :math:`\mathsf{AssetBase}` (see [#zip-0227-assetidentifier]_) when there is no corresponding real input note, in situations where the number of outputs are larger than the number of inputs. See formal definition in `Split Notes`_.
 - Split Action: an Action that contains a Split Input.
 
 Abstract
 ========
 
-ZIP 226 and ZIP 227 propose in conjunction the Zcash Shielded Assets (ZSA) protocol — a set
-of protocol features that enable the creation, transfer, and burn of Custom Assets on the Zcash chain.
-
-Creation of such Assets is defined in ZIP 227 [#zip-0227]_. Transfer and burn of such Assets is defined
-in ZIP 226 [#zip-0226]_. The ZSA protocol is proposed to be instantiated by a modification to the
-Orchard protocol, as specified in these ZIPs (although it has been designed with adaption
-to possible future shielded protocols in mind).
+The ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The ZSA protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of custom Assets on the Zcash chain. The creation of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
+While the proposed ZSA protocol is a modification to the Orchard protocol, it has been designed with adaption to possible future shielded protocols in mind.
 
 Motivation
 ==========
 
-None of the currently deployed Zcash transfer protocols support Custom Assets. Enabling
-multi-asset support on the Zcash chain will open the door for a host of applications, and
-enhance the ecosystem with application developers and Asset custody institutions for
-issuance and bridging purposes.
+None of the currently deployed Zcash transfer protocols support Custom Assets. Enabling multi-asset support on the Zcash chain will open the door for a host of applications, and enhance the ecosystem with application developers and Asset custody institutions for issuance and bridging purposes.
+This ZIP builds on the issuance mechanism introduced in ZIP 227 [#zip-0227]_.
 
 Overview
 ========
@@ -528,6 +514,7 @@ References
 .. [#zip-0224] `ZIP 224: Orchard <zip-0224.html>`_
 .. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zip-0226.html>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.html>`_
+.. [#zip-0227-assetidentifier] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier <zip-0227.html#specification-asset-identifier>`_
 .. [#zip-0227-txiddigest] `ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance <zip-0227.html#txid-digest-issuance>`_
 .. [#zip-0227-sigdigest] `ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest <zip-0227.html#signature-digest>`_
 .. [#zip-0227-authcommitment] `ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment <zip-0227.html#authorizing-data-commitment>`_

--- a/zip-0226.rst
+++ b/zip-0226.rst
@@ -37,7 +37,7 @@ We define the following additional terms:
 Abstract
 ========
 
-The ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The ZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
+This ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The ZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
 While the proposed ZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.
 
 Motivation


### PR DESCRIPTION
In #20, I defined common terms to both ZIPs in 227 to draw a cleaner connection between 227 and 226 and avoid taking the reader back and forth between both (227 is prerequisite for 226, yet some terms were defined in 226).
Now that #20 has been merged, this PR cascades this changes to 226, referring to 227 for common terms and revamping the abstract accordingly.