### PR TITLE
Adding ZIP 230, with the v6 transaction format, to the PR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Use ``make`` to check that you are using correct
 `reStructuredText <https://docutils.sourceforge.io/rst.html>`__ or
 `Markdown <https://pandoc.org/MANUAL.html#pandocs-markdown>`__ syntax,
 and double-check the generated ``draft-*.html`` file before filing a Pull Request.
-See `here <protocol/README.rst>`__ for the project dependencies.
+
 
 NU5 ZIPs
 --------
@@ -75,90 +75,93 @@ Index of ZIPs
 
   <embed><table>
     <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
-    <tr> <td>0</td> <td class="left"><a href="zip-0000.rst">ZIP Process</a></td> <td>Active</td>
-    <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zip-0001.rst">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zip-0002.rst">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
-    <tr> <td>32</td> <td class="left"><a href="zip-0032.rst">Shielded Hierarchical Deterministic Wallets</a></td> <td>Final</td>
-    <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zip-0076.rst">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
-    <tr> <td>143</td> <td class="left"><a href="zip-0143.rst">Transaction Signature Validation for Overwinter</a></td> <td>Final</td>
-    <tr> <td>155</td> <td class="left"><a href="zip-0155.rst">addrv2 message</a></td> <td>Proposed</td>
-    <tr> <td>173</td> <td class="left"><a href="zip-0173.rst">Bech32 Format</a></td> <td>Final</td>
-    <tr> <td>200</td> <td class="left"><a href="zip-0200.rst">Network Upgrade Mechanism</a></td> <td>Final</td>
-    <tr> <td>201</td> <td class="left"><a href="zip-0201.rst">Network Peer Management for Overwinter</a></td> <td>Final</td>
-    <tr> <td>202</td> <td class="left"><a href="zip-0202.rst">Version 3 Transaction Format for Overwinter</a></td> <td>Final</td>
-    <tr> <td>203</td> <td class="left"><a href="zip-0203.rst">Transaction Expiry</a></td> <td>Final</td>
-    <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zip-0204.rst">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
-    <tr> <td>205</td> <td class="left"><a href="zip-0205.rst">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>206</td> <td class="left"><a href="zip-0206.rst">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>207</td> <td class="left"><a href="zip-0207.rst">Funding Streams</a></td> <td>Final</td>
-    <tr> <td>208</td> <td class="left"><a href="zip-0208.rst">Shorter Block Target Spacing</a></td> <td>Final</td>
-    <tr> <td>209</td> <td class="left"><a href="zip-0209.rst">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
-    <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zip-0210.rst">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
-    <tr> <td>211</td> <td class="left"><a href="zip-0211.rst">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
-    <tr> <td>212</td> <td class="left"><a href="zip-0212.rst">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
-    <tr> <td>213</td> <td class="left"><a href="zip-0213.rst">Shielded Coinbase</a></td> <td>Final</td>
-    <tr> <td>214</td> <td class="left"><a href="zip-0214.rst">Consensus rules for a Zcash Development Fund</a></td> <td>Final</td>
-    <tr> <td>215</td> <td class="left"><a href="zip-0215.rst">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
-    <tr> <td>216</td> <td class="left"><a href="zip-0216.rst">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
-    <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zip-0217.rst">Aggregate Signatures</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zip-0219.rst">Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>Reserved</td>
-    <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zip-0220.rst">Zcash Shielded Assets</a></strike></td> <td>Withdrawn</td>
-    <tr> <td>221</td> <td class="left"><a href="zip-0221.rst">FlyClient - Consensus-Layer Changes</a></td> <td>Final</td>
-    <tr> <td>222</td> <td class="left"><a href="zip-0222.rst">Transparent Zcash Extensions</a></td> <td>Draft</td>
-    <tr> <td>224</td> <td class="left"><a href="zip-0224.rst">Orchard Shielded Protocol</a></td> <td>Final</td>
-    <tr> <td>225</td> <td class="left"><a href="zip-0225.rst">Version 5 Transaction Format</a></td> <td>Final</td>
-    <tr> <td>226</td> <td class="left"><a href="zip-0226.rst">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td>
-    <tr> <td>227</td> <td class="left"><a href="zip-0227.rst">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td>
-    <tr> <td>239</td> <td class="left"><a href="zip-0239.rst">Relay of Version 5 Transactions</a></td> <td>Final</td>
-    <tr> <td>243</td> <td class="left"><a href="zip-0243.rst">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
-    <tr> <td>244</td> <td class="left"><a href="zip-0244.rst">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
-    <tr> <td>245</td> <td class="left"><a href="zip-0245.rst">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td>
-    <tr> <td>250</td> <td class="left"><a href="zip-0250.rst">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>251</td> <td class="left"><a href="zip-0251.rst">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>252</td> <td class="left"><a href="zip-0252.rst">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>300</td> <td class="left"><a href="zip-0300.rst">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
-    <tr> <td>301</td> <td class="left"><a href="zip-0301.rst">Zcash Stratum Protocol</a></td> <td>Final</td>
-    <tr> <td>302</td> <td class="left"><a href="zip-0302.rst">Standardized Memo Field Format</a></td> <td>Draft</td>
-    <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zip-0303.rst">Sprout Payment Disclosure</a></td> <td>Reserved</td>
-    <tr> <td>304</td> <td class="left"><a href="zip-0304.rst">Sapling Address Signatures</a></td> <td>Draft</td>
-    <tr> <td><span class="reserved">305</span></td> <td class="left"><a class="reserved" href="zip-0305.rst">Best Practices for Hardware Wallets supporting Sapling</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">306</span></td> <td class="left"><a class="reserved" href="zip-0306.rst">Security Considerations for Anchor Selection</a></td> <td>Reserved</td>
-    <tr> <td>307</td> <td class="left"><a href="zip-0307.rst">Light Client Protocol for Payment Detection</a></td> <td>Draft</td>
-    <tr> <td>308</td> <td class="left"><a href="zip-0308.rst">Sprout to Sapling Migration</a></td> <td>Final</td>
-    <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zip-0309.rst">Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>Reserved</td>
-    <tr> <td>310</td> <td class="left"><a href="zip-0310.rst">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
-    <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311.rst">Sapling Payment Disclosure</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312.rst">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
-    <tr> <td>313</td> <td class="left"><a href="zip-0313.rst">Reduce Conventional Transaction Fee to 1000 zatoshis</a></td> <td>Active</td>
-    <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314.rst">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">315</span></td> <td class="left"><a class="reserved" href="zip-0315.rst">Best Practices for Wallet Handling of Multiple Pools</a></td> <td>Reserved</td>
-    <tr> <td>316</td> <td class="left"><a href="zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>Final</td>
-    <tr> <td>317</td> <td class="left"><a href="zip-0317.rst">Proportional Transfer Fee Mechanism</a></td> <td>Draft</td>
-    <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zip-0318.rst">Associated Payload Encryption</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
-    <tr> <td>321</td> <td class="left"><a href="zip-0321.rst">Payment Request URIs</a></td> <td>Proposed</td>
-    <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zip-0322.rst">Generic Signed Message Format</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zip-0323.rst">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zip-0332.rst">Wallet Recovery from zcashd HD Seeds</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zip-0339.rst">Wallet Recovery Words</a></td> <td>Reserved</td>
-    <tr> <td>400</td> <td class="left"><a href="zip-0400.rst">Wallet.dat format</a></td> <td>Draft</td>
-    <tr> <td>401</td> <td class="left"><a href="zip-0401.rst">Addressing Mempool Denial-of-Service</a></td> <td>Active</td>
-    <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zip-0402.rst">New Wallet Database Format</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zip-0403.rst">Verification Behaviour of zcashd</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zip-0416.rst">Support for Unified Addresses in zcashd</a></td> <td>Reserved</td>
-    <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zip-1001.rst">Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1002</strike></td> <td class="left"><strike><a href="zip-1002.rst">Opt-in Donation Feature</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1003</strike></td> <td class="left"><strike><a href="zip-1003.rst">20% Split Evenly Between the ECC and the Zcash Foundation, and a Voting System Mandate</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1004</strike></td> <td class="left"><strike><a href="zip-1004.rst">Miner-Directed Dev Fund</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1005</strike></td> <td class="left"><strike><a href="zip-1005.rst">Zcash Community Funding System</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1006</strike></td> <td class="left"><strike><a href="zip-1006.rst">Development Fund of 10% to a 2-of-3 Multisig with Community-Involved Third Entity</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1007</strike></td> <td class="left"><strike><a href="zip-1007.rst">Enforce Development Fund Commitments with a Legal Charter</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1008</strike></td> <td class="left"><strike><a href="zip-1008.rst">Fund ECC for Two More Years</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1009</strike></td> <td class="left"><strike><a href="zip-1009.rst">Five-Entity Strategic Council</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1010</strike></td> <td class="left"><strike><a href="zip-1010.rst">Compromise Dev Fund Proposal With Diverse Funding Streams</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1011</strike></td> <td class="left"><strike><a href="zip-1011.rst">Decentralize the Dev Fee</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1012</strike></td> <td class="left"><strike><a href="zip-1012.rst">Dev Fund to ECC + ZF + Major Grants</a></strike></td> <td>Obsolete</td>
-    <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zip-1013.rst">Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>Obsolete</td>
-    <tr> <td>1014</td> <td class="left"><a href="zip-1014.rst">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
-    <tr> <td>guide</td> <td class="left"><a href="zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td>
+    <tr> <td>0</td> <td class="left"><a href="zip-0000.rst">   ZIP Process
+  </a></td> <td>   Active
+  </td>
+    <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zip-0001.rst">   Network Upgrade Policy and Scheduling</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zip-0002.rst">   Design Considerations for Network Upgrades</a></td> <td>   Reserved</td>
+    <tr> <td>32</td> <td class="left"><a href="zip-0032.rst">   Shielded Hierarchical Deterministic Wallets</a></td> <td>   Final</td>
+    <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zip-0076.rst">   Transaction Signature Validation before Overwinter</a></td> <td>   Reserved</td>
+    <tr> <td>143</td> <td class="left"><a href="zip-0143.rst">   Transaction Signature Validation for Overwinter</a></td> <td>   Final</td>
+    <tr> <td>155</td> <td class="left"><a href="zip-0155.rst">   addrv2 message</a></td> <td>   Proposed</td>
+    <tr> <td>173</td> <td class="left"><a href="zip-0173.rst">   Bech32 Format</a></td> <td>   Final</td>
+    <tr> <td>200</td> <td class="left"><a href="zip-0200.rst">   Network Upgrade Mechanism</a></td> <td>   Final</td>
+    <tr> <td>201</td> <td class="left"><a href="zip-0201.rst">   Network Peer Management for Overwinter</a></td> <td>   Final</td>
+    <tr> <td>202</td> <td class="left"><a href="zip-0202.rst">   Version 3 Transaction Format for Overwinter</a></td> <td>   Final</td>
+    <tr> <td>203</td> <td class="left"><a href="zip-0203.rst">   Transaction Expiry</a></td> <td>   Final</td>
+    <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zip-0204.rst">   Zcash P2P Network Protocol</a></td> <td>   Reserved</td>
+    <tr> <td>205</td> <td class="left"><a href="zip-0205.rst">   Deployment of the Sapling Network Upgrade</a></td> <td>   Final</td>
+    <tr> <td>206</td> <td class="left"><a href="zip-0206.rst">   Deployment of the Blossom Network Upgrade</a></td> <td>   Final</td>
+    <tr> <td>207</td> <td class="left"><a href="zip-0207.rst">   Funding Streams</a></td> <td>   Final</td>
+    <tr> <td>208</td> <td class="left"><a href="zip-0208.rst">   Shorter Block Target Spacing</a></td> <td>   Final</td>
+    <tr> <td>209</td> <td class="left"><a href="zip-0209.rst">   Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>   Final</td>
+    <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zip-0210.rst">   Sapling Anchor Deduplication within Transactions</a></strike></td> <td>   Withdrawn</td>
+    <tr> <td>211</td> <td class="left"><a href="zip-0211.rst">   Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>   Final</td>
+    <tr> <td>212</td> <td class="left"><a href="zip-0212.rst">   Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>   Final</td>
+    <tr> <td>213</td> <td class="left"><a href="zip-0213.rst">   Shielded Coinbase</a></td> <td>   Final</td>
+    <tr> <td>214</td> <td class="left"><a href="zip-0214.rst">   Consensus rules for a Zcash Development Fund</a></td> <td>   Final</td>
+    <tr> <td>215</td> <td class="left"><a href="zip-0215.rst">   Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>   Final</td>
+    <tr> <td>216</td> <td class="left"><a href="zip-0216.rst">   Require Canonical Jubjub Point Encodings</a></td> <td>   Final</td>
+    <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zip-0217.rst">   Aggregate Signatures</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zip-0219.rst">   Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>   Reserved</td>
+    <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zip-0220.rst">   Zcash Shielded Assets</a></strike></td> <td>   Withdrawn</td>
+    <tr> <td>221</td> <td class="left"><a href="zip-0221.rst">   FlyClient - Consensus-Layer Changes</a></td> <td>   Final</td>
+    <tr> <td>222</td> <td class="left"><a href="zip-0222.rst">   Transparent Zcash Extensions</a></td> <td>   Draft</td>
+    <tr> <td>224</td> <td class="left"><a href="zip-0224.rst">   Orchard Shielded Protocol</a></td> <td>   Final</td>
+    <tr> <td>225</td> <td class="left"><a href="zip-0225.rst">   Version 5 Transaction Format</a></td> <td>   Final</td>
+    <tr> <td>226</td> <td class="left"><a href="zip-0226.rst">   Transfer and Burn of Zcash Shielded Assets</a></td> <td>   Draft</td>
+    <tr> <td>227</td> <td class="left"><a href="zip-0227.rst">   Issuance of Zcash Shielded Assets</a></td> <td>   Draft</td>
+    <tr> <td>230</td> <td class="left"><a href="zip-0230.rst">   Version 6 Transaction Format</a></td> <td>   Draft</td>
+    <tr> <td>239</td> <td class="left"><a href="zip-0239.rst">   Relay of Version 5 Transactions</a></td> <td>   Final</td>
+    <tr> <td>243</td> <td class="left"><a href="zip-0243.rst">   Transaction Signature Validation for Sapling</a></td> <td>   Final</td>
+    <tr> <td>244</td> <td class="left"><a href="zip-0244.rst">   Transaction Identifier Non-Malleability</a></td> <td>   Final</td>
+    <tr> <td>245</td> <td class="left"><a href="zip-0245.rst">   Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>   Draft</td>
+    <tr> <td>250</td> <td class="left"><a href="zip-0250.rst">   Deployment of the Heartwood Network Upgrade</a></td> <td>   Final</td>
+    <tr> <td>251</td> <td class="left"><a href="zip-0251.rst">   Deployment of the Canopy Network Upgrade</a></td> <td>   Final</td>
+    <tr> <td>252</td> <td class="left"><a href="zip-0252.rst">   Deployment of the NU5 Network Upgrade</a></td> <td>   Final</td>
+    <tr> <td>300</td> <td class="left"><a href="zip-0300.rst">   Cross-chain Atomic Transactions</a></td> <td>   Proposed</td>
+    <tr> <td>301</td> <td class="left"><a href="zip-0301.rst">   Zcash Stratum Protocol</a></td> <td>   Final</td>
+    <tr> <td>302</td> <td class="left"><a href="zip-0302.rst">   Standardized Memo Field Format</a></td> <td>   Draft</td>
+    <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zip-0303.rst">   Sprout Payment Disclosure</a></td> <td>   Reserved</td>
+    <tr> <td>304</td> <td class="left"><a href="zip-0304.rst">   Sapling Address Signatures</a></td> <td>   Draft</td>
+    <tr> <td><span class="reserved">305</span></td> <td class="left"><a class="reserved" href="zip-0305.rst">   Best Practices for Hardware Wallets supporting Sapling</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">306</span></td> <td class="left"><a class="reserved" href="zip-0306.rst">   Security Considerations for Anchor Selection</a></td> <td>   Reserved</td>
+    <tr> <td>307</td> <td class="left"><a href="zip-0307.rst">   Light Client Protocol for Payment Detection</a></td> <td>   Draft</td>
+    <tr> <td>308</td> <td class="left"><a href="zip-0308.rst">   Sprout to Sapling Migration</a></td> <td>   Final</td>
+    <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zip-0309.rst">   Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>   Reserved</td>
+    <tr> <td>310</td> <td class="left"><a href="zip-0310.rst">   Security Properties of Sapling Viewing Keys</a></td> <td>   Draft</td>
+    <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311.rst">   Sapling Payment Disclosure</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312.rst">   Shielded Multisignatures using FROST</a></td> <td>   Reserved</td>
+    <tr> <td>313</td> <td class="left"><a href="zip-0313.rst">   Reduce Conventional Transaction Fee to 1000 zatoshis</a></td> <td>   Active</td>
+    <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314.rst">   Privacy upgrades to the Zcash light client protocol</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">315</span></td> <td class="left"><a class="reserved" href="zip-0315.rst">   Best Practices for Wallet Handling of Multiple Pools</a></td> <td>   Reserved</td>
+    <tr> <td>316</td> <td class="left"><a href="zip-0316.rst">   Unified Addresses and Unified Viewing Keys</a></td> <td>   Final</td>
+    <tr> <td>317</td> <td class="left"><a href="zip-0317.rst">   Proportional Transfer Fee Mechanism</a></td> <td>   Draft</td>
+    <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zip-0318.rst">   Associated Payload Encryption</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zip-0319.rst">   Options for Shielded Pool Retirement</a></td> <td>   Reserved</td>
+    <tr> <td>321</td> <td class="left"><a href="zip-0321.rst">   Payment Request URIs</a></td> <td>   Proposed</td>
+    <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zip-0322.rst">   Generic Signed Message Format</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zip-0323.rst">   Specification of getblocktemplate for Zcash</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zip-0332.rst">   Wallet Recovery from zcashd HD Seeds</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zip-0339.rst">   Wallet Recovery Words</a></td> <td>   Reserved</td>
+    <tr> <td>400</td> <td class="left"><a href="zip-0400.rst">   Wallet.dat format</a></td> <td>   Draft</td>
+    <tr> <td>401</td> <td class="left"><a href="zip-0401.rst">   Addressing Mempool Denial-of-Service</a></td> <td>   Active</td>
+    <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zip-0402.rst">   New Wallet Database Format</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zip-0403.rst">   Verification Behaviour of zcashd</a></td> <td>   Reserved</td>
+    <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zip-0416.rst">   Support for Unified Addresses in zcashd</a></td> <td>   Reserved</td>
+    <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zip-1001.rst">   Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1002</strike></td> <td class="left"><strike><a href="zip-1002.rst">   Opt-in Donation Feature</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1003</strike></td> <td class="left"><strike><a href="zip-1003.rst">   20% Split Evenly Between the ECC and the Zcash Foundation, and a Voting System Mandate</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1004</strike></td> <td class="left"><strike><a href="zip-1004.rst">   Miner-Directed Dev Fund</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1005</strike></td> <td class="left"><strike><a href="zip-1005.rst">   Zcash Community Funding System</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1006</strike></td> <td class="left"><strike><a href="zip-1006.rst">    Development Fund of 10% to a 2-of-3 Multisig with Community-Involved Third Entity</a></strike></td> <td>    Obsolete</td>
+    <tr> <td><strike>1007</strike></td> <td class="left"><strike><a href="zip-1007.rst">   Enforce Development Fund Commitments with a Legal Charter</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1008</strike></td> <td class="left"><strike><a href="zip-1008.rst">   Fund ECC for Two More Years</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1009</strike></td> <td class="left"><strike><a href="zip-1009.rst">   Five-Entity Strategic Council</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1010</strike></td> <td class="left"><strike><a href="zip-1010.rst">   Compromise Dev Fund Proposal With Diverse Funding Streams</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1011</strike></td> <td class="left"><strike><a href="zip-1011.rst">   Decentralize the Dev Fee</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1012</strike></td> <td class="left"><strike><a href="zip-1012.rst">   Dev Fund to ECC + ZF + Major Grants</a></strike></td> <td>   Obsolete</td>
+    <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zip-1013.rst">   Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>   Obsolete</td>
+    <tr> <td>1014</td> <td class="left"><a href="zip-1014.rst">   Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>   Active</td>
+    <tr> <td>guide</td> <td class="left"><a href="zip-guide.rst">   {Something Short and To the Point}</a></td> <td>   Draft</td>
   </table></embed>

--- a/index.html
+++ b/index.html
@@ -49,92 +49,95 @@
         <section id="index-of-zips"><h2><span class="section-heading">Index of ZIPs</span><span class="section-anchor"> <a rel="bookmark" href="#index-of-zips"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
         <embed><table>
   <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
-  <tr> <td>0</td> <td class="left"><a href="zip-0000">ZIP Process</a></td> <td>Active</td>
-  <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zip-0001">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zip-0002">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
-  <tr> <td>32</td> <td class="left"><a href="zip-0032">Shielded Hierarchical Deterministic Wallets</a></td> <td>Final</td>
-  <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zip-0076">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
-  <tr> <td>143</td> <td class="left"><a href="zip-0143">Transaction Signature Validation for Overwinter</a></td> <td>Final</td>
-  <tr> <td>155</td> <td class="left"><a href="zip-0155">addrv2 message</a></td> <td>Proposed</td>
-  <tr> <td>173</td> <td class="left"><a href="zip-0173">Bech32 Format</a></td> <td>Final</td>
-  <tr> <td>200</td> <td class="left"><a href="zip-0200">Network Upgrade Mechanism</a></td> <td>Final</td>
-  <tr> <td>201</td> <td class="left"><a href="zip-0201">Network Peer Management for Overwinter</a></td> <td>Final</td>
-  <tr> <td>202</td> <td class="left"><a href="zip-0202">Version 3 Transaction Format for Overwinter</a></td> <td>Final</td>
-  <tr> <td>203</td> <td class="left"><a href="zip-0203">Transaction Expiry</a></td> <td>Final</td>
-  <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zip-0204">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
-  <tr> <td>205</td> <td class="left"><a href="zip-0205">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>206</td> <td class="left"><a href="zip-0206">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>207</td> <td class="left"><a href="zip-0207">Funding Streams</a></td> <td>Final</td>
-  <tr> <td>208</td> <td class="left"><a href="zip-0208">Shorter Block Target Spacing</a></td> <td>Final</td>
-  <tr> <td>209</td> <td class="left"><a href="zip-0209">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
-  <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zip-0210">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
-  <tr> <td>211</td> <td class="left"><a href="zip-0211">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
-  <tr> <td>212</td> <td class="left"><a href="zip-0212">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
-  <tr> <td>213</td> <td class="left"><a href="zip-0213">Shielded Coinbase</a></td> <td>Final</td>
-  <tr> <td>214</td> <td class="left"><a href="zip-0214">Consensus rules for a Zcash Development Fund</a></td> <td>Final</td>
-  <tr> <td>215</td> <td class="left"><a href="zip-0215">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
-  <tr> <td>216</td> <td class="left"><a href="zip-0216">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
-  <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zip-0217">Aggregate Signatures</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zip-0219">Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>Reserved</td>
-  <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zip-0220">Zcash Shielded Assets</a></strike></td> <td>Withdrawn</td>
-  <tr> <td>221</td> <td class="left"><a href="zip-0221">FlyClient - Consensus-Layer Changes</a></td> <td>Final</td>
-  <tr> <td>222</td> <td class="left"><a href="zip-0222">Transparent Zcash Extensions</a></td> <td>Draft</td>
-  <tr> <td>224</td> <td class="left"><a href="zip-0224">Orchard Shielded Protocol</a></td> <td>Final</td>
-  <tr> <td>225</td> <td class="left"><a href="zip-0225">Version 5 Transaction Format</a></td> <td>Final</td>
-  <tr> <td>226</td> <td class="left"><a href="zip-0226">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td>
-  <tr> <td>227</td> <td class="left"><a href="zip-0227">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td>
-  <tr> <td>239</td> <td class="left"><a href="zip-0239">Relay of Version 5 Transactions</a></td> <td>Final</td>
-  <tr> <td>243</td> <td class="left"><a href="zip-0243">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
-  <tr> <td>244</td> <td class="left"><a href="zip-0244">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
-  <tr> <td>245</td> <td class="left"><a href="zip-0245">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td>
-  <tr> <td>250</td> <td class="left"><a href="zip-0250">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>251</td> <td class="left"><a href="zip-0251">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>252</td> <td class="left"><a href="zip-0252">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>300</td> <td class="left"><a href="zip-0300">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
-  <tr> <td>301</td> <td class="left"><a href="zip-0301">Zcash Stratum Protocol</a></td> <td>Final</td>
-  <tr> <td>302</td> <td class="left"><a href="zip-0302">Standardized Memo Field Format</a></td> <td>Draft</td>
-  <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zip-0303">Sprout Payment Disclosure</a></td> <td>Reserved</td>
-  <tr> <td>304</td> <td class="left"><a href="zip-0304">Sapling Address Signatures</a></td> <td>Draft</td>
-  <tr> <td><span class="reserved">305</span></td> <td class="left"><a class="reserved" href="zip-0305">Best Practices for Hardware Wallets supporting Sapling</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">306</span></td> <td class="left"><a class="reserved" href="zip-0306">Security Considerations for Anchor Selection</a></td> <td>Reserved</td>
-  <tr> <td>307</td> <td class="left"><a href="zip-0307">Light Client Protocol for Payment Detection</a></td> <td>Draft</td>
-  <tr> <td>308</td> <td class="left"><a href="zip-0308">Sprout to Sapling Migration</a></td> <td>Final</td>
-  <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zip-0309">Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>Reserved</td>
-  <tr> <td>310</td> <td class="left"><a href="zip-0310">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
-  <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311">Sapling Payment Disclosure</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
-  <tr> <td>313</td> <td class="left"><a href="zip-0313">Reduce Conventional Transaction Fee to 1000 zatoshis</a></td> <td>Active</td>
-  <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">315</span></td> <td class="left"><a class="reserved" href="zip-0315">Best Practices for Wallet Handling of Multiple Pools</a></td> <td>Reserved</td>
-  <tr> <td>316</td> <td class="left"><a href="zip-0316">Unified Addresses and Unified Viewing Keys</a></td> <td>Final</td>
-  <tr> <td>317</td> <td class="left"><a href="zip-0317">Proportional Transfer Fee Mechanism</a></td> <td>Draft</td>
-  <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zip-0318">Associated Payload Encryption</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zip-0319">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
-  <tr> <td>321</td> <td class="left"><a href="zip-0321">Payment Request URIs</a></td> <td>Proposed</td>
-  <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zip-0322">Generic Signed Message Format</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zip-0323">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zip-0332">Wallet Recovery from zcashd HD Seeds</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zip-0339">Wallet Recovery Words</a></td> <td>Reserved</td>
-  <tr> <td>400</td> <td class="left"><a href="zip-0400">Wallet.dat format</a></td> <td>Draft</td>
-  <tr> <td>401</td> <td class="left"><a href="zip-0401">Addressing Mempool Denial-of-Service</a></td> <td>Active</td>
-  <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zip-0402">New Wallet Database Format</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zip-0403">Verification Behaviour of zcashd</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zip-0416">Support for Unified Addresses in zcashd</a></td> <td>Reserved</td>
-  <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zip-1001">Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1002</strike></td> <td class="left"><strike><a href="zip-1002">Opt-in Donation Feature</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1003</strike></td> <td class="left"><strike><a href="zip-1003">20% Split Evenly Between the ECC and the Zcash Foundation, and a Voting System Mandate</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1004</strike></td> <td class="left"><strike><a href="zip-1004">Miner-Directed Dev Fund</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1005</strike></td> <td class="left"><strike><a href="zip-1005">Zcash Community Funding System</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1006</strike></td> <td class="left"><strike><a href="zip-1006">Development Fund of 10% to a 2-of-3 Multisig with Community-Involved Third Entity</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1007</strike></td> <td class="left"><strike><a href="zip-1007">Enforce Development Fund Commitments with a Legal Charter</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1008</strike></td> <td class="left"><strike><a href="zip-1008">Fund ECC for Two More Years</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1009</strike></td> <td class="left"><strike><a href="zip-1009">Five-Entity Strategic Council</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1010</strike></td> <td class="left"><strike><a href="zip-1010">Compromise Dev Fund Proposal With Diverse Funding Streams</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1011</strike></td> <td class="left"><strike><a href="zip-1011">Decentralize the Dev Fee</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1012</strike></td> <td class="left"><strike><a href="zip-1012">Dev Fund to ECC + ZF + Major Grants</a></strike></td> <td>Obsolete</td>
-  <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zip-1013">Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>Obsolete</td>
-  <tr> <td>1014</td> <td class="left"><a href="zip-1014">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
-  <tr> <td>guide</td> <td class="left"><a href="zip-guide">{Something Short and To the Point}</a></td> <td>Draft</td>
+  <tr> <td>0</td> <td class="left"><a href="zip-0000">   ZIP Process
+</a></td> <td>   Active
+</td>
+  <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zip-0001">   Network Upgrade Policy and Scheduling</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zip-0002">   Design Considerations for Network Upgrades</a></td> <td>   Reserved</td>
+  <tr> <td>32</td> <td class="left"><a href="zip-0032">   Shielded Hierarchical Deterministic Wallets</a></td> <td>   Final</td>
+  <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zip-0076">   Transaction Signature Validation before Overwinter</a></td> <td>   Reserved</td>
+  <tr> <td>143</td> <td class="left"><a href="zip-0143">   Transaction Signature Validation for Overwinter</a></td> <td>   Final</td>
+  <tr> <td>155</td> <td class="left"><a href="zip-0155">   addrv2 message</a></td> <td>   Proposed</td>
+  <tr> <td>173</td> <td class="left"><a href="zip-0173">   Bech32 Format</a></td> <td>   Final</td>
+  <tr> <td>200</td> <td class="left"><a href="zip-0200">   Network Upgrade Mechanism</a></td> <td>   Final</td>
+  <tr> <td>201</td> <td class="left"><a href="zip-0201">   Network Peer Management for Overwinter</a></td> <td>   Final</td>
+  <tr> <td>202</td> <td class="left"><a href="zip-0202">   Version 3 Transaction Format for Overwinter</a></td> <td>   Final</td>
+  <tr> <td>203</td> <td class="left"><a href="zip-0203">   Transaction Expiry</a></td> <td>   Final</td>
+  <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zip-0204">   Zcash P2P Network Protocol</a></td> <td>   Reserved</td>
+  <tr> <td>205</td> <td class="left"><a href="zip-0205">   Deployment of the Sapling Network Upgrade</a></td> <td>   Final</td>
+  <tr> <td>206</td> <td class="left"><a href="zip-0206">   Deployment of the Blossom Network Upgrade</a></td> <td>   Final</td>
+  <tr> <td>207</td> <td class="left"><a href="zip-0207">   Funding Streams</a></td> <td>   Final</td>
+  <tr> <td>208</td> <td class="left"><a href="zip-0208">   Shorter Block Target Spacing</a></td> <td>   Final</td>
+  <tr> <td>209</td> <td class="left"><a href="zip-0209">   Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>   Final</td>
+  <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zip-0210">   Sapling Anchor Deduplication within Transactions</a></strike></td> <td>   Withdrawn</td>
+  <tr> <td>211</td> <td class="left"><a href="zip-0211">   Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>   Final</td>
+  <tr> <td>212</td> <td class="left"><a href="zip-0212">   Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>   Final</td>
+  <tr> <td>213</td> <td class="left"><a href="zip-0213">   Shielded Coinbase</a></td> <td>   Final</td>
+  <tr> <td>214</td> <td class="left"><a href="zip-0214">   Consensus rules for a Zcash Development Fund</a></td> <td>   Final</td>
+  <tr> <td>215</td> <td class="left"><a href="zip-0215">   Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>   Final</td>
+  <tr> <td>216</td> <td class="left"><a href="zip-0216">   Require Canonical Jubjub Point Encodings</a></td> <td>   Final</td>
+  <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zip-0217">   Aggregate Signatures</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zip-0219">   Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>   Reserved</td>
+  <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zip-0220">   Zcash Shielded Assets</a></strike></td> <td>   Withdrawn</td>
+  <tr> <td>221</td> <td class="left"><a href="zip-0221">   FlyClient - Consensus-Layer Changes</a></td> <td>   Final</td>
+  <tr> <td>222</td> <td class="left"><a href="zip-0222">   Transparent Zcash Extensions</a></td> <td>   Draft</td>
+  <tr> <td>224</td> <td class="left"><a href="zip-0224">   Orchard Shielded Protocol</a></td> <td>   Final</td>
+  <tr> <td>225</td> <td class="left"><a href="zip-0225">   Version 5 Transaction Format</a></td> <td>   Final</td>
+  <tr> <td>226</td> <td class="left"><a href="zip-0226">   Transfer and Burn of Zcash Shielded Assets</a></td> <td>   Draft</td>
+  <tr> <td>227</td> <td class="left"><a href="zip-0227">   Issuance of Zcash Shielded Assets</a></td> <td>   Draft</td>
+  <tr> <td>230</td> <td class="left"><a href="zip-0230">   Version 6 Transaction Format</a></td> <td>   Draft</td>
+  <tr> <td>239</td> <td class="left"><a href="zip-0239">   Relay of Version 5 Transactions</a></td> <td>   Final</td>
+  <tr> <td>243</td> <td class="left"><a href="zip-0243">   Transaction Signature Validation for Sapling</a></td> <td>   Final</td>
+  <tr> <td>244</td> <td class="left"><a href="zip-0244">   Transaction Identifier Non-Malleability</a></td> <td>   Final</td>
+  <tr> <td>245</td> <td class="left"><a href="zip-0245">   Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>   Draft</td>
+  <tr> <td>250</td> <td class="left"><a href="zip-0250">   Deployment of the Heartwood Network Upgrade</a></td> <td>   Final</td>
+  <tr> <td>251</td> <td class="left"><a href="zip-0251">   Deployment of the Canopy Network Upgrade</a></td> <td>   Final</td>
+  <tr> <td>252</td> <td class="left"><a href="zip-0252">   Deployment of the NU5 Network Upgrade</a></td> <td>   Final</td>
+  <tr> <td>300</td> <td class="left"><a href="zip-0300">   Cross-chain Atomic Transactions</a></td> <td>   Proposed</td>
+  <tr> <td>301</td> <td class="left"><a href="zip-0301">   Zcash Stratum Protocol</a></td> <td>   Final</td>
+  <tr> <td>302</td> <td class="left"><a href="zip-0302">   Standardized Memo Field Format</a></td> <td>   Draft</td>
+  <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zip-0303">   Sprout Payment Disclosure</a></td> <td>   Reserved</td>
+  <tr> <td>304</td> <td class="left"><a href="zip-0304">   Sapling Address Signatures</a></td> <td>   Draft</td>
+  <tr> <td><span class="reserved">305</span></td> <td class="left"><a class="reserved" href="zip-0305">   Best Practices for Hardware Wallets supporting Sapling</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">306</span></td> <td class="left"><a class="reserved" href="zip-0306">   Security Considerations for Anchor Selection</a></td> <td>   Reserved</td>
+  <tr> <td>307</td> <td class="left"><a href="zip-0307">   Light Client Protocol for Payment Detection</a></td> <td>   Draft</td>
+  <tr> <td>308</td> <td class="left"><a href="zip-0308">   Sprout to Sapling Migration</a></td> <td>   Final</td>
+  <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zip-0309">   Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>   Reserved</td>
+  <tr> <td>310</td> <td class="left"><a href="zip-0310">   Security Properties of Sapling Viewing Keys</a></td> <td>   Draft</td>
+  <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311">   Sapling Payment Disclosure</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312">   Shielded Multisignatures using FROST</a></td> <td>   Reserved</td>
+  <tr> <td>313</td> <td class="left"><a href="zip-0313">   Reduce Conventional Transaction Fee to 1000 zatoshis</a></td> <td>   Active</td>
+  <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314">   Privacy upgrades to the Zcash light client protocol</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">315</span></td> <td class="left"><a class="reserved" href="zip-0315">   Best Practices for Wallet Handling of Multiple Pools</a></td> <td>   Reserved</td>
+  <tr> <td>316</td> <td class="left"><a href="zip-0316">   Unified Addresses and Unified Viewing Keys</a></td> <td>   Final</td>
+  <tr> <td>317</td> <td class="left"><a href="zip-0317">   Proportional Transfer Fee Mechanism</a></td> <td>   Draft</td>
+  <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zip-0318">   Associated Payload Encryption</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zip-0319">   Options for Shielded Pool Retirement</a></td> <td>   Reserved</td>
+  <tr> <td>321</td> <td class="left"><a href="zip-0321">   Payment Request URIs</a></td> <td>   Proposed</td>
+  <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zip-0322">   Generic Signed Message Format</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zip-0323">   Specification of getblocktemplate for Zcash</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zip-0332">   Wallet Recovery from zcashd HD Seeds</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zip-0339">   Wallet Recovery Words</a></td> <td>   Reserved</td>
+  <tr> <td>400</td> <td class="left"><a href="zip-0400">   Wallet.dat format</a></td> <td>   Draft</td>
+  <tr> <td>401</td> <td class="left"><a href="zip-0401">   Addressing Mempool Denial-of-Service</a></td> <td>   Active</td>
+  <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zip-0402">   New Wallet Database Format</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zip-0403">   Verification Behaviour of zcashd</a></td> <td>   Reserved</td>
+  <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zip-0416">   Support for Unified Addresses in zcashd</a></td> <td>   Reserved</td>
+  <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zip-1001">   Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1002</strike></td> <td class="left"><strike><a href="zip-1002">   Opt-in Donation Feature</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1003</strike></td> <td class="left"><strike><a href="zip-1003">   20% Split Evenly Between the ECC and the Zcash Foundation, and a Voting System Mandate</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1004</strike></td> <td class="left"><strike><a href="zip-1004">   Miner-Directed Dev Fund</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1005</strike></td> <td class="left"><strike><a href="zip-1005">   Zcash Community Funding System</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1006</strike></td> <td class="left"><strike><a href="zip-1006">    Development Fund of 10% to a 2-of-3 Multisig with Community-Involved Third Entity</a></strike></td> <td>    Obsolete</td>
+  <tr> <td><strike>1007</strike></td> <td class="left"><strike><a href="zip-1007">   Enforce Development Fund Commitments with a Legal Charter</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1008</strike></td> <td class="left"><strike><a href="zip-1008">   Fund ECC for Two More Years</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1009</strike></td> <td class="left"><strike><a href="zip-1009">   Five-Entity Strategic Council</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1010</strike></td> <td class="left"><strike><a href="zip-1010">   Compromise Dev Fund Proposal With Diverse Funding Streams</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1011</strike></td> <td class="left"><strike><a href="zip-1011">   Decentralize the Dev Fee</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1012</strike></td> <td class="left"><strike><a href="zip-1012">   Dev Fund to ECC + ZF + Major Grants</a></strike></td> <td>   Obsolete</td>
+  <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zip-1013">   Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>   Obsolete</td>
+  <tr> <td>1014</td> <td class="left"><a href="zip-1014">   Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>   Active</td>
+  <tr> <td>guide</td> <td class="left"><a href="zip-guide">   {Something Short and To the Point}</a></td> <td>   Draft</td>
 </table></embed></section>
     </section>
 </body>

--- a/zip-0230.html
+++ b/zip-0230.html
@@ -1,0 +1,648 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ZIP 230: Version 6 Transaction Format</title>
+    <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="css/style.css"></head>
+<body>
+    <section>
+        <pre>ZIP: 230
+Title: Version 6 Transaction Format
+Owners: Daira Emma Hopwood &lt;daira@electriccoin.co&gt;
+        Jack Grigg &lt;jack@electriccoin.co&gt;
+        Kris Nuttycombe &lt;kris@electriccoin.co&gt;
+        Greg Pfeil &lt;greg@electriccoin.co&gt;
+        Deirdre Connolly &lt;deirdre@zfnd.org&gt;
+        Pablo Kogan &lt;pablo@qed-it.com&gt;
+        Vivek Arte &lt;vivek@qed-it.com&gt;
+Credits: Ying Tong Lai
+Status: Draft
+Category: Consensus
+Created: 2023-04-18
+License: MIT
+Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://github.com/zcash/zips/issues/686</a>&gt;</pre>
+        <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The character § is used when referring to sections of the Zcash Protocol Specification <a id="footnote-reference-2" class="footnote_reference" href="#protocol">2</a>.</p>
+        </section>
+        <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This proposal defines a new Zcash peer-to-peer transaction format, which includes data that supports Zcash Shielded Assets on the Orchard shielded pool <a id="footnote-reference-3" class="footnote_reference" href="#protocol">2</a>. The new transaction format defines well-bounded regions of the serialized form to serve each of the existing pools of funds, and adds and describes a new elements containing ZSA-specific elements.</p>
+            <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0244">9</a>.</p>
+        </section>
+        <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The new Orchard shielded pool requires serialized data elements that are distinct from any previous Zcash transaction. Since ZIP 244 was activated in NU5, the v5 and later serialized transaction formats are not consensus-critical. Thus, this ZIP defines format that can easily accommodate future extensions, where elements or a given pool are kept separate.</p>
+        </section>
+        <section id="requirements"><h2><span class="section-heading">Requirements</span><span class="section-anchor"> <a rel="bookmark" href="#requirements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The new format must fully support the Orchard protocol.</p>
+            <p>The new format must fully support Zcash Shielded Assets (ZSAs).</p>
+            <p>The new format should lend itself to future extension or pruning to add or remove value pools.</p>
+            <p>The computation of the non-malleable transaction identifier hash must include all newly incorporated elements except those that attest to transaction validity.</p>
+            <p>The computation of the commitment to authorizing data for a transaction must include all newly incorporated elements that attest to transaction validity.</p>
+        </section>
+        <section id="non-requirements"><h2><span class="section-heading">Non-requirements</span><span class="section-anchor"> <a rel="bookmark" href="#non-requirements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>More general forms of extensibility, such as definining a key/value format that allows for parsers that are unaware of some components, are not required.</p>
+        </section>
+        <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>All fields in this specification are encoded as little-endian.</p>
+            <p>The Zcash transaction format for transaction version 6 is as follows:</p>
+            <section id="transaction-format"><h3><span class="section-heading">Transaction Format</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-format"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td colspan="4"><strong>Common Transaction Fields</strong></td>
+                        </tr>
+                        <tr>
+                            <td><code>4</code></td>
+                            <td><code>header</code></td>
+                            <td><code>uint32</code></td>
+                            <td>
+                                <dl>
+                                    <dt>Contains:</dt>
+                                    <dd>
+                                        <ul>
+                                            <li><code>fOverwintered</code> flag (bit 31, always set)</li>
+                                            <li><code>version</code> (bits 30 .. 0) – transaction version.</li>
+                                        </ul>
+                                    </dd>
+                                </dl>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>4</code></td>
+                            <td><code>nVersionGroupId</code></td>
+                            <td><code>uint32</code></td>
+                            <td>Version group ID (nonzero).</td>
+                        </tr>
+                        <tr>
+                            <td><code>4</code></td>
+                            <td><code>nConsensusBranchId</code></td>
+                            <td><code>uint32</code></td>
+                            <td>Consensus branch ID (nonzero).</td>
+                        </tr>
+                        <tr>
+                            <td><code>4</code></td>
+                            <td><code>lock_time</code></td>
+                            <td><code>uint32</code></td>
+                            <td>Unix-epoch UTC time or block height, encoded as in Bitcoin.</td>
+                        </tr>
+                        <tr>
+                            <td><code>4</code></td>
+                            <td><code>nExpiryHeight</code></td>
+                            <td><code>uint32</code></td>
+                            <td>A block height in the range {1 .. 499999999} after which the transaction will expire, or 0 to disable expiry. [ZIP-203]</td>
+                        </tr>
+                        <tr>
+                            <td><code>8</code></td>
+                            <td><code>fee</code></td>
+                            <td><code>int64</code></td>
+                            <td>The fee to be paid by this transaction, in zatoshis.</td>
+                        </tr>
+                        <tr>
+                            <td colspan="4"><strong>Transparent Transaction Fields</strong></td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>tx_in_count</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>Number of transparent inputs in <code>tx_in</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>tx_in</code></td>
+                            <td><code>tx_in</code></td>
+                            <td>Transparent inputs, encoded as in Bitcoin.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>tx_out_count</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>Number of transparent outputs in <code>tx_out</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>tx_out</code></td>
+                            <td><code>tx_out</code></td>
+                            <td>Transparent outputs, encoded as in Bitcoin.</td>
+                        </tr>
+                        <tr>
+                            <td colspan="4"><strong>Sapling Transaction Fields</strong></td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nSpendsSapling</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>Number of Sapling Spend descriptions in <code>vSpendsSapling</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>96 * nSpendsSapling</code></td>
+                            <td><code>vSpendsSapling</code></td>
+                            <td><code>SpendDescriptionV6[nSpendsSapling]</code></td>
+                            <td>A sequence of Sapling Spend descriptions, encoded per protocol §7.3 ‘Spend Description Encoding and Consensus’.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nOutputsSapling</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>Number of Sapling Output Decriptions in <code>vOutputsSapling</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>756 * nOutputsSapling</code></td>
+                            <td><code>vOutputsSapling</code></td>
+                            <td><code>OutputDescriptionV6[nOutputsSapling]</code></td>
+                            <td>A sequence of Sapling Output descriptions, encoded per protocol §7.4 ‘Output Description Encoding and Consensus’.</td>
+                        </tr>
+                        <tr>
+                            <td><code>8</code></td>
+                            <td><code>valueBalanceSapling</code></td>
+                            <td><code>int64</code></td>
+                            <td>The net value of Sapling Spends minus Outputs</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>anchorSapling</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>A root of the Sapling note commitment tree at some block height in the past.</td>
+                        </tr>
+                        <tr>
+                            <td><code>192 * nSpendsSapling</code></td>
+                            <td><code>vSpendProofsSapling</code></td>
+                            <td><code>byte[192 * nSpendsSapling]</code></td>
+                            <td>Encodings of the zk-SNARK proofs for each Sapling Spend.</td>
+                        </tr>
+                        <tr>
+                            <td><code>64 * nSpendsSapling</code></td>
+                            <td><code>vSpendAuthSigsSapling</code></td>
+                            <td><code>byte[64 * nSpendsSapling]</code></td>
+                            <td>Authorizing signatures for each Sapling Spend.</td>
+                        </tr>
+                        <tr>
+                            <td><code>192 * nOutputsSapling</code></td>
+                            <td><code>vOutputProofsSapling</code></td>
+                            <td><code>byte[192 * nOutputsSapling]</code></td>
+                            <td>Encodings of the zk-SNARK proofs for each Sapling Output.</td>
+                        </tr>
+                        <tr>
+                            <td><code>64</code></td>
+                            <td><code>bindingSigSapling</code></td>
+                            <td><code>byte[64]</code></td>
+                            <td>A Sapling binding signature on the SIGHASH transaction hash.</td>
+                        </tr>
+                        <tr>
+                            <td colspan="4"><strong>Orchard Transaction Fields</strong></td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nActionsOrchard</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of Orchard Action descriptions in <code>vActionsOrchard</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>852 * nActionsOrchard</code></td>
+                            <td><code>vActionsOrchard</code></td>
+                            <td><code>ZSAOrchardAction[nActionsOrchard]</code></td>
+                            <td>A sequence of ZSA Orchard Action descriptions, encoded per the <cite>ZSA Orchard Action Description Encoding</cite>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>1</code></td>
+                            <td><code>flagsOrchard</code></td>
+                            <td><code>byte</code></td>
+                            <td>
+                                <dl>
+                                    <dt>An 8-bit value representing a set of flags. Ordered from LSB to MSB:</dt>
+                                    <dd>
+                                        <ul>
+                                            <li><code>enableSpendsOrchard</code></li>
+                                            <li><code>enableOutputsOrchard</code></li>
+                                            <li><code>enableZSAs</code></li>
+                                            <li>The remaining bits are set to <code>0</code>.</li>
+                                        </ul>
+                                    </dd>
+                                </dl>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>8</code></td>
+                            <td><code>valueBalanceOrchard</code></td>
+                            <td><code>int64</code></td>
+                            <td>The net value of Orchard spends minus outputs.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>anchorOrchard</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>A root of the Orchard note commitment tree at some block height in the past.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>sizeProofsOrchardZSA</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>Length in bytes of <code>proofsOrchardZSA</code>. Value is <strong>(TO UPDATE)</strong>
+                                <span class="math">\(2720 + 2272 \cdot \mathtt{nActionsOrchard}\)</span>
+                            .</td>
+                        </tr>
+                        <tr>
+                            <td><code>sizeProofsOrchardZSA</code></td>
+                            <td><code>proofsOrchardZSA</code></td>
+                            <td><code>byte[sizeProofsOrchardZSA]</code></td>
+                            <td>Encoding of aggregated zk-SNARK proofs for ZSA Orchard Actions.</td>
+                        </tr>
+                        <tr>
+                            <td><code>64 * nActionsOrchard</code></td>
+                            <td><code>vSpendAuthSigsOrchard</code></td>
+                            <td><code>byte[64 * nActionsOrchard]</code></td>
+                            <td>Authorizing signatures for each ZSA Orchard Action.</td>
+                        </tr>
+                        <tr>
+                            <td><code>64</code></td>
+                            <td><code>bindingSigOrchard</code></td>
+                            <td><code>byte[64]</code></td>
+                            <td>An Orchard binding signature on the SIGHASH transaction hash.</td>
+                        </tr>
+                        <tr>
+                            <td colspan="4"><strong>ZSA Burn Fields</strong></td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nAssetBurn</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of Assets burnt.</td>
+                        </tr>
+                        <tr>
+                            <td><code>40 * nAssetBurn</code></td>
+                            <td><code>vAssetBurn</code></td>
+                            <td><code>AssetBurn[nAssetBurn]</code></td>
+                            <td>A sequence of Asset Burn descriptions, encoded per <a href="#zsa-asset-burn-description">ZSA Asset Burn Description</a>.</td>
+                        </tr>
+                        <tr>
+                            <td colspan="4"><strong>ZSA Issuance Fields</strong></td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nIssueActions</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of issuance actions in the bundle.</td>
+                        </tr>
+                        <tr>
+                            <td><code>IssueActionSize * nIssueActions</code></td>
+                            <td><code>vIssueActions</code></td>
+                            <td><code>IssueAction[nIssueActions]</code></td>
+                            <td>A sequence of issuance action descriptions, where IssueActionSize is the size, in bytes, of an IssueAction description.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>ik</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The issuance validating key of the issuer, used to validate the signature.</td>
+                        </tr>
+                        <tr>
+                            <td><code>64</code></td>
+                            <td><code>issueAuthSig</code></td>
+                            <td><code>byte[64]</code></td>
+                            <td>The signature of the transaction SIGHASH, signed by the issuer, validated as in Issuance Authorization Signature Scheme <a id="footnote-reference-5" class="footnote_reference" href="#zip-0227">8</a>.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <ul>
+                    <li>The fields <code>valueBalanceSapling</code> and <code>bindingSigSapling</code> are present if and only if
+                        <span class="math">\(\mathtt{nSpendsSapling} + \mathtt{nOutputsSapling} &gt; 0\)</span>
+                    . If <code>valueBalanceSapling</code> is not present, then
+                        <span class="math">\(\mathsf{v^{balanceSapling}}`\)</span>
+                     is defined to be 0.</li>
+                    <li>The field <code>anchorSapling</code> is present if and only if
+                        <span class="math">\(\mathtt{nSpendsSapling} &gt; 0\)</span>
+                    .</li>
+                    <li>The fields <code>flagsOrchard</code>, <code>valueBalanceOrchard</code>, <code>anchorOrchard</code>, <code>sizeProofsOrchardZSA</code>, <code>proofsOrchardZSA</code>, and <code>bindingSigOrchard</code> are present if and only if
+                        <span class="math">\(\mathtt{nActionsOrchard} &gt; 0\)</span>
+                    . If <code>valueBalanceOrchard</code> is not present, then
+                        <span class="math">\(\mathsf{v^{balanceOrchard}}\)</span>
+                     is defined to be 0.</li>
+                    <li>The elements of <code>vSpendProofsSapling</code> and <code>vSpendAuthSigsSapling</code> have a 1:1 correspondence to the elements of <code>vSpendsSapling</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>SpendDescriptionV6</code> at the same index.</li>
+                    <li>The elements of <code>vOutputProofsSapling</code> have a 1:1 correspondence to the elements of <code>vOutputsSapling</code> and MUST be ordered such that the proof at a given index corresponds to the <code>OutputDescriptionV6</code> at the same index.</li>
+                    <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>ZSAOrchardAction</code> at the same index.</li>
+                    <li>For coinbase transactions, the <code>enableSpendsOrchard</code> and <code>enableZSAs</code> bits MUST be set to <code>0</code>.</li>
+                </ul>
+                <p>The encodings of <code>tx_in</code>, and <code>tx_out</code> are as in a version 4 transaction (i.e. unchanged from Canopy). The encodings of <code>SpendDescriptionV6</code>, <code>OutputDescriptionV6</code> , <code>ZSAOrchardAction</code>, <code>AssetBurn</code> and <code>IssueAction</code> are described below. The encoding of Sapling Spends and Outputs has changed relative to prior versions in order to better separate data that describe the effects of the transaction from the proofs of and commitments to those effects, and for symmetry with this separation in the Orchard-related parts of the transaction format.</p>
+            </section>
+            <section id="sapling-spend-description-spenddescriptionv6"><h3><span class="section-heading">Sapling Spend Description (<code>SpendDescriptionV6</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#sapling-spend-description-spenddescriptionv6"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>cv</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>A value commitment to the net value of the input note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>nullifier</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The nullifier of the input note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>rk</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The randomized validating key for the element of spendAuthSigsSapling corresponding to this Spend.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>The encodings of each of these elements are defined in §7.3 ‘Spend Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-6" class="footnote_reference" href="#protocol-spenddesc">3</a>.</p>
+            </section>
+            <section id="sapling-output-description-outputdescriptionv6"><h3><span class="section-heading">Sapling Output Description (<code>OutputDescriptionV6</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#sapling-output-description-outputdescriptionv6"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>cv</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>A value commitment to the net value of the output note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>cmu</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The u-coordinate of the note commitment for the output note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>ephemeralKey</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>An encoding of an ephemeral Jubjub public key.</td>
+                        </tr>
+                        <tr>
+                            <td><code>580</code></td>
+                            <td><code>encCiphertext</code></td>
+                            <td><code>byte[580]</code></td>
+                            <td>The encrypted contents of the note plaintext.</td>
+                        </tr>
+                        <tr>
+                            <td><code>80</code></td>
+                            <td><code>outCiphertext</code></td>
+                            <td><code>byte[80]</code></td>
+                            <td>The encrypted contents of the byte string created by concatenation of the transmission key with the ephemeral secret key.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>The encodings of each of these elements are defined in §7.4 ‘Output Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-7" class="footnote_reference" href="#protocol-outputdesc">4</a>.</p>
+            </section>
+            <section id="zsa-orchard-action-description-zsaorchardaction"><h3><span class="section-heading">ZSA Orchard Action Description (<code>ZSAOrchardAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#zsa-orchard-action-description-zsaorchardaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>cv</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>A value commitment to the net value of the input note minus the output note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>nullifier</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The nullifier of the input note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>rk</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The randomized validating key for the element of spendAuthSigsOrchard corresponding to this Action.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>cmx</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>The x-coordinate of the note commitment for the output note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>ephemeralKey</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>An encoding of an ephemeral Pallas public key</td>
+                        </tr>
+                        <tr>
+                            <td><code>612</code></td>
+                            <td><code>encCiphertext</code></td>
+                            <td><code>byte[580]</code></td>
+                            <td>The encrypted contents of the note plaintext.</td>
+                        </tr>
+                        <tr>
+                            <td><code>80</code></td>
+                            <td><code>outCiphertext</code></td>
+                            <td><code>byte[80]</code></td>
+                            <td>The encrypted contents of the byte string created by concatenation of the transmission key with the ephemeral secret key.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-8" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
+            </section>
+            <section id="zsa-asset-burn-description"><h3><span class="section-heading">ZSA Asset Burn Description</span><span class="section-anchor"> <a rel="bookmark" href="#zsa-asset-burn-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>A ZSA Asset Burn description is encoded in a transaction as an instance of an <code>AssetBurn</code> type:</p>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>32</td>
+                            <td><code>AssetBase</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>For the Orchard-based ZSA protocol, this is the encoding of the Asset Base
+                                <span class="math">\(\mathsf{AssetBase}^{\mathsf{Orchard}}\)</span>
+                            .</td>
+                        </tr>
+                        <tr>
+                            <td>8</td>
+                            <td><code>valueBurn</code></td>
+                            <td>
+                                <span class="math">\(\{1 .. 2^{64} - 1\}\)</span>
+                            </td>
+                            <td>The amount being burnt.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0226">7</a>.</p>
+            </section>
+            <section id="issuance-action-description-issueaction"><h3><span class="section-heading">Issuance Action Description (<code>IssueAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description-issueaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>2</code></td>
+                            <td><code>assetDescSize</code></td>
+                            <td><code>byte</code></td>
+                            <td>The length of the asset description string in bytes.</td>
+                        </tr>
+                        <tr>
+                            <td><code>assetDescSize</code></td>
+                            <td><code>asset_desc</code></td>
+                            <td><code>byte[assetDescSize]</code></td>
+                            <td>A byte sequence of length <code>assetDescSize</code> bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nNotes</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of notes in the issuance action.</td>
+                        </tr>
+                        <tr>
+                            <td><code>noteSize * nNotes</code></td>
+                            <td><code>vNotes</code></td>
+                            <td><code>Note[nNotes]</code></td>
+                            <td>A sequence of note descriptions within the issuance action, where <code>noteSize</code> is the size, in bytes, of a Note.</td>
+                        </tr>
+                        <tr>
+                            <td><code>1</code></td>
+                            <td><code>flagsIssuance</code></td>
+                            <td><code>byte</code></td>
+                            <td>
+                                <dl>
+                                    <dt>An 8-bit value representing a set of flags. Ordered from LSB to MSB:</dt>
+                                    <dd>
+                                        <ul>
+                                            <li>
+                                                <span class="math">\(\mathsf{finalize}\)</span>
+                                            </li>
+                                            <li>The remaining bits are set to <code>0</code>.</li>
+                                        </ul>
+                                    </dd>
+                                </dl>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>The encodings of each of these elements are defined in ZIP 227 <a id="footnote-reference-10" class="footnote_reference" href="#zip-0227">8</a>.</p>
+            </section>
+        </section>
+        <section id="reference-implementation"><h2><span class="section-heading">Reference implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>TODO</p>
+        </section>
+        <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <table id="rfc2119" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>1</th>
+                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>2</th>
+                        <td><a href="protocol/protocol.pdf">Zcash Protocol Specification, Version 2021.2.16 or later [NU5 proposal]</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol-spenddesc" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>3</th>
+                        <td><a href="protocol/protocol.pdf#spenddesc">Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.4: Spend Descriptions</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol-outputdesc" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>4</th>
+                        <td><a href="protocol/protocol.pdf#outputdesc">Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.5: Output Descriptions</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol-actiondesc" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>5</th>
+                        <td><a href="protocol/protocol.pdf#actiondesc">Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.6: Action Descriptions</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0222" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>6</th>
+                        <td><a href="zip-0222">ZIP 222: Transparent Zcash Extensions</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0226" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>7</th>
+                        <td><a href="https://qed-it.github.io/zips/zip-0226">ZIP 226: Transfer and Burn of Zcash Shielded Assets</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0227" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>8</th>
+                        <td><a href="https://qed-it.github.io/zips/zip-0227">ZIP 227: Issuance of Zcash Shielded Assets</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0244" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>9</th>
+                        <td><a href="zip-0244">ZIP 244: Transaction Identifier Non-Malleability</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0307" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>10</th>
+                        <td><a href="zip-0307">ZIP 307: Light Client Protocol for Payment Detection</a></td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+</html>

--- a/zip-0230.rst
+++ b/zip-0230.rst
@@ -1,0 +1,352 @@
+::
+
+  ZIP: 230
+  Title: Version 6 Transaction Format
+  Owners: Daira Emma Hopwood <daira@electriccoin.co>
+          Jack Grigg <jack@electriccoin.co>
+          Kris Nuttycombe <kris@electriccoin.co>
+          Greg Pfeil <greg@electriccoin.co>
+          Deirdre Connolly <deirdre@zfnd.org>
+          Pablo Kogan <pablo@qed-it.com>
+          Vivek Arte <vivek@qed-it.com>
+  Credits: Ying Tong Lai
+  Status: Draft
+  Category: Consensus
+  Created: 2023-04-18
+  License: MIT
+  Discussions-To: <https://github.com/zcash/zips/issues/686>
+
+
+Terminology
+===========
+
+The key words "MUST" and "MAY" in this document are to be interpreted as described in
+RFC 2119. [#RFC2119]_
+
+The character § is used when referring to sections of the Zcash Protocol Specification
+[#protocol]_.
+
+
+Abstract
+========
+
+This proposal defines a new Zcash peer-to-peer transaction format, which includes data that supports Zcash Shielded Assets on the Orchard shielded pool [#protocol]_.  The
+new transaction format defines well-bounded regions of the serialized form to
+serve each of the existing pools of funds, and adds and describes a new elements
+containing ZSA-specific elements.
+
+This ZIP also depends upon and defines modifications to the computation of the values
+**TxId Digest**, **Signature Digest**, and **Authorizing Data Commitment** defined by ZIP
+244 [#zip-0244]_.
+
+
+Motivation
+==========
+
+The new Orchard shielded pool requires serialized data elements that are distinct from
+any previous Zcash transaction. Since ZIP 244 was activated in NU5, the
+v5 and later serialized transaction formats are not consensus-critical. 
+Thus, this ZIP defines format that can easily accommodate future extensions,
+where elements or a given pool are kept separate.
+
+
+Requirements
+============
+
+The new format must fully support the Orchard protocol.
+
+The new format must fully support Zcash Shielded Assets (ZSAs).
+
+The new format should lend itself to future extension or pruning to add or remove
+value pools.
+
+The computation of the non-malleable transaction identifier hash must include all
+newly incorporated elements except those that attest to transaction validity.
+
+The computation of the commitment to authorizing data for a transaction must include
+all newly incorporated elements that attest to transaction validity.
+
+
+Non-requirements
+================
+
+More general forms of extensibility, such as definining a key/value format that
+allows for parsers that are unaware of some components, are not required.
+
+
+Specification
+=============
+
+All fields in this specification are encoded as little-endian.
+
+The Zcash transaction format for transaction version 6 is as follows:
+
+Transaction Format
+------------------
+
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| Bytes                              | Name                     | Data Type                              | Description                                                               |
++====================================+==========================+========================================+===========================================================================+
+| **Common Transaction Fields**                                                                                                                                                      |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``header``                |``uint32``                              |Contains:                                                                  |
+|                                    |                          |                                        |  * ``fOverwintered`` flag (bit 31, always set)                            |
+|                                    |                          |                                        |  * ``version`` (bits 30 .. 0) – transaction version.                      |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``nVersionGroupId``       |``uint32``                              |Version group ID (nonzero).                                                |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``nConsensusBranchId``    |``uint32``                              |Consensus branch ID (nonzero).                                             |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``lock_time``             |``uint32``                              |Unix-epoch UTC time or block height, encoded as in Bitcoin.                |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``nExpiryHeight``         |``uint32``                              |A block height in the range {1 .. 499999999} after which                   |
+|                                    |                          |                                        |the transaction will expire, or 0 to disable expiry.                       |
+|                                    |                          |                                        |[ZIP-203]                                                                  |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``8``                               |``fee``                   |``int64``                               |The fee to be paid by this transaction, in zatoshis.                       |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| **Transparent Transaction Fields**                                                                                                                                                 |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_in_count``           |``compactSize``                         |Number of transparent inputs in ``tx_in``.                                 |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_in``                 |``tx_in``                               |Transparent inputs, encoded as in Bitcoin.                                 |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_out_count``          |``compactSize``                         |Number of transparent outputs in ``tx_out``.                               |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_out``                |``tx_out``                              |Transparent outputs, encoded as in Bitcoin.                                |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| **Sapling Transaction Fields**                                                                                                                                                     |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nSpendsSapling``        |``compactSize``                         |Number of Sapling Spend descriptions in ``vSpendsSapling``.                |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``96 * nSpendsSapling``             |``vSpendsSapling``        |``SpendDescriptionV6[nSpendsSapling]``  |A sequence of Sapling Spend descriptions, encoded per                      |
+|                                    |                          |                                        |protocol §7.3 ‘Spend Description Encoding and Consensus’.                  |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nOutputsSapling``       |``compactSize``                         |Number of Sapling Output Decriptions in ``vOutputsSapling``.               |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``756 * nOutputsSapling``           |``vOutputsSapling``       |``OutputDescriptionV6[nOutputsSapling]``|A sequence of Sapling Output descriptions, encoded per                     |
+|                                    |                          |                                        |protocol §7.4 ‘Output Description Encoding and Consensus’.                 |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``8``                               |``valueBalanceSapling``   |``int64``                               |The net value of Sapling Spends minus Outputs                              |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``32``                              |``anchorSapling``         |``byte[32]``                            |A root of the Sapling note commitment tree                                 |
+|                                    |                          |                                        |at some block height in the past.                                          |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``192 * nSpendsSapling``            |``vSpendProofsSapling``   |``byte[192 * nSpendsSapling]``          |Encodings of the zk-SNARK proofs for each Sapling Spend.                   |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``64 * nSpendsSapling``             |``vSpendAuthSigsSapling`` |``byte[64 * nSpendsSapling]``           |Authorizing signatures for each Sapling Spend.                             |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``192 * nOutputsSapling``           |``vOutputProofsSapling``  |``byte[192 * nOutputsSapling]``         |Encodings of the zk-SNARK proofs for each Sapling Output.                  |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``64``                              |``bindingSigSapling``     |``byte[64]``                            |A Sapling binding signature on the SIGHASH transaction hash.               |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| **Orchard Transaction Fields**                                                                                                                                                     |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nActionsOrchard``       |``compactSize``                         |The number of Orchard Action descriptions in                               |
+|                                    |                          |                                        |``vActionsOrchard``.                                                       |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``852 * nActionsOrchard``           |``vActionsOrchard``       |``ZSAOrchardAction[nActionsOrchard]``   |A sequence of ZSA Orchard Action descriptions, encoded per                 |
+|                                    |                          |                                        |the `ZSA Orchard Action Description Encoding`.                             |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``1``                               |``flagsOrchard``          |``byte``                                |An 8-bit value representing a set of flags. Ordered from LSB to MSB:       |
+|                                    |                          |                                        | * ``enableSpendsOrchard``                                                 |
+|                                    |                          |                                        | * ``enableOutputsOrchard``                                                |
+|                                    |                          |                                        | * ``enableZSAs``                                                          |
+|                                    |                          |                                        | * The remaining bits are set to ``0``.                                    |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``8``                               |``valueBalanceOrchard``   |``int64``                               |The net value of Orchard spends minus outputs.                             |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``32``                              |``anchorOrchard``         |``byte[32]``                            |A root of the Orchard note commitment tree at some block                   |
+|                                    |                          |                                        |height in the past.                                                        |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``sizeProofsOrchardZSA``  |``compactSize``                         |Length in bytes of ``proofsOrchardZSA``. Value is **(TO UPDATE)**          |
+|                                    |                          |                                        |:math:`2720 + 2272 \cdot \mathtt{nActionsOrchard}`.                        |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``sizeProofsOrchardZSA``            |``proofsOrchardZSA``      |``byte[sizeProofsOrchardZSA]``          |Encoding of aggregated zk-SNARK proofs for ZSA Orchard Actions.            |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64 * nActionsOrchard]``          |Authorizing signatures for each ZSA Orchard Action.                        |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``64``                              |``bindingSigOrchard``     |``byte[64]``                            |An Orchard binding signature on the SIGHASH transaction hash.              |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| **ZSA Burn Fields**                                                                                                                                                                |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| ``varies``                         | ``nAssetBurn``           | ``compactSize``                        | The number of Assets burnt.                                               |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| ``40 * nAssetBurn``                | ``vAssetBurn``           | ``AssetBurn[nAssetBurn]``              | A sequence of Asset Burn descriptions,                                    |
+|                                    |                          |                                        | encoded per `ZSA Asset Burn Description`_.                                |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+| **ZSA Issuance Fields**                                                                                                                                                            |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nIssueActions``         |``compactSize``                         |The number of issuance actions in the bundle.                              |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``IssueActionSize * nIssueActions`` |``vIssueActions``         |``IssueAction[nIssueActions]``          |A sequence of issuance action descriptions, where IssueActionSize is       |
+|                                    |                          |                                        |the size, in bytes, of an IssueAction description.                         |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``32``                              |``ik``                    |``byte[32]``                            |The issuance validating key of the issuer, used to validate the signature. |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+|``64``                              |``issueAuthSig``          |``byte[64]``                            |The signature of the transaction SIGHASH, signed by the issuer,            |
+|                                    |                          |                                        |validated as in Issuance Authorization Signature Scheme [#zip-0227]_.      |
++------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
+
+
+* The fields ``valueBalanceSapling`` and ``bindingSigSapling`` are present if and only if
+  :math:`\mathtt{nSpendsSapling} + \mathtt{nOutputsSapling} > 0`. If ``valueBalanceSapling``
+  is not present, then :math:`\mathsf{v^{balanceSapling}}`` is defined to be 0.
+
+* The field ``anchorSapling`` is present if and only if :math:`\mathtt{nSpendsSapling} > 0`.
+
+* The fields ``flagsOrchard``, ``valueBalanceOrchard``, ``anchorOrchard``,
+  ``sizeProofsOrchardZSA``, ``proofsOrchardZSA``, and ``bindingSigOrchard`` are present if and
+  only if :math:`\mathtt{nActionsOrchard} > 0`. If ``valueBalanceOrchard`` is not present,
+  then :math:`\mathsf{v^{balanceOrchard}}` is defined to be 0.
+
+* The elements of ``vSpendProofsSapling`` and ``vSpendAuthSigsSapling`` have a 1:1
+  correspondence to the elements of ``vSpendsSapling`` and MUST be ordered such that the
+  proof or signature at a given index corresponds to the ``SpendDescriptionV6`` at the
+  same index.
+
+* The elements of ``vOutputProofsSapling`` have a 1:1 correspondence to the elements of
+  ``vOutputsSapling`` and MUST be ordered such that the proof at a given index corresponds
+  to the ``OutputDescriptionV6`` at the same index.
+
+* The proofs aggregated in ``proofsOrchardZSA``, and the elements of
+  ``vSpendAuthSigsOrchard``, each have a 1:1 correspondence to the elements of
+  ``vActionsOrchard`` and MUST be ordered such that the proof or signature at a given
+  index corresponds to the ``ZSAOrchardAction`` at the same index.
+
+* For coinbase transactions, the ``enableSpendsOrchard`` and ``enableZSAs`` bits MUST be set to ``0``.
+
+The encodings of ``tx_in``, and ``tx_out`` are as in a version 4 transaction (i.e.
+unchanged from Canopy). The encodings of ``SpendDescriptionV6``, ``OutputDescriptionV6``
+, ``ZSAOrchardAction``, ``AssetBurn`` and ``IssueAction`` are described below. The encoding of Sapling Spends and Outputs has
+changed relative to prior versions in order to better separate data that describe the
+effects of the transaction from the proofs of and commitments to those effects, and for
+symmetry with this separation in the Orchard-related parts of the transaction format.
+
+Sapling Spend Description (``SpendDescriptionV6``)
+--------------------------------------------------
+
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+| Bytes                       | Name                     | Data Type                            | Description                                                |
++=============================+==========================+======================================+============================================================+
+|``32``                       |``cv``                    |``byte[32]``                          |A value commitment to the net value of the input note.      |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``nullifier``             |``byte[32]``                          |The nullifier of the input note.                            |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``rk``                    |``byte[32]``                          |The randomized validating key for the element of            |
+|                             |                          |                                      |spendAuthSigsSapling corresponding to this Spend.           |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+
+The encodings of each of these elements are defined in §7.3 ‘Spend Description Encoding
+and Consensus’ of the Zcash Protocol Specification [#protocol-spenddesc]_.
+
+Sapling Output Description (``OutputDescriptionV6``)
+----------------------------------------------------
+
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+| Bytes                       | Name                     | Data Type                            | Description                                                |
++=============================+==========================+======================================+============================================================+
+|``32``                       |``cv``                    |``byte[32]``                          |A value commitment to the net value of the output note.     |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``cmu``                   |``byte[32]``                          |The u-coordinate of the note commitment for the output note.|
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``ephemeralKey``          |``byte[32]``                          |An encoding of an ephemeral Jubjub public key.              |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``580``                      |``encCiphertext``         |``byte[580]``                         |The encrypted contents of the note plaintext.               |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``80``                       |``outCiphertext``         |``byte[80]``                          |The encrypted contents of the byte string created by        |
+|                             |                          |                                      |concatenation of the transmission key with the ephemeral    |
+|                             |                          |                                      |secret key.                                                 |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+
+The encodings of each of these elements are defined in §7.4 ‘Output Description Encoding
+and Consensus’ of the Zcash Protocol Specification [#protocol-outputdesc]_.
+
+ZSA Orchard Action Description (``ZSAOrchardAction``)
+-----------------------------------------------------
+
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+| Bytes                       | Name                     | Data Type                            | Description                                                |
++=============================+==========================+======================================+============================================================+
+|``32``                       |``cv``                    |``byte[32]``                          |A value commitment to the net value of the input note minus |
+|                             |                          |                                      |the output note.                                            |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``nullifier``             |``byte[32]``                          |The nullifier of the input note.                            |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``rk``                    |``byte[32]``                          |The randomized validating key for the element of            |
+|                             |                          |                                      |spendAuthSigsOrchard corresponding to this Action.          |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``cmx``                   |``byte[32]``                          |The x-coordinate of the note commitment for the output note.|
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``32``                       |``ephemeralKey``          |``byte[32]``                          |An encoding of an ephemeral Pallas public key               |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``612``                      |``encCiphertext``         |``byte[580]``                         |The encrypted contents of the note plaintext.               |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+|``80``                       |``outCiphertext``         |``byte[80]``                          |The encrypted contents of the byte string created by        |
+|                             |                          |                                      |concatenation of the transmission key with the ephemeral    |
+|                             |                          |                                      |secret key.                                                 |
++-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
+
+The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding
+and Consensus’ of the Zcash Protocol Specification [#protocol-actiondesc]_.
+
+ZSA Asset Burn Description
+--------------------------
+
+A ZSA Asset Burn description is encoded in a transaction as an instance of an ``AssetBurn`` type:
+
++-------+---------------+-----------------------------+---------------------------------------------------------------------------------------------------------------------------+
+| Bytes | Name          | Data Type                   | Description                                                                                                               |
++=======+===============+=============================+===========================================================================================================================+
+| 32    | ``AssetBase`` | ``byte[32]``                | For the Orchard-based ZSA protocol, this is the encoding of the Asset Base :math:`\mathsf{AssetBase}^{\mathsf{Orchard}}`. |
++-------+---------------+-----------------------------+---------------------------------------------------------------------------------------------------------------------------+
+| 8     | ``valueBurn`` | :math:`\{1 .. 2^{64} - 1\}` | The amount being burnt.                                                                                                   |
++-------+---------------+-----------------------------+---------------------------------------------------------------------------------------------------------------------------+
+
+The encodings of each of these elements are defined in ZIP 226 [#zip-0226]_.
+
+Issuance Action Description (``IssueAction``)
+---------------------------------------------
+
+An issuance action, ``IssueAction``, is the instance of issuing a specific Custom Asset, and contains the following fields:
+
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+| Bytes                       | Name                     | Data Type                                 | Description                                                         |
++=============================+==========================+===========================================+=====================================================================+
+|``2``                        |``assetDescSize``         |``byte``                                   |The length of the asset description string in bytes.                 |  
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``assetDescSize``            |``asset_desc``            |``byte[assetDescSize]``                    |A byte sequence of length ``assetDescSize`` bytes which SHOULD be a  |
+|                             |                          |                                           |well-formed UTF-8 code unit sequence according to Unicode 15.0.0     |
+|                             |                          |                                           |or later.                                                            |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``varies``                   |``nNotes``                |``compactSize``                            |The number of notes in the issuance action.                          |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``noteSize * nNotes``        |``vNotes``                |``Note[nNotes]``                           |A sequence of note descriptions within the issuance action,          |
+|                             |                          |                                           |where ``noteSize`` is the size, in bytes, of a Note.                 |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+|``1``                        |``flagsIssuance``         |``byte``                                   |An 8-bit value representing a set of flags. Ordered from LSB to MSB: |
+|                             |                          |                                           | * :math:`\mathsf{finalize}`                                         |
+|                             |                          |                                           | * The remaining bits are set to ``0``.                              |
++-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+
+The encodings of each of these elements are defined in ZIP 227 [#zip-0227]_.
+
+Reference implementation
+========================
+
+TODO
+
+
+References
+==========
+
+.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later [NU5 proposal] <protocol/protocol.pdf>`_
+.. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.4: Spend Descriptions <protocol/protocol.pdf#spenddesc>`_
+.. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_
+.. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.6: Action Descriptions <protocol/protocol.pdf#actiondesc>`_
+.. [#zip-0222] `ZIP 222: Transparent Zcash Extensions <zip-0222.rst>`_
+.. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <https://qed-it.github.io/zips/zip-0226>`_
+.. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <https://qed-it.github.io/zips/zip-0227>`_
+.. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.rst>`_
+.. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_


### PR DESCRIPTION
We are adding the ZSA changes to the transaction format to this PR, so that we have a single point of access to all Zcash Shielded Assets changes. This also lets us view the v6 transaction format conveniently in html form via the Netlify page.