### PR TITLE
Setting transaction to contain issuance fields if and only if a non-zero number of issuance actions are present.

### DIFF
--- a/zip-0227.html
+++ b/zip-0227.html
@@ -658,7 +658,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
 T.5b: issuanceValidatingKey   (32 bytes)</pre>
                 <p>The personalization field of this hash is set to:</p>
                 <pre>"ZTxIdSAIssueHash"</pre>
-                <p>In case the transaction has no issuance components, ''issue_actions_digest'' is:</p>
+                <p>In case the transaction has no issuance components, ''issuance_digest'' is:</p>
                 <pre>BLAKE2b-256("ZTxIdSAIssueHash", [])</pre>
                 <section id="t-5a-issue-actions-digest"><h4><span class="section-heading">T.5a: issue_actions_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-issue-actions-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>A BLAKE2b-256 hash of Issue Action information for all Issuance Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
@@ -676,6 +676,8 @@ T.5a.i.4: rho                          (field encoding bytes)
 T.5a.i.5: rseed                        (field encoding bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdIAcNoteHash"</pre>
+                        <p>In case the transaction has no Issue Notes, ''issue_notes_digest'' is:</p>
+                        <pre>BLAKE2b-256("ZTxIdIAcNoteHash", [])</pre>
                         <section id="t-5a-i-1-recipient"><h6><span class="section-heading">T.5a.i.1: recipient</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-1-recipient"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">21</a>.</p>
                         </section>

--- a/zip-0227.rst
+++ b/zip-0227.rst
@@ -406,7 +406,7 @@ The personalization field of this hash is set to::
 
   "ZTxIdSAIssueHash"
 
-In case the transaction has no issuance components, ''issue_actions_digest'' is::
+In case the transaction has no issuance components, ''issuance_digest'' is::
 
     BLAKE2b-256("ZTxIdSAIssueHash", [])
 
@@ -435,6 +435,10 @@ A BLAKE2b-256 hash of Note information for all Notes belonging to the Issuance A
 The personalization field of this hash is set to::
 
   "ZTxIdIAcNoteHash"
+
+In case the transaction has no Issue Notes, ''issue_notes_digest'' is::
+
+    BLAKE2b-256("ZTxIdIAcNoteHash", [])
 
 T.5a.i.1: recipient
 ...................

--- a/zip-0230.html
+++ b/zip-0230.html
@@ -334,6 +334,9 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         <span class="math">\(0\!\)</span>
                     .</li>
                     <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
+                    <li>The fields <code>ik</code> and <code>issueAuthSig</code> are present if and only if
+                        <span class="math">\(\mathtt{nIssueActions} &gt; 0\!\)</span>
+                    .</li>
                     <li>For coinbase transactions, the <code>enableSpendsOrchard</code> and <code>enableZSAs</code> bits MUST be set to
                         <span class="math">\(0\!\)</span>
                     .</li>

--- a/zip-0230.html
+++ b/zip-0230.html
@@ -572,7 +572,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in ZIP 227 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">7</a>.</p>
+                <p>The encodings of each of these elements are defined in ZIP 227 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">7</a>. Note that we allow the number of notes (represented by <code>nNotes</code>) to be zero. This allows for issuers to create Issuance Actions to only finalize an issued Asset, without needing them to simultaneously issue more of that Asset.</p>
             </section>
         </section>
         <section id="reference-implementation"><h2><span class="section-heading">Reference implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/zip-0230.html
+++ b/zip-0230.html
@@ -324,6 +324,8 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     <li>The field <code>anchorSapling</code> is present if and only if
                         <span class="math">\(\mathtt{nSpendsSapling} &gt; 0\!\)</span>
                     .</li>
+                    <li>The elements of <code>vSpendProofsSapling</code> and <code>vSpendAuthSigsSapling</code> have a 1:1 correspondence to the elements of <code>vSpendsSapling</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>SpendDescriptionV6</code> at the same index.</li>
+                    <li>The elements of <code>vOutputProofsSapling</code> have a 1:1 correspondence to the elements of <code>vOutputsSapling</code> and MUST be ordered such that the proof at a given index corresponds to the <code>OutputDescriptionV6</code> at the same index.</li>
                     <li>The fields <code>flagsOrchard</code>, <code>valueBalanceOrchard</code>, <code>anchorOrchard</code>, <code>sizeProofsOrchardZSA</code>, <code>proofsOrchardZSA</code>, and <code>bindingSigOrchard</code> are present if and only if
                         <span class="math">\(\mathtt{nActionsOrchard} &gt; 0\!\)</span>
                     . If <code>valueBalanceOrchard</code> is not present, then
@@ -331,8 +333,6 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                      is defined to be
                         <span class="math">\(0\!\)</span>
                     .</li>
-                    <li>The elements of <code>vSpendProofsSapling</code> and <code>vSpendAuthSigsSapling</code> have a 1:1 correspondence to the elements of <code>vSpendsSapling</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>SpendDescriptionV6</code> at the same index.</li>
-                    <li>The elements of <code>vOutputProofsSapling</code> have a 1:1 correspondence to the elements of <code>vOutputsSapling</code> and MUST be ordered such that the proof at a given index corresponds to the <code>OutputDescriptionV6</code> at the same index.</li>
                     <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
                     <li>For coinbase transactions, the <code>enableSpendsOrchard</code> and <code>enableZSAs</code> bits MUST be set to
                         <span class="math">\(0\!\)</span>

--- a/zip-0230.rst
+++ b/zip-0230.rst
@@ -214,6 +214,8 @@ Transaction Format
   ``vActionsOrchard`` and MUST be ordered such that the proof or signature at a given
   index corresponds to the ``OrchardZsaAction`` at the same index.
 
+* The fields ``ik`` and ``issueAuthSig`` are present if and only if :math:`\mathtt{nIssueActions} > 0\!`.
+
 * For coinbase transactions, the ``enableSpendsOrchard`` and ``enableZSAs`` bits MUST be set to :math:`0\!`.
 
 The encodings of ``tx_in``, and ``tx_out`` are as in a version 4 transaction (i.e.

--- a/zip-0230.rst
+++ b/zip-0230.rst
@@ -334,6 +334,8 @@ An issuance action, ``IssueAction``, is the instance of issuing a specific Custo
 +-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
 
 The encodings of each of these elements are defined in ZIP 227 [#zip-0227]_.
+Note that we allow the number of notes (represented by ``nNotes``) to be zero. 
+This allows for issuers to create Issuance Actions to only finalize an issued Asset, without needing them to simultaneously issue more of that Asset. 
 
 Reference implementation
 ========================

--- a/zip-0230.rst
+++ b/zip-0230.rst
@@ -195,11 +195,6 @@ Transaction Format
 
 * The field ``anchorSapling`` is present if and only if :math:`\mathtt{nSpendsSapling} > 0\!`.
 
-* The fields ``flagsOrchard``, ``valueBalanceOrchard``, ``anchorOrchard``,
-  ``sizeProofsOrchardZSA``, ``proofsOrchardZSA``, and ``bindingSigOrchard`` are present if and
-  only if :math:`\mathtt{nActionsOrchard} > 0\!`. If ``valueBalanceOrchard`` is not present,
-  then :math:`\mathsf{v^{balanceOrchard}}` is defined to be :math:`0\!`.
-
 * The elements of ``vSpendProofsSapling`` and ``vSpendAuthSigsSapling`` have a 1:1
   correspondence to the elements of ``vSpendsSapling`` and MUST be ordered such that the
   proof or signature at a given index corresponds to the ``SpendDescriptionV6`` at the
@@ -208,6 +203,11 @@ Transaction Format
 * The elements of ``vOutputProofsSapling`` have a 1:1 correspondence to the elements of
   ``vOutputsSapling`` and MUST be ordered such that the proof at a given index corresponds
   to the ``OutputDescriptionV6`` at the same index.
+
+* The fields ``flagsOrchard``, ``valueBalanceOrchard``, ``anchorOrchard``,
+  ``sizeProofsOrchardZSA``, ``proofsOrchardZSA``, and ``bindingSigOrchard`` are present if and
+  only if :math:`\mathtt{nActionsOrchard} > 0\!`. If ``valueBalanceOrchard`` is not present,
+  then :math:`\mathsf{v^{balanceOrchard}}` is defined to be :math:`0\!`.
 
 * The proofs aggregated in ``proofsOrchardZSA``, and the elements of
   ``vSpendAuthSigsOrchard``, each have a 1:1 correspondence to the elements of


### PR DESCRIPTION
As described in the title, this PR adds to the transaction format to require that the `ik` and `issueAuthSig` fields be present in the transaction format if and only if there are a non-zero number of issuance actions.