### PR TITLE
Clarifying the encoding of `ik`

### DIFF
--- a/zip-0227.html
+++ b/zip-0227.html
@@ -184,7 +184,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                     <p>where the
                         <span class="math">\(\textit{PubKey}\)</span>
-                     algorithm is defined in BIP 340 <a id="footnote-reference-16" class="footnote_reference" href="#bip-0340">17</a>.</p>
+                     algorithm is defined in BIP 340 <a id="footnote-reference-16" class="footnote_reference" href="#bip-0340">17</a>. Note that the byte representation of
+                        <span class="math">\(\mathsf{ik}\)</span>
+                     is in big-endian order as defined in BIP 340.</p>
                     <p>It is possible for the
                         <span class="math">\(\textit{PubKey}\)</span>
                      algorithm to fail with very low probability, which means that
@@ -276,8 +278,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             , where</p>
             <ul>
                 <li>
-                    <span class="math">\(\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathsf{0x00} || \mathsf{repr}_{\mathbb{P}}(\mathsf{ik}) || \mathsf{asset\_desc}\!\)</span>
+                    <span class="math">\(\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathsf{0x00} || \mathsf{ik} || \mathsf{asset\_desc}\!\)</span>
                 .</li>
+                <li>Note that the initial
+                    <span class="math">\(\mathsf{0x00}\)</span>
+                 byte is a version byte.</li>
             </ul>
             <p>Define
                 <span class="math">\(\mathsf{AssetBase_{\mathsf{AssetId}}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest}_{\mathsf{AssetId}})\)</span>

--- a/zip-0227.rst
+++ b/zip-0227.rst
@@ -147,6 +147,7 @@ Define :math:`\mathsf{IssueAuthSig.DerivePublic}\: : \: (\mathsf{isk}\: : \: \ma
 * Return :math:`\bot` if the :math:`\textit{PubKey}` algorithm invocation fails, otherwise return :math:`\mathsf{ik}`.
 
 where the :math:`\textit{PubKey}` algorithm is defined in BIP 340 [#bip-0340]_. 
+Note that the byte representation of :math:`\mathsf{ik}` is in big-endian order as defined in BIP 340.
 
 It is possible for the :math:`\textit{PubKey}` algorithm to fail with very low probability, which means that :math:`\mathsf{IssueAuthSig.DerivePublic}` could return :math:`\bot` with very low probability. 
 If this happens, discard the keys and repeat with a different :math:`\mathsf{isk}`.
@@ -189,7 +190,8 @@ Let
 Define :math:`\mathsf{AssetDigest_{\mathsf{AssetId}}} := \textsf{BLAKE2b-512}(\texttt{"ZSA-Asset-Digest"},\; \mathsf{EncodeAssetId}(\mathsf{AssetId}))`,
 where
 
-- :math:`\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathsf{0x00} || \mathsf{repr}_{\mathbb{P}}(\mathsf{ik}) || \mathsf{asset\_desc}\!`.
+- :math:`\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathsf{0x00} || \mathsf{ik} || \mathsf{asset\_desc}\!`.
+- Note that the initial :math:`\mathsf{0x00}` byte is a version byte.
 
 Define :math:`\mathsf{AssetBase_{\mathsf{AssetId}}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest}_{\mathsf{AssetId}})`
 


### PR DESCRIPTION
This PR makes it clear that the encoding of `ik` used in the Asset Base derivation is big-endian, as in the case of the underlying BIP 340 Schnorr signature scheme.

It also adds a clarification about the version byte used in the Asset Base derivation.