### PR TITLE
Fix typo in Orchard-ZSA Action Description.

### DIFF
--- a/zip-0230.html
+++ b/zip-0230.html
@@ -453,7 +453,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         <tr>
                             <td><code>612</code></td>
                             <td><code>encCiphertext</code></td>
-                            <td><code>byte[580]</code></td>
+                            <td><code>byte[612]</code></td>
                             <td>The encrypted contents of the note plaintext.</td>
                         </tr>
                         <tr>

--- a/zip-0230.rst
+++ b/zip-0230.rst
@@ -278,7 +278,7 @@ Orchard-ZSA Action Description (``OrchardZsaAction``)
 +-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
 |``32``                       |``ephemeralKey``          |``byte[32]``                          |An encoding of an ephemeral Pallas public key               |
 +-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
-|``612``                      |``encCiphertext``         |``byte[580]``                         |The encrypted contents of the note plaintext.               |
+|``612``                      |``encCiphertext``         |``byte[612]``                         |The encrypted contents of the note plaintext.               |
 +-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
 |``80``                       |``outCiphertext``         |``byte[80]``                          |The encrypted contents of the byte string created by        |
 |                             |                          |                                      |concatenation of the transmission key with the ephemeral    |


### PR DESCRIPTION
This PR fixes a typo in the ZSA-Orchard Action Description table, wherein one table entry was not updated from 580 to 612 bytes.