### PR TITLE
Adding the `orchard_zsa_burn_digest` to the TxId digest.

### DIFF
--- a/zip-0226.html
+++ b/zip-0226.html
@@ -467,9 +467,10 @@ T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     <pre>T.4a: orchard_actions_compact_digest      (32-byte hash output)          [UPDATED FOR ZSA]
 T.4b: orchard_actions_memos_digest        (32-byte hash output)          [UPDATED FOR ZSA]
 T.4c: orchard_actions_noncompact_digest   (32-byte hash output)          [UPDATED FOR ZSA]
-T.4d: flagsOrchard                        (1 byte)
-T.4e: valueBalanceOrchard                 (64-bit signed little-endian)
-T.4f: anchorOrchard                       (32 bytes)</pre>
+T.4d: orchard_zsa_burn_digest             (32-byte hash output)          [ADDED FOR ZSA]
+T.4e: flagsOrchard                        (1 byte)
+T.4f: valueBalanceOrchard                 (64-bit signed little-endian)
+T.4g: anchorOrchard                       (32 bytes)</pre>
                     <section id="t-4a-orchard-actions-compact-digest"><h5><span class="section-heading">T.4a: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                         <pre>T.4a.i  : nullifier            (field encoding bytes)
@@ -493,6 +494,25 @@ T.4d.iii: encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED F
 T.4d.iv : outCiphertext         (field encoding bytes)</pre>
                         <p>The personalization field of this hash is defined identically to ZIP 244:</p>
                         <pre>"ZTxIdOrcActNHash"</pre>
+                    </section>
+                    <section id="t-4d-orchard-zsa-burn-digest"><h5><span class="section-heading">T.4d: orchard_zsa_burn_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4d-orchard-zsa-burn-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                        <p>A BLAKE2b-256 hash of the data from the burn fields of the transaction. For each tuple in the
+                            <span class="math">\(\mathsf{assetBurn}\)</span>
+                         set, the following elements are included in the hash:</p>
+                        <pre>T.4d.i : assetBase    (field encoding bytes)
+T.4d.ii: valueBurn    (field encoding bytes)</pre>
+                        <p>The personalization field of this hash is set to:</p>
+                        <pre>"ZTxIdOrcBurnHash"</pre>
+                        <p>In case the transaction does not perform the burning of any Assets (i.e. the
+                            <span class="math">\(\mathsf{assetBurn}\)</span>
+                         set is empty), the ''orchard_zsa_burn_digest'' is:</p>
+                        <pre>BLAKE2b-256("ZTxIdOrcBurnHash", [])</pre>
+                        <section id="t-4d-i-assetbase"><h6><span class="section-heading">T.4d.i: assetBase</span><span class="section-anchor"> <a rel="bookmark" href="#t-4d-i-assetbase"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                            <p>The Asset Base being burnt encoded as the 32-byte representation of a point on the Pallas curve.</p>
+                        </section>
+                        <section id="t-4d-ii-valueburn"><h6><span class="section-heading">T.4d.ii: valueBurn</span><span class="section-anchor"> <a rel="bookmark" href="#t-4d-ii-valueburn"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                            <p>Value of the Asset Base being burnt encoded as little-endian 8-byte representation of 64-bit unsigned integer (e.g. u64 in Rust) raw value.</p>
+                        </section>
                     </section>
                 </section>
                 <section id="t-5-issuance-digest"><h4><span class="section-heading">T.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>

--- a/zip-0226.rst
+++ b/zip-0226.rst
@@ -344,9 +344,10 @@ When Orchard Actions are present in the transaction, this digest is a BLAKE2b-25
    T.4a: orchard_actions_compact_digest      (32-byte hash output)          [UPDATED FOR ZSA]
    T.4b: orchard_actions_memos_digest        (32-byte hash output)          [UPDATED FOR ZSA]
    T.4c: orchard_actions_noncompact_digest   (32-byte hash output)          [UPDATED FOR ZSA]
-   T.4d: flagsOrchard                        (1 byte)
-   T.4e: valueBalanceOrchard                 (64-bit signed little-endian)
-   T.4f: anchorOrchard                       (32 bytes)
+   T.4d: orchard_zsa_burn_digest             (32-byte hash output)          [ADDED FOR ZSA]
+   T.4e: flagsOrchard                        (1 byte)
+   T.4f: valueBalanceOrchard                 (64-bit signed little-endian)
+   T.4g: anchorOrchard                       (32 bytes)
 
 T.4a: orchard_actions_compact_digest
 ''''''''''''''''''''''''''''''''''''
@@ -396,6 +397,36 @@ the following elements are included in the hash::
 The personalization field of this hash is defined identically to ZIP 244::
 
     "ZTxIdOrcActNHash"
+
+
+T.4d: orchard_zsa_burn_digest
+'''''''''''''''''''''''''''''
+
+A BLAKE2b-256 hash of the data from the burn fields of the transaction. For each tuple in 
+the :math:`\mathsf{assetBurn}` set, the following elements are included in the hash::
+
+    T.4d.i : assetBase    (field encoding bytes)
+    T.4d.ii: valueBurn    (field encoding bytes)
+
+The personalization field of this hash is set to::
+
+    "ZTxIdOrcBurnHash"
+
+In case the transaction does not perform the burning of any Assets (i.e. the 
+:math:`\mathsf{assetBurn}` set is empty), the ''orchard_zsa_burn_digest'' is::
+
+    BLAKE2b-256("ZTxIdOrcBurnHash", [])
+
+T.4d.i: assetBase
+.................
+The Asset Base being burnt encoded as the 32-byte representation of a point on the 
+Pallas curve.
+
+T.4d.ii: valueBurn
+..................
+Value of the Asset Base being burnt encoded as little-endian 8-byte representation 
+of 64-bit unsigned integer (e.g. u64 in Rust) raw value.
+
 
 T.5: issuance_digest
 ````````````````````


### PR DESCRIPTION
This PR adds a field to the TxId digest to include the burn fields of the transaction to the SIGHASH.