### PR TITLE
Updates to naming conventions and table format

### DIFF
--- a/zip-0226.html
+++ b/zip-0226.html
@@ -90,9 +90,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
         <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Most of the protocol is kept the same as the Orchard protocol released with NU5, except for the following.</p>
             <section id="asset-identifiers"><h3><span class="section-heading">Asset Identifiers</span><span class="section-anchor"> <a rel="bookmark" href="#asset-identifiers"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>For every new Asset, there must be a new and unique Asset Identifier. Every Asset is defined by an <em>Asset description</em>,
-                    <span class="math">\(\mathsf{asset\_desc}\)</span>
-                , which is a global byte string (scoped across all future versions of Zcash). From this Asset description and the issuance key of the issuer, the specific Asset Identifier,
+                <p>For every new Asset, there must be a new and unique Asset Identifier. Every Asset is defined by an <em>Asset description</em>, <code>assetDesc</code>, which is a global byte string (scoped across all future versions of Zcash). From this Asset description and the issuance key of the issuer, the specific Asset Identifier,
                     <span class="math">\(\mathsf{AssetId}\)</span>
                 , the Asset Digest, and the Asset Base (
                     <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>

--- a/zip-0226.html
+++ b/zip-0226.html
@@ -427,22 +427,6 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </tr>
                     <tr>
                         <td><code>1</code></td>
-                        <td><code>flagsFinalize</code></td>
-                        <td><code>byte</code></td>
-                        <td>
-                            <dl>
-                                <dt>An 8-bit value representing a set of flags. Ordered from LSB to MSB:</dt>
-                                <dd>
-                                    <ul>
-                                        <li><code>finalize</code></li>
-                                        <li>The remaining bits are set to <code>0</code>.</li>
-                                    </ul>
-                                </dd>
-                            </dl>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><code>1</code></td>
                         <td><code>flagsOrchard</code></td>
                         <td><code>byte</code></td>
                         <td></td>

--- a/zip-0226.html
+++ b/zip-0226.html
@@ -429,6 +429,22 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </tr>
                     <tr>
                         <td><code>1</code></td>
+                        <td><code>flagsFinalize</code></td>
+                        <td><code>byte</code></td>
+                        <td>
+                            <dl>
+                                <dt>An 8-bit value representing a set of flags. Ordered from LSB to MSB:</dt>
+                                <dd>
+                                    <ul>
+                                        <li><code>finalize</code></li>
+                                        <li>The remaining bits are set to <code>0</code>.</li>
+                                    </ul>
+                                </dd>
+                            </dl>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>1</code></td>
                         <td><code>flagsOrchard</code></td>
                         <td><code>byte</code></td>
                         <td></td>

--- a/zip-0226.rst
+++ b/zip-0226.rst
@@ -84,7 +84,7 @@ Most of the protocol is kept the same as the Orchard protocol released with NU5,
 Asset Identifiers
 -----------------
 
-For every new Asset, there must be a new and unique Asset Identifier. Every Asset is defined by an *Asset description*, :math:`\mathsf{asset\_desc}`, which is a global byte string (scoped across all future versions of Zcash). From this Asset description and the issuance key of the issuer, the specific Asset Identifier, :math:`\mathsf{AssetId}`, the Asset Digest, and the Asset Base (:math:`\mathsf{AssetBase}^{\mathsf{Orchard}}` for the Orchard-based ZSA protocol) are derived as defined in ZIP 227 [#zip-0227]_.
+For every new Asset, there must be a new and unique Asset Identifier. Every Asset is defined by an *Asset description*, ``assetDesc``, which is a global byte string (scoped across all future versions of Zcash). From this Asset description and the issuance key of the issuer, the specific Asset Identifier, :math:`\mathsf{AssetId}`, the Asset Digest, and the Asset Base (:math:`\mathsf{AssetBase}^{\mathsf{Orchard}}` for the Orchard-based ZSA protocol) are derived as defined in ZIP 227 [#zip-0227]_.
 
 This :math:`\mathsf{AssetBase}^{\mathsf{Orchard}}` will be the base point of the value commitment for the specific Custom Asset. Note that the :math:`\mathsf{AssetBase}^{\mathsf{Orchard}}` of the ZEC Asset will be kept as the original value base point, :math:`\mathcal{V}^\mathsf{Orchard}`.
 

--- a/zip-0226.rst
+++ b/zip-0226.rst
@@ -320,9 +320,11 @@ For brevity, we omit the descriptions from the table below unless they differ fr
 |``852 * nActionsOrchard``    |``vActionsOrchard``       |``ZSAOrchardAction[nActionsOrchard]``      |A sequence of ZSA Orchard Action descriptions, encoded per           |
 |                             |                          |                                           |the `ZSA Orchard Action Description Encoding`_. **[UPDATED FOR ZSA]**|
 +-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``1``                        |``flagsFinalize``         |``byte``                                   |An 8-bit value representing a set of flags. Ordered from LSB to MSB: |
+|                             |                          |                                           | * ``finalize``                                                      |
+|                             |                          |                                           | * The remaining bits are set to ``0``.                              |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
 |``1``                        |``flagsOrchard``          |``byte``                                   |                                                                     |
-|                             |                          |                                           |                                                                     |
-|                             |                          |                                           |                                                                     |
 |                             |                          |                                           |                                                                     |
 +-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
 |``8``                        |``valueBalanceOrchard``   |``int64``                                  |                                                                     |

--- a/zip-0226.rst
+++ b/zip-0226.rst
@@ -320,10 +320,6 @@ For brevity, we omit the descriptions from the table below unless they differ fr
 |``852 * nActionsOrchard``    |``vActionsOrchard``       |``ZSAOrchardAction[nActionsOrchard]``      |A sequence of ZSA Orchard Action descriptions, encoded per           |
 |                             |                          |                                           |the `ZSA Orchard Action Description Encoding`_. **[UPDATED FOR ZSA]**|
 +-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
-|``1``                        |``flagsFinalize``         |``byte``                                   |An 8-bit value representing a set of flags. Ordered from LSB to MSB: |
-|                             |                          |                                           | * ``finalize``                                                      |
-|                             |                          |                                           | * The remaining bits are set to ``0``.                              |
-+-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
 |``1``                        |``flagsOrchard``          |``byte``                                   |                                                                     |
 |                             |                          |                                           |                                                                     |
 +-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+

--- a/zip-0227.html
+++ b/zip-0227.html
@@ -211,7 +211,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
         <section id="specification-global-issuance-state"><h2><span class="section-heading">Specification: Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#specification-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Issuance requires the following additions to the global state defined at block boundaries:</p>
             <ul>
-                <li><code>previously_finalized</code>, a set of
+                <li><code>finalized_assets</code>, a set of
                     <span class="math">\(\mathsf{AssetId}\)</span>
                  that have been finalized (i.e.: the <code>finalize</code> flag has been set to <code>1</code> in some issuance transaction preceding the block boundary).</li>
             </ul>
@@ -231,10 +231,10 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </ul>
                 <p>An asset's
                     <span class="math">\(\mathsf{AssetId}\)</span>
-                 is added to the <code>previously_finalized</code> set after a block that contains any issuance transaction for that asset with <code>finalize = 1</code>. It then cannot be removed from this set. For Assets with
-                    <span class="math">\(\mathsf{AssetId} \in \mathtt{previously\_finalized}\)</span>
+                 is added to the <code>finalized_assets</code> set after a block that contains any issuance transaction for that asset with <code>finalize = 1</code>. It then cannot be removed from this set. For Assets with
+                    <span class="math">\(\mathsf{AssetId} \in \mathtt{finalized\_assets}\)</span>
                 , no further tokens can be issued, so as seen below, the validators will reject the transaction. For Assets with
-                    <span class="math">\(\mathsf{AssetId} \not\in \mathtt{previously\_finalized}\)</span>
+                    <span class="math">\(\mathsf{AssetId} \not\in \mathtt{finalized\_assets}\)</span>
                 , new issuance actions can be issued in future transactions. These must use the same Asset description, <code>assetDesc</code>, and can either maintain <code>finalize = 0</code> or change it to <code>finalize = 1</code>, denoting that this Custom Asset cannot be issued after the containing block.</p>
                 <table>
                     <thead>
@@ -401,7 +401,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  is derived from the issuance validating key <code>ik</code> and <code>assetDesc</code> as described in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
                 <li>check that the
                     <span class="math">\(\mathsf{AssetId}\)</span>
-                 does not exist in the <code>previously_finalized</code> set in the global state.</li>
+                 does not exist in the <code>finalized_assets</code> set in the global state.</li>
                 <li>check that every note in the <code>IssueAction</code> contains the same
                     <span class="math">\(\mathsf{AssetBase}\)</span>
                  and is properly constructed as
@@ -418,7 +418,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  to the Merkle tree of note commitments.</li>
                 <li>If <code>finalize = 1</code>, add
                     <span class="math">\(\mathsf{AssetId}\)</span>
-                 to the <code>previously_finalized</code> set immediately after the block in which this transaction occurs.</li>
+                 to the <code>finalized_assets</code> set immediately after the block in which this transaction occurs.</li>
                 <li>(Replay Protection) If issue bundle is present, the fees MUST be greater than zero.</li>
             </ul>
         </section>
@@ -435,7 +435,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <li>information to be committed by the issuer, though not enforceable by the protocol.</li>
                     </ul>
                 </li>
-                <li>We require a check whether the <code>finalize</code> flag only has been set in a previous block rather than a previous transaction in the same block. In other words, we only update the <code>previously_finalized</code> set at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.</li>
+                <li>We require a check whether the <code>finalize</code> flag only has been set in a previous block rather than a previous transaction in the same block. In other words, we only update the <code>finalized_assets</code> set at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.</li>
                 <li>We require non-zero fees in the presence of an issue bundle, in order to preclude the possibility of a transaction containing only an issue bundle. If a transaction includes only an issue bundle, the <code>SIGHASH</code> would be computed solely based on the issue bundle. A duplicate bundle would have the same <code>SIGHASH</code>, potentially allowing for a replay attack.</li>
             </ul>
             <section id="concrete-applications"><h3><span class="section-heading">Concrete Applications</span><span class="section-anchor"> <a rel="bookmark" href="#concrete-applications"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>

--- a/zip-0227.html
+++ b/zip-0227.html
@@ -212,7 +212,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>Issuance requires the following additions to the global state defined at block boundaries:</p>
             <ul>
                 <li><code>finalized_assets</code>, a set of
-                    <span class="math">\(\mathsf{AssetId}\)</span>
+                    <span class="math">\(\mathsf{AssetDigest}\)</span>
                  that have been finalized (i.e.: the <code>finalize</code> flag has been set to <code>1</code> in some issuance transaction preceding the block boundary).</li>
             </ul>
         </section>
@@ -230,11 +230,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <li><code>flagsIssuance</code>: a byte that stores the <code>finalize</code> boolean that defines whether the issuance of that specific Custom Asset is finalized or not</li>
                 </ul>
                 <p>An asset's
-                    <span class="math">\(\mathsf{AssetId}\)</span>
+                    <span class="math">\(\mathsf{AssetDigest}\)</span>
                  is added to the <code>finalized_assets</code> set after a block that contains any issuance transaction for that asset with <code>finalize = 1</code>. It then cannot be removed from this set. For Assets with
-                    <span class="math">\(\mathsf{AssetId} \in \mathtt{finalized\_assets}\)</span>
+                    <span class="math">\(\mathsf{AssetDigest} \in \mathtt{finalized\_assets}\)</span>
                 , no further tokens can be issued, so as seen below, the validators will reject the transaction. For Assets with
-                    <span class="math">\(\mathsf{AssetId} \not\in \mathtt{finalized\_assets}\)</span>
+                    <span class="math">\(\mathsf{AssetDigest} \not\in \mathtt{finalized\_assets}\)</span>
                 , new issuance actions can be issued in future transactions. These must use the same Asset description, <code>assetDesc</code>, and can either maintain <code>finalize = 0</code> or change it to <code>finalize = 1</code>, denoting that this Custom Asset cannot be issued after the containing block.</p>
                 <table>
                     <thead>
@@ -400,7 +400,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{AssetBase}\)</span>
                  is derived from the issuance validating key <code>ik</code> and <code>assetDesc</code> as described in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
                 <li>check that the
-                    <span class="math">\(\mathsf{AssetId}\)</span>
+                    <span class="math">\(\mathsf{AssetDigest}\)</span>
                  does not exist in the <code>finalized_assets</code> set in the global state.</li>
                 <li>check that every note in the <code>IssueAction</code> contains the same
                     <span class="math">\(\mathsf{AssetBase}\)</span>
@@ -417,7 +417,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{cm}\)</span>
                  to the Merkle tree of note commitments.</li>
                 <li>If <code>finalize = 1</code>, add
-                    <span class="math">\(\mathsf{AssetId}\)</span>
+                    <span class="math">\(\mathsf{AssetDigest}\)</span>
                  to the <code>finalized_assets</code> set immediately after the block in which this transaction occurs.</li>
                 <li>(Replay Protection) If issue bundle is present, the fees MUST be greater than zero.</li>
             </ul>

--- a/zip-0227.html
+++ b/zip-0227.html
@@ -223,41 +223,31 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
         <section id="specification-global-issuance-state"><h2><span class="section-heading">Specification: Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#specification-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Issuance requires the following additions to the global state defined at block boundaries:</p>
             <ul>
-                <li>
-                    <span class="math">\(\mathsf{previously\_finalized}\)</span>
-                , a set of
+                <li><code>previously_finalized</code>, a set of
                     <span class="math">\(\mathsf{AssetId}\)</span>
                  that have been finalized (i.e.: the <code>finalize</code> flag has been set to <code>1</code> in some issuance transaction preceding the block boundary).</li>
             </ul>
         </section>
         <section id="specification-issuance-action-issuance-bundle-and-issuance-protocol"><h2><span class="section-heading">Specification: Issuance Action, Issuance Bundle and Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-action-issuance-bundle-and-issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="issuance-action-description"><h3><span class="section-heading">Issuance Action Description</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>An issuance action, <cite>IssueAction</cite>, is the instance of issuing a specific custom Asset, and contains the following fields:</p>
+                <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific custom Asset, and contains the following fields:</p>
                 <ul>
-                    <li>
-                        <span class="math">\(\mathsf{assetDescSize}\)</span>
-                    : the size of the Asset description, a number between
+                    <li><code>assetDescSize</code>: the size of the Asset description, a number between
                         <span class="math">\(0\)</span>
                      and
                         <span class="math">\(512\)</span>
                     , stored in two bytes.</li>
-                    <li>
-                        <span class="math">\(\mathsf{asset\_desc}\)</span>
-                    : the Asset description, a byte string of up to 512 bytes as defined in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
-                    <li><cite>notes</cite>: an array of <cite>Note</cite> containing the unencrypted output notes of the recipients of the Asset.</li>
-                    <li><code>finalize</code>: a boolean that defines whether the issuance of that specific custom Asset is finalized or not</li>
+                    <li><code>assetDesc</code>: the Asset description, a byte string of up to 512 bytes as defined in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
+                    <li><code>vNotes</code>: an array of <code>Note</code> containing the unencrypted output notes of the recipients of the Asset.</li>
+                    <li><code>flagsIssuance</code>: a byte that stores the <code>finalize</code> boolean that defines whether the issuance of that specific Custom Asset is finalized or not</li>
                 </ul>
                 <p>An asset's
                     <span class="math">\(\mathsf{AssetId}\)</span>
-                 is added to the
-                    <span class="math">\(\mathsf{previously\_finalized}\)</span>
-                 set after a block that contains any issuance transaction for that asset with <code>finalize = 1</code>. It then cannot be removed from this set. For Assets with
-                    <span class="math">\(\mathsf{AssetId} \in \mathsf{previously\_finalized}\)</span>
+                 is added to the <code>previously_finalized</code> set after a block that contains any issuance transaction for that asset with <code>finalize = 1</code>. It then cannot be removed from this set. For Assets with
+                    <span class="math">\(\mathsf{AssetId} \in \mathtt{previously\_finalized}\)</span>
                 , no further tokens can be issued, so as seen below, the validators will reject the transaction. For Assets with
-                    <span class="math">\(\mathsf{AssetId} \not\in \mathsf{previously\_finalized}\)</span>
-                , new issuance actions can be issued in future transactions. These must use the same Asset description,
-                    <span class="math">\(\mathsf{asset\_desc}\)</span>
-                , and can either maintain <code>finalize = 0</code> or change it to <code>finalize = 1</code>, denoting that this custom Asset cannot be issued after the containing block.</p>
+                    <span class="math">\(\mathsf{AssetId} \not\in \mathtt{previously\_finalized}\)</span>
+                , new issuance actions can be issued in future transactions. These must use the same Asset description, <code>assetDesc</code>, and can either maintain <code>finalize = 0</code> or change it to <code>finalize = 1</code>, denoting that this Custom Asset cannot be issued after the containing block.</p>
                 <table>
                     <thead>
                         <tr>
@@ -269,50 +259,57 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </thead>
                     <tbody>
                         <tr>
-                            <td>2</td>
-                            <td>assetDescSize</td>
-                            <td>byte</td>
-                            <td>The length of the asset_desc string in bytes</td>
+                            <td><code>2</code></td>
+                            <td><code>assetDescSize</code></td>
+                            <td><code>byte</code></td>
+                            <td>The length of the <code>assetDesc</code> string in bytes.</td>
                         </tr>
                         <tr>
-                            <td>Varies</td>
-                            <td>asset_desc</td>
-                            <td>byte</td>
-                            <td>UTF-8 encoded string, of size assetDescSize bytes</td>
+                            <td><code>assetDescSize</code></td>
+                            <td><code>assetDesc</code></td>
+                            <td><code>byte[assetDescSize]</code></td>
+                            <td>A byte sequence of length <code>assetDescSize</code> bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.</td>
                         </tr>
                         <tr>
-                            <td>Varies</td>
-                            <td>nNotes</td>
-                            <td>compactSize</td>
-                            <td>The number of notes in the issuance action</td>
+                            <td><code>varies</code></td>
+                            <td><code>nNotes</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of notes in the issuance action.</td>
                         </tr>
                         <tr>
-                            <td>noteSize * nNotes</td>
-                            <td>vNotes</td>
-                            <td>Note[nNotes]</td>
-                            <td>A sequence of note descriptions within the issuance action</td>
+                            <td><code>noteSize * nNotes</code></td>
+                            <td><code>vNotes</code></td>
+                            <td><code>Note[nNotes]</code></td>
+                            <td>A sequence of note descriptions within the issuance action, where <code>noteSize</code> is the size, in bytes, of a Note.</td>
                         </tr>
                         <tr>
-                            <td>1</td>
-                            <td>flagsIssuance</td>
-                            <td>byte</td>
-                            <td>An 8-bit value with the <code>finalize</code> boolean value as the LSB, and the other bits set to 0. (See: <a href="#t-5a-iii-flagsissuance">T.5a.iii: flagsIssuance</a>)</td>
+                            <td><code>1</code></td>
+                            <td><code>flagsIssuance</code></td>
+                            <td><code>byte</code></td>
+                            <td>
+                                <dl>
+                                    <dt>An 8-bit value representing a set of flags. Ordered from LSB to MSB:</dt>
+                                    <dd>
+                                        <ul>
+                                            <li><code>finalize</code></li>
+                                            <li>The remaining bits are set to <code>0</code>.</li>
+                                        </ul>
+                                    </dd>
+                                </dl>
+                            </td>
                         </tr>
                     </tbody>
                 </table>
-                <p>, where noteSize is the size, in bytes, of a Note.</p>
-                <p>We note that the output note commitment of the recipient's notes are not included in the actual transaction, but when added to the global state of the chain, they will be added to the <cite>NoteCommitmentTree</cite> as a shielded note. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
+                <p>We note that the output note commitment of the recipient's notes are not included in the actual transaction, but when added to the global state of the chain, they will be added to the note commitment tree as a shielded note. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
             </section>
             <section id="issuance-bundle"><h3><span class="section-heading">Issuance Bundle</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-bundle"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>An issuance bundle, <cite>IssueBundle</cite>, is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:</p>
+                <p>An issuance bundle, <code>IssueBundle</code>, is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:</p>
                 <ul>
-                    <li>
-                        <span class="math">\(\mathsf{ik}\)</span>
-                    : the issuance validating key, that allows the validators to verify that the
+                    <li><code>ik</code>: the issuance validating key, that allows the validators to verify that the
                         <span class="math">\(\mathsf{AssetId}\)</span>
                      is properly associated with the issuer.</li>
-                    <li><cite>actions</cite>: an array of issuance actions, of type <cite>IssueAction</cite>.</li>
-                    <li><cite>issueAuthSig</cite>: the signature of the transaction SIGHASH, signed by the issuance authorizing key,
+                    <li><code>vIssueActions</code>: an array of issuance actions, of type <cite>IssueAction</cite>.</li>
+                    <li><code>issueAuthSig</code>: the signature of the transaction SIGHASH, signed by the issuance authorizing key,
                         <span class="math">\(\mathsf{isk}\)</span>
                     , that validates the issuance .</li>
                 </ul>
@@ -328,110 +325,99 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </thead>
                     <tbody>
                         <tr>
-                            <td>Varies</td>
-                            <td>nIssueActions</td>
-                            <td>compactSize</td>
-                            <td>The number of issuance actions in the bundle</td>
+                            <td><code>varies</code></td>
+                            <td><code>nIssueActions</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of issuance actions in the bundle.</td>
                         </tr>
                         <tr>
-                            <td>IssueActionSize * nIssueActions</td>
-                            <td>vIssueActions</td>
-                            <td>IssueAction[nIssueActions]</td>
-                            <td>A sequence of issuance actions descriptions</td>
+                            <td><code>IssueActionSize * nIssueActions</code></td>
+                            <td><code>vIssueActions</code></td>
+                            <td><code>IssueAction[nIssueActions]</code></td>
+                            <td>A sequence of issuance action descriptions, where IssueActionSize is the size, in bytes, of an IssueAction description.</td>
                         </tr>
                         <tr>
-                            <td>32</td>
-                            <td>ik</td>
-                            <td>byte[32]</td>
-                            <td>The issuance validating key of the issuer, used to validate the signature</td>
+                            <td><code>32</code></td>
+                            <td><code>ik</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The issuance validating key of the issuer, used to validate the signature.</td>
                         </tr>
                         <tr>
-                            <td>64</td>
-                            <td>issueAuthSig</td>
-                            <td>byte[64]</td>
-                            <td>The signature of the transaction SIGHASH, signed by the issuer, validated as in <a href="#issuance-authorization-signature-scheme">Issuance Authorization Signature Scheme</a></td>
+                            <td><code>64</code></td>
+                            <td><code>issueAuthSig</code></td>
+                            <td><code>byte[64]</code></td>
+                            <td>The signature of the transaction SIGHASH, signed by the issuer, validated as in <a href="#issuance-authorization-signature-scheme">Issuance Authorization Signature Scheme</a>.</td>
                         </tr>
                     </tbody>
                 </table>
-                <p>, where IssueActionSize is the size, in bytes, of an IssueAction description.</p>
             </section>
             <section id="issuance-protocol"><h3><span class="section-heading">Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The issuer program performs the following operations</p>
-                <p>For all actions <cite>IssueAction</cite>:</p>
+                <p>For all actions <code>IssueAction</code>:</p>
                 <ul>
-                    <li>encode
-                        <span class="math">\(\mathsf{asset\_desc}\)</span>
-                     as a UTF-8 byte string of size up to 512.</li>
+                    <li>encode <code>assetDesc</code> as a UTF-8 byte string of size up to 512.</li>
                     <li>compute
                         <span class="math">\(\mathsf{AssetDigest}\)</span>
-                     from the issuance validating key
-                        <span class="math">\(\mathsf{ik}\)</span>
-                     and
-                        <span class="math">\(\mathsf{asset\_desc}\)</span>
-                     as decribed in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
+                     from the issuance validating key <code>ik</code> and <code>assetDesc</code> as decribed in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
                     <li>compute
                         <span class="math">\(\mathsf{AssetBase^{Protocol}}\)</span>
                      from
                         <span class="math">\(\mathsf{AssetDigest}\)</span>
                      as decribed in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
-                    <li>set the <code>finalize</code> boolean as desired (if more issuance actions are to be created for this Asset Identifier, set <code>finalize = 0</code>, otherwise set <code>finalize = 1</code>)</li>
+                    <li>set the <code>finalize</code> boolean as desired (if more issuance actions are to be created for this Asset Identifier, set <code>finalize = 0</code>, otherwise set <code>finalize = 1</code>).</li>
                     <li>For each recipient
                         <span class="math">\(i\)</span>
                     :
                         <ul>
                             <li>generate a ZSA output note that includes the Asset Base. For an Orchard-based ZSA note this is
-                                <span class="math">\(\mathsf{note}_i = (\mathsf{d}_i, \mathsf{pk}_{\mathsf{d},i}, \mathsf{v}_i, \rho_i, \psi_i, \mathsf{AssetBase^{Orchard}}, \mathsf{rcm}_i)\!\)</span>
+                                <span class="math">\(\mathsf{note}_i = (\mathsf{d}_i, \mathsf{pk}_{\mathsf{d}_i}, \mathsf{v}_i, \rho_i, \mathsf{rseed}_i, \mathsf{AssetBase^{Orchard}}, \mathsf{rcm}_i)\!\)</span>
                             .</li>
                         </ul>
                     </li>
-                    <li>encode the <cite>IssueAction</cite> into the vector <cite>vIssueActions</cite> of the bundle</li>
+                    <li>encode the <code>IssueAction</code> into the vector <code>vIssueActions</code> of the bundle.</li>
                 </ul>
-                <p>For the <cite>IssueBundle</cite>:</p>
+                <p>For the <code>IssueBundle</code>:</p>
                 <ul>
-                    <li>encode the <cite>vIssueActions</cite> vector</li>
-                    <li>encode the
-                        <span class="math">\(\mathsf{ik}\)</span>
-                     as 32 byte-string</li>
-                    <li>sign the <cite>SIGHASH</cite> of the transaction with the issuance authorizing key,
+                    <li>encode the <code>vIssueActions</code> vector.</li>
+                    <li>encode the <code>ik</code> as 32 byte-string.</li>
+                    <li>sign the <code>SIGHASH</code> of the transaction with the issuance authorizing key,
                         <span class="math">\(\mathsf{isk}\)</span>
                     , using the
                         <span class="math">\(\mathsf{IssueAuthSig}\)</span>
                      signature scheme. The signature is then added to the issuance bundle.</li>
                 </ul>
-                <p><strong>Note:</strong> that the commitment is not included in the <cite>IssuanceAction</cite> itself. As explained below, it is computed later by the validators and added to the <cite>NoteCommitmentTree</cite>.</p>
+                <p><strong>Note:</strong> that the commitment is not included in the <code>IssuanceAction</code> itself. As explained below, it is computed later by the validators and added to the note commitment tree.</p>
             </section>
         </section>
         <section id="specification-consensus-rule-changes"><h2><span class="section-heading">Specification: Consensus Rule Changes</span><span class="section-anchor"> <a rel="bookmark" href="#specification-consensus-rule-changes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>For the IssueBundle:</p>
+            <p>For the <code>IssueBundle</code>:</p>
             <ul>
-                <li>Verify the RedPallas-based issuance authorization signature on <cite>SIGHASH</cite>, <cite>issueAuthSig</cite>, is verified by invoking <cite>issueAuthSig.VerifySig(ik, SIGHASH)</cite></li>
+                <li>Verify the RedPallas-based issuance authorization signature on <code>SIGHASH</code>, <code>issueAuthSig</code>, is verified by invoking
+                    <span class="math">\(\mathsf{issueAuthSig.VerifySig}(\mathtt{ik}, \mathtt{SIGHASH})\)</span>
+                .</li>
             </ul>
-            <p>For each <cite>IssueAction</cite> in <cite>IssueBundle</cite>:</p>
+            <p>For each <code>IssueAction</code> in <code>IssueBundle</code>:</p>
             <ul>
                 <li>check that
-                    <span class="math">\(0 &lt; \mathsf{assetDescSize} &lt;= 512\)</span>
+                    <span class="math">\(0 &lt; \mathtt{assetDescSize} &lt;= 512\)</span>
                 .</li>
                 <li>check that
-                    <span class="math">\(\mathsf{asset\_desc}\)</span>
+                    <span class="math">\(\mathtt{assetDesc}\)</span>
                  is a string of length
-                    <span class="math">\(\mathsf{assetDescSize}\)</span>
+                    <span class="math">\(\mathtt{assetDescSize}\)</span>
                  bytes.</li>
                 <li>retrieve
                     <span class="math">\(\mathsf{AssetBase}\)</span>
                  from the first note in the sequence and check that
                     <span class="math">\(\mathsf{AssetBase}\)</span>
-                 is derived from the issuance validating key
-                    <span class="math">\(\mathsf{ik}\)</span>
-                 and
-                    <span class="math">\(\mathsf{asset\_desc}\)</span>
-                 as described in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
+                 is derived from the issuance validating key <code>ik</code> and <code>assetDesc</code> as described in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
                 <li>check that the
                     <span class="math">\(\mathsf{AssetId}\)</span>
                  does not exist in the <code>previously_finalized</code> set in the global state.</li>
-                <li>check that every note in the <cite>IssueAction</cite> contains the same
+                <li>check that every note in the <code>IssueAction</code> contains the same
                     <span class="math">\(\mathsf{AssetBase}\)</span>
                  and is properly constructed as
-                    <span class="math">\(note = (\mathsf{g_d, pk_d, v, \rho, \psi, AssetBase})\)</span>
+                    <span class="math">\(\mathsf{note} = (\mathsf{g_d, pk_d, v, \rho, rseed, AssetBase})\)</span>
                 .</li>
             </ul>
             <p>If all of the above checks pass, do the following:</p>
@@ -439,9 +425,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <li>For each note, compute the note commitment as
                     <span class="math">\(\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}(repr_{\mathbb{P}}(g_d), repr_{\mathbb{P}}(pk_d), v, \rho, \psi, AssetBase)}\)</span>
                  as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0226-notestructure">5</a> and</li>
-                <li>add
+                <li>Add
                     <span class="math">\(\mathsf{cm}\)</span>
-                 to the Merkle tree of note commitments, <cite>NoteCommitmentTree</cite>.</li>
+                 to the Merkle tree of note commitments.</li>
                 <li>If <code>finalize = 1</code>, add
                     <span class="math">\(\mathsf{AssetId}\)</span>
                  to the <code>previously_finalized</code> set immediately after the block in which this transaction occurs.</li>

--- a/zip-0227.html
+++ b/zip-0227.html
@@ -76,12 +76,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <li>The issuance master key, denoted as
                     <span class="math">\(\mathsf{sk}_{\mathsf{iss}}\)</span>
                 , as the name suggests, is the master key that is used to derive the other two keys.</li>
-                <li>The issuance authorizing key is the key that is used to sign the issuance transaction, and is denoted as
-                    <span class="math">\(\mathsf{isk}\)</span>
-                . This key is used to authorize the issuance of a specific Asset Identifier, and is only used by the issuer.</li>
-                <li>The issuance validating key, denoted as
-                    <span class="math">\(\mathsf{ik}\)</span>
-                , is the key that is used to validate the issuance transaction. This key is used to validate the issuance of a specific Asset Identifier, and is used by all blockchain users (specifically the Asset owners and consensus validators) to associate the Asset in question with the issuer.</li>
+                <li>The issuance authorizing key is the key that is used to sign the issuance transaction, and is denoted as <code>isk</code>. This key is used to authorize the issuance of a specific Asset Identifier, and is only used by the issuer.</li>
+                <li>The issuance validating key, denoted as <code>ik</code>, is the key that is used to validate the issuance transaction. This key is used to validate the issuance of a specific Asset Identifier, and is used by all blockchain users (specifically the Asset owners and consensus validators) to associate the Asset in question with the issuer.</li>
             </ol>
             <p>The relations between these keys are shown in the following diagram:</p>
             <figure class="align-center" align="center">
@@ -156,13 +152,13 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                             <span class="math">\(\mathsf{sk}_{\mathsf{iss}}\)</span>
                         , as a private signature key:</li>
                     </ul>
-                    <div class="math">\(\mathsf{isk} := \mathsf{ToScalar}^{\mathsf{Orchard}}(︀ \mathsf{sk}_{\mathsf{iss}} )\)</div>
+                    <div class="math">\(\mathtt{isk} := \mathsf{ToScalar}^{\mathsf{Orchard}}(︀ \mathsf{sk}_{\mathsf{iss}} )\)</div>
                     <ul>
                         <li>The issuance validating key is derived from the issuance authorizing key,
-                            <span class="math">\(\mathsf{isk}\)</span>
+                            <span class="math">\(\mathtt{isk}\)</span>
                         , as a public verification key:</li>
                     </ul>
-                    <div class="math">\(\mathsf{ik} := \mathsf{IssueAuthSig}.\mathsf{DerivePublic}(\mathsf{isk})\)</div>
+                    <div class="math">\(\mathtt{ik} := \mathsf{IssueAuthSig}.\mathsf{DerivePublic}(\mathtt{isk})\)</div>
                     <p>This allows the issuer to use the same wallet it usually uses to transfer Assets, while keeping a disconnect from the other keys. Specifically, this method is aligned with the requirements and motivation of ZIP 32 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0032">11</a>. It provides further anonymity and the ability to delegate issuance of an Asset (or in the future, generate a multi-signature protocol) while the rest of the keys remain in the wallet safe.</p>
                 </section>
             </section>
@@ -171,12 +167,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>For every new Asset, there must be a new and unique Asset Identifier, denoted
                 <span class="math">\(\mathsf{AssetId}\)</span>
             . We define this to be a globally unique pair
-                <span class="math">\(\mathsf{AssetId} := (\mathsf{ik}, \mathsf{asset\_desc})\)</span>
-            , where
-                <span class="math">\(\mathsf{ik}\)</span>
-             is the issuance key and
-                <span class="math">\(\mathsf{asset\_desc}\)</span>
-             is a byte string.</p>
+                <span class="math">\(\mathsf{AssetId} := (\mathtt{ik}, \mathtt{assetDesc})\)</span>
+            , where <code>ik</code> is the issuance key and <code>assetDesc</code> is a byte string.</p>
             <p>A given Asset Identifier is used across all Zcash protocols that support ZSAs -- that is, the Orchard-based ZSA protocol and potentially future Zcash shielded protocols. For this Asset Identifier, we derive an Asset Digest,
                 <span class="math">\(\mathsf{AssetDigest}\)</span>
             , which is simply is a
@@ -186,19 +178,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
              for the Orchard-based ZSA protocol), using the applicable hash-to-curve algorithm. This Asset Base is included in shielded notes.</p>
             <p>Let</p>
             <ul>
-                <li>
-                    <span class="math">\(\mathsf{asset\_desc}\)</span>
-                 be the asset description, which includes any information pertaining to the issuance, and is a byte sequence of up to 512 bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.</li>
-                <li>
-                    <span class="math">\(\mathsf{ik}\)</span>
-                 be the issuance validating key of the issuer, a public key used to verify the signature on the issuance transaction's SIGHASH.</li>
+                <li><code>assetDesc</code> be the asset description, which includes any information pertaining to the issuance, and is a byte sequence of up to 512 bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.</li>
+                <li><code>ik</code> be the issuance validating key of the issuer, a public key used to verify the signature on the issuance transaction's SIGHASH.</li>
             </ul>
             <p>Define
                 <span class="math">\(\mathsf{AssetDigest_{\mathsf{AssetId}}} := \textsf{BLAKE2b-512}(\texttt{"ZSA-Asset-Digest"},\; \mathsf{EncodeAssetId}(\mathsf{AssetId}))\)</span>
             , where</p>
             <ul>
                 <li>
-                    <span class="math">\(\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathsf{0x00} || \mathsf{repr}_{\mathbb{P}}(\mathsf{ik}) || \mathsf{asset\_desc}\!\)</span>
+                    <span class="math">\(\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathtt{ik}, \mathtt{assetDesc})) := \mathsf{0x00} || \mathsf{repr}_{\mathbb{P}}(\mathtt{ik}) || \mathtt{assetDesc}\!\)</span>
                 .</li>
             </ul>
             <p>Define
@@ -310,7 +298,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      is properly associated with the issuer.</li>
                     <li><code>vIssueActions</code>: an array of issuance actions, of type <cite>IssueAction</cite>.</li>
                     <li><code>issueAuthSig</code>: the signature of the transaction SIGHASH, signed by the issuance authorizing key,
-                        <span class="math">\(\mathsf{isk}\)</span>
+                        <span class="math">\(\mathtt{isk}\)</span>
                     , that validates the issuance .</li>
                 </ul>
                 <p>The issuance bundle is then added within the transaction format as a new bundle. That is, issuance requires the addition of the following information to the transaction format <a id="footnote-reference-20" class="footnote_reference" href="#protocol-transactionstructure">23</a>.</p>
@@ -381,7 +369,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <li>encode the <code>vIssueActions</code> vector.</li>
                     <li>encode the <code>ik</code> as 32 byte-string.</li>
                     <li>sign the <code>SIGHASH</code> of the transaction with the issuance authorizing key,
-                        <span class="math">\(\mathsf{isk}\)</span>
+                        <span class="math">\(\mathtt{isk}\)</span>
                     , using the
                         <span class="math">\(\mathsf{IssueAuthSig}\)</span>
                      signature scheme. The signature is then added to the issuance bundle.</li>
@@ -439,9 +427,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <ul>
                 <li>The issuance key structure is independent of the original key tree, but derived in an analogous manner (via ZIP 32). This is in order to keep the issuance details and the Asset Identifiers consistent across multiple shielded pools.</li>
                 <li>The design decision is not to have a chosen name to describe the Custom Asset, but to delegate it to an off-chain mapping, as this would imply a land-grab “war”.</li>
-                <li>The
-                    <span class="math">\(\mathsf{asset\_desc}\)</span>
-                 is a general byte string in order to allow for a wide range of information type to be included that may be associated with the Assets. Some are:
+                <li>The <code>assetDesc</code> is a general byte string in order to allow for a wide range of information type to be included that may be associated with the Assets. Some are:
                     <ul>
                         <li>links for storage such as for NFTs.</li>
                         <li>metadata for Assets, encoded in any format.</li>
@@ -618,9 +604,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317b <a id="footnote-reference-30" class="footnote_reference" href="#zip-0317b">10</a>.</p>
             </section>
             <section id="future-work"><h3><span class="section-heading">Future Work</span><span class="section-anchor"> <a rel="bookmark" href="#future-work"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In future versions of this ZIP, the protocol may also include a "key rotation" mechanism. This would allow an issuer to change the underlying
-                    <span class="math">\(\mathsf{ik}\)</span>
-                 of a given Asset, in case the original one was compromised, without having to change the Asset Identifier altogether.</p>
+                <p>In future versions of this ZIP, the protocol may also include a "key rotation" mechanism. This would allow an issuer to change the underlying <code>ik</code> of a given Asset, in case the original one was compromised, without having to change the Asset Identifier altogether.</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/zip-0227.rst
+++ b/zip-0227.rst
@@ -184,106 +184,122 @@ Specification: Global Issuance State
 
 Issuance requires the following additions to the global state defined at block boundaries:
 
-- :math:`\mathsf{previously\_finalized}`, a set of :math:`\mathsf{AssetId}` that have been finalized (i.e.: the ``finalize`` flag has been set to ``1`` in some issuance transaction preceding the block boundary).
+- ``previously_finalized``, a set of :math:`\mathsf{AssetId}` that have been finalized (i.e.: the ``finalize`` flag has been set to ``1`` in some issuance transaction preceding the block boundary).
 
 
 Specification: Issuance Action, Issuance Bundle and Issuance Protocol
-=================================================================================
+=====================================================================
 
 Issuance Action Description
 ---------------------------
 
-An issuance action, `IssueAction`, is the instance of issuing a specific custom Asset, and contains the following fields:
+An issuance action, ``IssueAction``, is the instance of issuing a specific custom Asset, and contains the following fields:
 
-- :math:`\mathsf{assetDescSize}`: the size of the Asset description, a number between :math:`0` and :math:`512`, stored in two bytes.
-- :math:`\mathsf{asset\_desc}`: the Asset description, a byte string of up to 512 bytes as defined in the `Specification: Asset Identifier`_ section.
-- `notes`: an array of `Note` containing the unencrypted output notes of the recipients of the Asset.
-- ``finalize``: a boolean that defines whether the issuance of that specific custom Asset is finalized or not
+- ``assetDescSize``: the size of the Asset description, a number between :math:`0` and :math:`512`, stored in two bytes.
+- ``assetDesc``: the Asset description, a byte string of up to 512 bytes as defined in the `Specification: Asset Identifier`_ section.
+- ``vNotes``: an array of ``Note`` containing the unencrypted output notes of the recipients of the Asset.
+- ``flagsIssuance``: a byte that stores the ``finalize`` boolean that defines whether the issuance of that specific Custom Asset is finalized or not
 
-An asset's :math:`\mathsf{AssetId}` is added to the :math:`\mathsf{previously\_finalized}` set after a block that contains any issuance transaction for that asset with ``finalize = 1``. It then cannot be removed from this set. For Assets with :math:`\mathsf{AssetId} \in \mathsf{previously\_finalized}`, no further tokens can be issued, so as seen below, the validators will reject the transaction. For Assets with :math:`\mathsf{AssetId} \not\in \mathsf{previously\_finalized}`, new issuance actions can be issued in future transactions. These must use the same Asset description, :math:`\mathsf{asset\_desc}`, and can either maintain ``finalize = 0`` or change it to ``finalize = 1``, denoting that this custom Asset cannot be issued after the containing block.
-  
-==================== ===================== ======================= ===========================================================================================
-Bytes                Name                  Data Type               Description
-==================== ===================== ======================= ===========================================================================================
-2                    assetDescSize         byte                    The length of the asset\_desc string in bytes
-Varies               asset\_desc           byte                    UTF-8 encoded string, of size assetDescSize bytes
-Varies               nNotes                compactSize             The number of notes in the issuance action
-noteSize * nNotes    vNotes                Note[nNotes]            A sequence of note descriptions within the issuance action
-1                    flagsIssuance         byte                    An 8-bit value with the ``finalize`` boolean value as the LSB, and the other bits set to 0. (See: `T.5a.iii: flagsIssuance`_)
-==================== ===================== ======================= ===========================================================================================
+An asset's :math:`\mathsf{AssetId}` is added to the ``previously_finalized`` set after a block that contains any issuance transaction for that asset with ``finalize = 1``. It then cannot be removed from this set. 
+For Assets with :math:`\mathsf{AssetId} \in \mathtt{previously\_finalized}`, no further tokens can be issued, so as seen below, the validators will reject the transaction. 
+For Assets with :math:`\mathsf{AssetId} \not\in \mathtt{previously\_finalized}`, new issuance actions can be issued in future transactions. 
+These must use the same Asset description, ``assetDesc``, and can either maintain ``finalize = 0`` or change it to ``finalize = 1``, denoting that this Custom Asset cannot be issued after the containing block.
 
-, where noteSize is the size, in bytes, of a Note.
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+| Bytes                       | Name                     | Data Type                                 | Description                                                         |
++=============================+==========================+===========================================+=====================================================================+
+|``2``                        |``assetDescSize``         |``byte``                                   |The length of the ``assetDesc`` string in bytes.                     |  
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``assetDescSize``            |``assetDesc``             |``byte[assetDescSize]``                    |A byte sequence of length ``assetDescSize`` bytes which SHOULD be a  |
+|                             |                          |                                           |well-formed UTF-8 code unit sequence according to Unicode 15.0.0     |
+|                             |                          |                                           |or later.                                                            |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``varies``                   |``nNotes``                |``compactSize``                            |The number of notes in the issuance action.                          |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``noteSize * nNotes``        |``vNotes``                |``Note[nNotes]``                           |A sequence of note descriptions within the issuance action,          |
+|                             |                          |                                           |where ``noteSize`` is the size, in bytes, of a Note.                 |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``1``                        |``flagsIssuance``         |``byte``                                   |An 8-bit value representing a set of flags. Ordered from LSB to MSB: |
+|                             |                          |                                           | * ``finalize``                                                      |
+|                             |                          |                                           | * The remaining bits are set to ``0``.                              |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
 
-We note that the output note commitment of the recipient's notes are not included in the actual transaction, but when added to the global state of the chain, they will be added to the `NoteCommitmentTree` as a shielded note. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.
+We note that the output note commitment of the recipient's notes are not included in the actual transaction, but when added to the global state of the chain, they will be added to the note commitment tree as a shielded note. 
+This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.
 
 Issuance Bundle
 ---------------
 
-An issuance bundle, `IssueBundle`, is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:
+An issuance bundle, ``IssueBundle``, is the aggregate of all the issuance-related information. 
+Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. 
+It contains the following fields:
 
-- :math:`\mathsf{ik}`: the issuance validating key, that allows the validators to verify that the :math:`\mathsf{AssetId}` is properly associated with the issuer.
-- `actions`: an array of issuance actions, of type `IssueAction`.
-- `issueAuthSig`: the signature of the transaction SIGHASH, signed by the issuance authorizing key, :math:`\mathsf{isk}`, that validates the issuance .
+- ``ik``: the issuance validating key, that allows the validators to verify that the :math:`\mathsf{AssetId}` is properly associated with the issuer.
+- ``vIssueActions``: an array of issuance actions, of type `IssueAction`.
+- ``issueAuthSig``: the signature of the transaction SIGHASH, signed by the issuance authorizing key, :math:`\mathsf{isk}`, that validates the issuance .
 
 The issuance bundle is then added within the transaction format as a new bundle. That is, issuance requires the addition of the following information to the transaction format [#protocol-transactionstructure]_.
 
-================================= ===================== ========================== ===============================================================================
-Bytes                             Name                  Data Type                  Description
-================================= ===================== ========================== ===============================================================================
-Varies                            nIssueActions         compactSize                The number of issuance actions in the bundle
-IssueActionSize * nIssueActions   vIssueActions         IssueAction[nIssueActions] A sequence of issuance actions descriptions
-32                                ik                    byte[32]                   The issuance validating key of the issuer, used to validate the signature
-64                                issueAuthSig          byte[64]                   The signature of the transaction SIGHASH, signed by the issuer, validated as in `Issuance Authorization Signature Scheme`_
-================================= ===================== ========================== ===============================================================================
-
-, where IssueActionSize is the size, in bytes, of an IssueAction description.
++------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
+| Bytes                              | Name                     | Data Type                                 | Description                                                               |
++====================================+==========================+===========================================+===========================================================================+
+|``varies``                          |``nIssueActions``         |``compactSize``                            |The number of issuance actions in the bundle.                              |
++------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
+|``IssueActionSize * nIssueActions`` |``vIssueActions``         |``IssueAction[nIssueActions]``             |A sequence of issuance action descriptions, where IssueActionSize is       |
+|                                    |                          |                                           |the size, in bytes, of an IssueAction description.                         |
++------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
+|``32``                              |``ik``                    |``byte[32]``                               |The issuance validating key of the issuer, used to validate the signature. |
++------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
+|``64``                              |``issueAuthSig``          |``byte[64]``                               |The signature of the transaction SIGHASH, signed by the issuer,            |
+|                                    |                          |                                           |validated as in `Issuance Authorization Signature Scheme`_.                |
++------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
 
 Issuance Protocol
 -----------------
 The issuer program performs the following operations
 
-For all actions `IssueAction`:
+For all actions ``IssueAction``:
 
-- encode :math:`\mathsf{asset\_desc}` as a UTF-8 byte string of size up to 512.
-- compute :math:`\mathsf{AssetDigest}` from the issuance validating key :math:`\mathsf{ik}` and :math:`\mathsf{asset\_desc}` as decribed in the `Specification: Asset Identifier`_ section.
+- encode ``assetDesc`` as a UTF-8 byte string of size up to 512.
+- compute :math:`\mathsf{AssetDigest}` from the issuance validating key ``ik`` and ``assetDesc`` as decribed in the `Specification: Asset Identifier`_ section.
 - compute :math:`\mathsf{AssetBase^{Protocol}}` from :math:`\mathsf{AssetDigest}` as decribed in the `Specification: Asset Identifier`_ section.
-- set the ``finalize`` boolean as desired (if more issuance actions are to be created for this Asset Identifier, set ``finalize = 0``, otherwise set ``finalize = 1``)
+- set the ``finalize`` boolean as desired (if more issuance actions are to be created for this Asset Identifier, set ``finalize = 0``, otherwise set ``finalize = 1``).
 - For each recipient :math:`i`:
 
-    - generate a ZSA output note that includes the Asset Base. For an Orchard-based ZSA note this is :math:`\mathsf{note}_i = (\mathsf{d}_i, \mathsf{pk}_{\mathsf{d},i}, \mathsf{v}_i, \rho_i, \psi_i, \mathsf{AssetBase^{Orchard}}, \mathsf{rcm}_i)\!`.
+    - generate a ZSA output note that includes the Asset Base. For an Orchard-based ZSA note this is :math:`\mathsf{note}_i = (\mathsf{d}_i, \mathsf{pk}_{\mathsf{d}_i}, \mathsf{v}_i, \rho_i, \mathsf{rseed}_i, \mathsf{AssetBase^{Orchard}}, \mathsf{rcm}_i)\!`.
 
-- encode the `IssueAction` into the vector `vIssueActions` of the bundle
+- encode the ``IssueAction`` into the vector ``vIssueActions`` of the bundle.
 
-For the `IssueBundle`:
+For the ``IssueBundle``:
 
-- encode the `vIssueActions` vector
-- encode the :math:`\mathsf{ik}` as 32 byte-string
-- sign the `SIGHASH` of the transaction with the issuance authorizing key, :math:`\mathsf{isk}`, using the :math:`\mathsf{IssueAuthSig}` signature scheme. The signature is then added to the issuance bundle.
+- encode the ``vIssueActions`` vector.
+- encode the ``ik`` as 32 byte-string.
+- sign the ``SIGHASH`` of the transaction with the issuance authorizing key, :math:`\mathsf{isk}`, using the :math:`\mathsf{IssueAuthSig}` signature scheme. The signature is then added to the issuance bundle.
 
 
-**Note:** that the commitment is not included in the `IssuanceAction` itself. As explained below, it is computed later by the validators and added to the `NoteCommitmentTree`.
+**Note:** that the commitment is not included in the ``IssuanceAction`` itself. As explained below, it is computed later by the validators and added to the note commitment tree.
 
 
 Specification: Consensus Rule Changes
 =====================================
 
-For the IssueBundle:
+For the ``IssueBundle``:
 
-- Verify the RedPallas-based issuance authorization signature on `SIGHASH`, `issueAuthSig`, is verified by invoking `issueAuthSig.VerifySig(ik, SIGHASH)`
+- Verify the RedPallas-based issuance authorization signature on ``SIGHASH``, ``issueAuthSig``, is verified by invoking :math:`\mathsf{issueAuthSig.VerifySig}(\mathtt{ik}, \mathtt{SIGHASH})`.
 
-For each `IssueAction` in `IssueBundle`:
+For each ``IssueAction`` in ``IssueBundle``:
 
-- check that :math:`0 < \mathsf{assetDescSize} <= 512`.
-- check that :math:`\mathsf{asset\_desc}` is a string of length :math:`\mathsf{assetDescSize}` bytes.
+- check that :math:`0 < \mathtt{assetDescSize} <= 512`.
+- check that :math:`\mathtt{assetDesc}` is a string of length :math:`\mathtt{assetDescSize}` bytes.
 
-- retrieve :math:`\mathsf{AssetBase}` from the first note in the sequence and check that :math:`\mathsf{AssetBase}` is derived from the issuance validating key :math:`\mathsf{ik}` and :math:`\mathsf{asset\_desc}` as described in the `Specification: Asset Identifier`_ section.
+- retrieve :math:`\mathsf{AssetBase}` from the first note in the sequence and check that :math:`\mathsf{AssetBase}` is derived from the issuance validating key ``ik`` and ``assetDesc`` as described in the `Specification: Asset Identifier`_ section.
 - check that the :math:`\mathsf{AssetId}` does not exist in the ``previously_finalized`` set in the global state.
-- check that every note in the `IssueAction` contains the same :math:`\mathsf{AssetBase}` and is properly constructed as :math:`note = (\mathsf{g_d, pk_d, v, \rho, \psi, AssetBase})`.
+- check that every note in the ``IssueAction`` contains the same :math:`\mathsf{AssetBase}` and is properly constructed as :math:`\mathsf{note} = (\mathsf{g_d, pk_d, v, \rho, rseed, AssetBase})`.
 
 If all of the above checks pass, do the following:
 
 - For each note, compute the note commitment as :math:`\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}(repr_{\mathbb{P}}(g_d), repr_{\mathbb{P}}(pk_d), v, \rho, \psi, AssetBase)}` as defined in the Note Structure and Commitment section of ZIP 226 [#zip-0226-notestructure]_ and
-- add :math:`\mathsf{cm}` to the Merkle tree of note commitments, `NoteCommitmentTree`.
+- Add :math:`\mathsf{cm}` to the Merkle tree of note commitments.
 - If ``finalize = 1``, add :math:`\mathsf{AssetId}` to the ``previously_finalized`` set immediately after the block in which this transaction occurs.
 - (Replay Protection) If issue bundle is present, the fees MUST be greater than zero.
 

--- a/zip-0227.rst
+++ b/zip-0227.rst
@@ -184,7 +184,7 @@ Specification: Global Issuance State
 
 Issuance requires the following additions to the global state defined at block boundaries:
 
-- ``previously_finalized``, a set of :math:`\mathsf{AssetId}` that have been finalized (i.e.: the ``finalize`` flag has been set to ``1`` in some issuance transaction preceding the block boundary).
+- ``finalized_assets``, a set of :math:`\mathsf{AssetId}` that have been finalized (i.e.: the ``finalize`` flag has been set to ``1`` in some issuance transaction preceding the block boundary).
 
 
 Specification: Issuance Action, Issuance Bundle and Issuance Protocol
@@ -200,9 +200,9 @@ An issuance action, ``IssueAction``, is the instance of issuing a specific custo
 - ``vNotes``: an array of ``Note`` containing the unencrypted output notes of the recipients of the Asset.
 - ``flagsIssuance``: a byte that stores the ``finalize`` boolean that defines whether the issuance of that specific Custom Asset is finalized or not
 
-An asset's :math:`\mathsf{AssetId}` is added to the ``previously_finalized`` set after a block that contains any issuance transaction for that asset with ``finalize = 1``. It then cannot be removed from this set. 
-For Assets with :math:`\mathsf{AssetId} \in \mathtt{previously\_finalized}`, no further tokens can be issued, so as seen below, the validators will reject the transaction. 
-For Assets with :math:`\mathsf{AssetId} \not\in \mathtt{previously\_finalized}`, new issuance actions can be issued in future transactions. 
+An asset's :math:`\mathsf{AssetId}` is added to the ``finalized_assets`` set after a block that contains any issuance transaction for that asset with ``finalize = 1``. It then cannot be removed from this set. 
+For Assets with :math:`\mathsf{AssetId} \in \mathtt{finalized\_assets}`, no further tokens can be issued, so as seen below, the validators will reject the transaction. 
+For Assets with :math:`\mathsf{AssetId} \not\in \mathtt{finalized\_assets}`, new issuance actions can be issued in future transactions. 
 These must use the same Asset description, ``assetDesc``, and can either maintain ``finalize = 0`` or change it to ``finalize = 1``, denoting that this Custom Asset cannot be issued after the containing block.
 
 +-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
@@ -293,14 +293,14 @@ For each ``IssueAction`` in ``IssueBundle``:
 - check that :math:`\mathtt{assetDesc}` is a string of length :math:`\mathtt{assetDescSize}` bytes.
 
 - retrieve :math:`\mathsf{AssetBase}` from the first note in the sequence and check that :math:`\mathsf{AssetBase}` is derived from the issuance validating key ``ik`` and ``assetDesc`` as described in the `Specification: Asset Identifier`_ section.
-- check that the :math:`\mathsf{AssetId}` does not exist in the ``previously_finalized`` set in the global state.
+- check that the :math:`\mathsf{AssetId}` does not exist in the ``finalized_assets`` set in the global state.
 - check that every note in the ``IssueAction`` contains the same :math:`\mathsf{AssetBase}` and is properly constructed as :math:`\mathsf{note} = (\mathsf{g_d, pk_d, v, \rho, rseed, AssetBase})`.
 
 If all of the above checks pass, do the following:
 
 - For each note, compute the note commitment as :math:`\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}(repr_{\mathbb{P}}(g_d), repr_{\mathbb{P}}(pk_d), v, \rho, \psi, AssetBase)}` as defined in the Note Structure and Commitment section of ZIP 226 [#zip-0226-notestructure]_ and
 - Add :math:`\mathsf{cm}` to the Merkle tree of note commitments.
-- If ``finalize = 1``, add :math:`\mathsf{AssetId}` to the ``previously_finalized`` set immediately after the block in which this transaction occurs.
+- If ``finalize = 1``, add :math:`\mathsf{AssetId}` to the ``finalized_assets`` set immediately after the block in which this transaction occurs.
 - (Replay Protection) If issue bundle is present, the fees MUST be greater than zero.
 
 
@@ -318,7 +318,7 @@ The following is a list of rationale for different decisions made in the proposa
     - bridging information for Wrapped Assets (chain of origin, issuer name, etc)
     - information to be committed by the issuer, though not enforceable by the protocol.
 
-- We require a check whether the ``finalize`` flag only has been set in a previous block rather than a previous transaction in the same block. In other words, we only update the ``previously_finalized`` set at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.
+- We require a check whether the ``finalize`` flag only has been set in a previous block rather than a previous transaction in the same block. In other words, we only update the ``finalized_assets`` set at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.
 - We require non-zero fees in the presence of an issue bundle, in order to preclude the possibility of a transaction containing only an issue bundle. If a transaction includes only an issue bundle, the ``SIGHASH`` would be computed solely based on the issue bundle. A duplicate bundle would have the same ``SIGHASH``, potentially allowing for a replay attack. 
 
 Concrete Applications

--- a/zip-0227.rst
+++ b/zip-0227.rst
@@ -84,9 +84,9 @@ The ZSA Protocol adds the following three keys to the key components [#protocol-
 
 1. The issuance master key, denoted as :math:`\mathsf{sk}_{\mathsf{iss}}`, as the name suggests, is the master key that is used to derive the other two keys.
 
-2. The issuance authorizing key is the key that is used to sign the issuance transaction, and is denoted as :math:`\mathsf{isk}`. This key is used to authorize the issuance of a specific Asset Identifier, and is only used by the issuer.
+2. The issuance authorizing key is the key that is used to sign the issuance transaction, and is denoted as ``isk``. This key is used to authorize the issuance of a specific Asset Identifier, and is only used by the issuer.
 
-3. The issuance validating key, denoted as :math:`\mathsf{ik}`, is the key that is used to validate the issuance transaction. This key is used to validate the issuance of a specific Asset Identifier, and is used by all blockchain users (specifically the Asset owners and consensus validators) to associate the Asset in question with the issuer.
+3. The issuance validating key, denoted as ``ik``, is the key that is used to validate the issuance transaction. This key is used to validate the issuance of a specific Asset Identifier, and is used by all blockchain users (specifically the Asset owners and consensus validators) to associate the Asset in question with the issuer.
 
 The relations between these keys are shown in the following diagram:
 
@@ -135,31 +135,31 @@ The issuance authorizing key and issuance validating key are derived from the is
 
 - The issuance authorizing key is derived from the issuance master key, :math:`\mathsf{sk}_{\mathsf{iss}}`, as a private signature key:
 
-.. math:: \mathsf{isk} := \mathsf{ToScalar}^{\mathsf{Orchard}}(︀ \mathsf{sk}_{\mathsf{iss}} )
+.. math:: \mathtt{isk} := \mathsf{ToScalar}^{\mathsf{Orchard}}(︀ \mathsf{sk}_{\mathsf{iss}} )
 
-- The issuance validating key is derived from the issuance authorizing key, :math:`\mathsf{isk}`, as a public verification key:
+- The issuance validating key is derived from the issuance authorizing key, :math:`\mathtt{isk}`, as a public verification key:
 
-.. math:: \mathsf{ik} := \mathsf{IssueAuthSig}.\mathsf{DerivePublic}(\mathsf{isk})
+.. math:: \mathtt{ik} := \mathsf{IssueAuthSig}.\mathsf{DerivePublic}(\mathtt{isk})
 
 This allows the issuer to use the same wallet it usually uses to transfer Assets, while keeping a disconnect from the other keys. Specifically, this method is aligned with the requirements and motivation of ZIP 32 [#zip-0032]_. It provides further anonymity and the ability to delegate issuance of an Asset (or in the future, generate a multi-signature protocol) while the rest of the keys remain in the wallet safe.
 
 Specification: Asset Identifier
 ===============================
 
-For every new Asset, there must be a new and unique Asset Identifier, denoted :math:`\mathsf{AssetId}`. We define this to be a globally unique pair :math:`\mathsf{AssetId} := (\mathsf{ik}, \mathsf{asset\_desc})`, where :math:`\mathsf{ik}` is the issuance key and :math:`\mathsf{asset\_desc}` is a byte string.
+For every new Asset, there must be a new and unique Asset Identifier, denoted :math:`\mathsf{AssetId}`. We define this to be a globally unique pair :math:`\mathsf{AssetId} := (\mathtt{ik}, \mathtt{assetDesc})`, where ``ik`` is the issuance key and ``assetDesc`` is a byte string.
 
 A given Asset Identifier is used across all Zcash protocols that support ZSAs -- that is, the Orchard-based ZSA protocol and potentially future Zcash shielded protocols. For this Asset Identifier, we derive an Asset Digest, :math:`\mathsf{AssetDigest}`, which is simply is a :math:`\textsf{BLAKE2b-512}` hash of the Asset Identifier.
 From the Asset Digest, we derive a specific Asset Base within each such shielded protocol (for example :math:`\mathsf{AssetBase}^{\mathsf{Orchard}}_{\mathsf{AssetId}}` for the Orchard-based ZSA protocol), using the applicable hash-to-curve algorithm. This Asset Base is included in shielded notes.
 
 Let 
 
-- :math:`\mathsf{asset\_desc}` be the asset description, which includes any information pertaining to the issuance, and is a byte sequence of up to 512 bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.
-- :math:`\mathsf{ik}` be the issuance validating key of the issuer, a public key used to verify the signature on the issuance transaction's SIGHASH.
+- ``assetDesc`` be the asset description, which includes any information pertaining to the issuance, and is a byte sequence of up to 512 bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.
+- ``ik`` be the issuance validating key of the issuer, a public key used to verify the signature on the issuance transaction's SIGHASH.
 
 Define :math:`\mathsf{AssetDigest_{\mathsf{AssetId}}} := \textsf{BLAKE2b-512}(\texttt{"ZSA-Asset-Digest"},\; \mathsf{EncodeAssetId}(\mathsf{AssetId}))`,
 where
 
-- :math:`\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathsf{0x00} || \mathsf{repr}_{\mathbb{P}}(\mathsf{ik}) || \mathsf{asset\_desc}\!`.
+- :math:`\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathtt{ik}, \mathtt{assetDesc})) := \mathsf{0x00} || \mathsf{repr}_{\mathbb{P}}(\mathtt{ik}) || \mathtt{assetDesc}\!`.
 
 Define :math:`\mathsf{AssetBase^{Protocol}_{\mathsf{AssetId}}} := \mathsf{ZSAValueBase^{Protocol}}(\mathsf{AssetDigest}_{\mathsf{AssetId}})`,
 where
@@ -236,7 +236,7 @@ It contains the following fields:
 
 - ``ik``: the issuance validating key, that allows the validators to verify that the :math:`\mathsf{AssetId}` is properly associated with the issuer.
 - ``vIssueActions``: an array of issuance actions, of type `IssueAction`.
-- ``issueAuthSig``: the signature of the transaction SIGHASH, signed by the issuance authorizing key, :math:`\mathsf{isk}`, that validates the issuance .
+- ``issueAuthSig``: the signature of the transaction SIGHASH, signed by the issuance authorizing key, :math:`\mathtt{isk}`, that validates the issuance .
 
 The issuance bundle is then added within the transaction format as a new bundle. That is, issuance requires the addition of the following information to the transaction format [#protocol-transactionstructure]_.
 
@@ -274,7 +274,7 @@ For the ``IssueBundle``:
 
 - encode the ``vIssueActions`` vector.
 - encode the ``ik`` as 32 byte-string.
-- sign the ``SIGHASH`` of the transaction with the issuance authorizing key, :math:`\mathsf{isk}`, using the :math:`\mathsf{IssueAuthSig}` signature scheme. The signature is then added to the issuance bundle.
+- sign the ``SIGHASH`` of the transaction with the issuance authorizing key, :math:`\mathtt{isk}`, using the :math:`\mathsf{IssueAuthSig}` signature scheme. The signature is then added to the issuance bundle.
 
 
 **Note:** that the commitment is not included in the ``IssuanceAction`` itself. As explained below, it is computed later by the validators and added to the note commitment tree.
@@ -311,7 +311,7 @@ The following is a list of rationale for different decisions made in the proposa
 
 - The issuance key structure is independent of the original key tree, but derived in an analogous manner (via ZIP 32). This is in order to keep the issuance details and the Asset Identifiers consistent across multiple shielded pools.
 - The design decision is not to have a chosen name to describe the Custom Asset, but to delegate it to an off-chain mapping, as this would imply a land-grab “war”.
-- The :math:`\mathsf{asset\_desc}` is a general byte string in order to allow for a wide range of information type to be included that may be associated with the Assets. Some are:
+- The ``assetDesc`` is a general byte string in order to allow for a wide range of information type to be included that may be associated with the Assets. Some are:
 
     - links for storage such as for NFTs.
     - metadata for Assets, encoded in any format.
@@ -538,7 +538,7 @@ The fee mechanism described in this ZIP will follow the mechanism described in Z
 Future Work
 -----------
 
-In future versions of this ZIP, the protocol may also include a "key rotation" mechanism. This would allow an issuer to change the underlying :math:`\mathsf{ik}` of a given Asset, in case the original one was compromised, without having to change the Asset Identifier altogether.
+In future versions of this ZIP, the protocol may also include a "key rotation" mechanism. This would allow an issuer to change the underlying ``ik`` of a given Asset, in case the original one was compromised, without having to change the Asset Identifier altogether.
 
 Test Vectors
 ============

--- a/zip-0227.rst
+++ b/zip-0227.rst
@@ -184,7 +184,7 @@ Specification: Global Issuance State
 
 Issuance requires the following additions to the global state defined at block boundaries:
 
-- ``finalized_assets``, a set of :math:`\mathsf{AssetId}` that have been finalized (i.e.: the ``finalize`` flag has been set to ``1`` in some issuance transaction preceding the block boundary).
+- ``finalized_assets``, a set of :math:`\mathsf{AssetDigest}` that have been finalized (i.e.: the ``finalize`` flag has been set to ``1`` in some issuance transaction preceding the block boundary).
 
 
 Specification: Issuance Action, Issuance Bundle and Issuance Protocol
@@ -200,9 +200,9 @@ An issuance action, ``IssueAction``, is the instance of issuing a specific custo
 - ``vNotes``: an array of ``Note`` containing the unencrypted output notes of the recipients of the Asset.
 - ``flagsIssuance``: a byte that stores the ``finalize`` boolean that defines whether the issuance of that specific Custom Asset is finalized or not
 
-An asset's :math:`\mathsf{AssetId}` is added to the ``finalized_assets`` set after a block that contains any issuance transaction for that asset with ``finalize = 1``. It then cannot be removed from this set. 
-For Assets with :math:`\mathsf{AssetId} \in \mathtt{finalized\_assets}`, no further tokens can be issued, so as seen below, the validators will reject the transaction. 
-For Assets with :math:`\mathsf{AssetId} \not\in \mathtt{finalized\_assets}`, new issuance actions can be issued in future transactions. 
+An asset's :math:`\mathsf{AssetDigest}` is added to the ``finalized_assets`` set after a block that contains any issuance transaction for that asset with ``finalize = 1``. It then cannot be removed from this set. 
+For Assets with :math:`\mathsf{AssetDigest} \in \mathtt{finalized\_assets}`, no further tokens can be issued, so as seen below, the validators will reject the transaction. 
+For Assets with :math:`\mathsf{AssetDigest} \not\in \mathtt{finalized\_assets}`, new issuance actions can be issued in future transactions. 
 These must use the same Asset description, ``assetDesc``, and can either maintain ``finalize = 0`` or change it to ``finalize = 1``, denoting that this Custom Asset cannot be issued after the containing block.
 
 +-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
@@ -293,14 +293,14 @@ For each ``IssueAction`` in ``IssueBundle``:
 - check that :math:`\mathtt{assetDesc}` is a string of length :math:`\mathtt{assetDescSize}` bytes.
 
 - retrieve :math:`\mathsf{AssetBase}` from the first note in the sequence and check that :math:`\mathsf{AssetBase}` is derived from the issuance validating key ``ik`` and ``assetDesc`` as described in the `Specification: Asset Identifier`_ section.
-- check that the :math:`\mathsf{AssetId}` does not exist in the ``finalized_assets`` set in the global state.
+- check that the :math:`\mathsf{AssetDigest}` does not exist in the ``finalized_assets`` set in the global state.
 - check that every note in the ``IssueAction`` contains the same :math:`\mathsf{AssetBase}` and is properly constructed as :math:`\mathsf{note} = (\mathsf{g_d, pk_d, v, \rho, rseed, AssetBase})`.
 
 If all of the above checks pass, do the following:
 
 - For each note, compute the note commitment as :math:`\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}(repr_{\mathbb{P}}(g_d), repr_{\mathbb{P}}(pk_d), v, \rho, \psi, AssetBase)}` as defined in the Note Structure and Commitment section of ZIP 226 [#zip-0226-notestructure]_ and
 - Add :math:`\mathsf{cm}` to the Merkle tree of note commitments.
-- If ``finalize = 1``, add :math:`\mathsf{AssetId}` to the ``finalized_assets`` set immediately after the block in which this transaction occurs.
+- If ``finalize = 1``, add :math:`\mathsf{AssetDigest}` to the ``finalized_assets`` set immediately after the block in which this transaction occurs.
 - (Replay Protection) If issue bundle is present, the fees MUST be greater than zero.
 
 


### PR DESCRIPTION
This PR makes the naming conventions for variables more consistent, largely with a view to using double backticks for terms that appear in the transaction format and datatype description tables. 

These tables have also been reformatted to be consistent with other ZIPs in their rst form. 