### PR TITLE
Updating specification of the global issuance state, the issued_assets map

### DIFF
--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -214,25 +214,39 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  set.</p>
                 <section id="additional-consensus-rules"><h4><span class="section-heading">Additional Consensus Rules</span><span class="section-anchor"> <a rel="bookmark" href="#additional-consensus-rules"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <ol type="1">
-                        <li>We require that for every
-                            <span class="math">\((\mathsf{AssetBase_{AssetId}}, \mathsf{v_{AssetId}}) \in \mathsf{assetBurn}, \mathsf{AssetBase_{AssetId}} \neq \mathcal{V}^{\mathsf{Orchard}}\!\)</span>
+                        <li>Check that for every
+                            <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{AssetBase} \neq \mathcal{V}^{\mathsf{Orchard}}\!\)</span>
                         . That is, ZEC or TAZ is not allowed to be burnt by this mechanism.</li>
-                        <li>We require that for every
-                            <span class="math">\((\mathsf{AssetBase_{AssetId}}, \mathsf{v_{AssetId}}) \in \mathsf{assetBurn}, \mathsf{v_{AssetId}} \neq 0\!\)</span>
+                        <li>Check that for every
+                            <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{v} \neq 0\!\)</span>
                         .</li>
-                        <li>We require that there be no duplication of Custom Assets in the
+                        <li>Check that there is no duplication of Custom Assets in the
                             <span class="math">\(\mathsf{assetBurn}\)</span>
                          set. That is, every
-                            <span class="math">\(\mathsf{AssetBase_{AssetId}}\)</span>
+                            <span class="math">\(\mathsf{AssetBase}\)</span>
                          has at most one entry in
                             <span class="math">\(\mathsf{assetBurn}\!\)</span>
                         .</li>
+                        <li>Check that for every
+                            <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!\)</span>
+                        ,
+                            <span class="math">\(\mathsf{v} \leq \mathsf{issued\_assets(AssetDigest).balance}\!\)</span>
+                        , where the map
+                            <span class="math">\(\mathsf{issued\_assets}\)</span>
+                         is defined in ZIP 227 <a id="footnote-reference-39" class="footnote_reference" href="#zip-0227">5</a>. That is, it is not possible to burn more of an Asset than is currently in circulation.</li>
                     </ol>
+                    <p>If all these checks pass, then for every
+                        <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!\)</span>
+                    , reduce the value of
+                        <span class="math">\(\mathsf{issued\_assets(AssetDigest).balance}\)</span>
+                     in the global state by
+                        <span class="math">\(\mathsf{v}\!\)</span>
+                    .</p>
                     <p><strong>Note:</strong> Even if this mechanism allows having transparent ↔ shielded Asset transfers in theory, the transparent protocol will not be changed with this ZIP to adapt to a multiple Asset structure. This means that unless future consensus rules changes do allow it, unshielding will not be possible for Custom Assets.</p>
                 </section>
             </section>
             <section id="value-balance-verification"><h3><span class="section-heading">Value Balance Verification</span><span class="section-anchor"> <a rel="bookmark" href="#value-balance-verification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-39" class="footnote_reference" href="#protocol-orchardbalance">18</a>, with the addition of the burn information.</p>
+                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-40" class="footnote_reference" href="#protocol-orchardbalance">18</a>, with the addition of the burn information.</p>
                 <p>For a total of
                     <span class="math">\(n\)</span>
                  Actions in a transfer, the prover MUST still sign the SIGHASH transaction hash using the binding signature key
@@ -255,7 +269,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      the set of indices of Actions that are related to Custom Assets.</p>
                     <p>The right hand side of the value balance verification equation can be expanded to:</p>
                     <div class="math">\(((\sum_{i \in S_{\mathsf{ZEC}}} \mathsf{cv}^{\mathsf{net}}_i) + (\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j)) - ([\mathsf{v^{balanceOrchard}}]\,\mathcal{V}^{\mathsf{Orchard}} + [0]\,\mathcal{R}^{\mathsf{Orchard}}) - (\sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} + [0]\,\mathcal{R}^{\mathsf{Orchard}})\)</div>
-                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-40" class="footnote_reference" href="#protocol-orchardbalance">18</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
+                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-41" class="footnote_reference" href="#protocol-orchardbalance">18</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
                         <span class="math">\(\mathsf{assetBurn}\)</span>
                      set. As such, for a correctly constructed transaction, we will get
                         <span class="math">\(\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j - \sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} = \sum_{j \in S_{\mathsf{CA}}} [\mathsf{rcv}^{\mathsf{net}}_j]\,\mathcal{R}^{\mathsf{Orchard}}\!\)</span>
@@ -304,11 +318,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathbb{F}_{q_{\mathbb{P}}}\!\)</span>
                 ,
                     <span class="math">\(\mathcal{K}^{\mathsf{Orchard}}\)</span>
-                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-41" class="footnote_reference" href="#protocol-commitmentsandnullifiers">19</a>, and
+                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-42" class="footnote_reference" href="#protocol-commitmentsandnullifiers">19</a>, and
                     <span class="math">\(\mathcal{L}^{\mathsf{Orchard}} := \mathsf{GroupHash^{\mathbb{P}}}(\texttt{"z.cash:Orchard"}, \texttt{"L"})\!\)</span>
                 .</p>
                 <section id="rationale-for-split-notes"><h4><span class="section-heading">Rationale for Split Notes</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-split-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-42" class="footnote_reference" href="#protocol-orcharddummynotes">17</a> to the Actions that have not been assigned input notes.</p>
+                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orcharddummynotes">17</a> to the Actions that have not been assigned input notes.</p>
                     <p>The Orchard technique requires modification for the ZSA protocol with multiple Asset Identifiers, as the output note of the split Actions <em>cannot</em> contain <em>just any</em> Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.</p>
                     <p>Therefore, for Custom Assets we enforce that <em>every</em> input note to an ZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the
                         <span class="math">\(\mathsf{split\_flag}\)</span>
@@ -317,8 +331,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="circuit-statement"><h3><span class="section-heading">Circuit Statement</span><span class="section-anchor"> <a rel="bookmark" href="#circuit-statement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Every <em>ZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-43" class="footnote_reference" href="#protocol-actionstatement">20</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
-                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-44" class="footnote_reference" href="#circuit-modifications">31</a>.</p>
+                <p>Every <em>ZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">20</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
+                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-45" class="footnote_reference" href="#circuit-modifications">31</a>.</p>
                 <section id="asset-base-equality"><h4><span class="section-heading">Asset Base Equality</span><span class="section-anchor"> <a rel="bookmark" href="#asset-base-equality"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>The following constraints must be added to ensure that the input and output note are of the same
                         <span class="math">\(\mathsf{AssetBase}\!\)</span>
@@ -327,12 +341,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <li>The Asset Base,
                             <span class="math">\(\mathsf{AssetBase_{AssetId}}\!\)</span>
                         , for the note is witnessed once, as an auxiliary input.</li>
-                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-45" class="footnote_reference" href="#protocol-actionstatement">20</a>,
+                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">20</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
                         .</li>
-                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">20</a>,
+                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-47" class="footnote_reference" href="#protocol-actionstatement">20</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
@@ -449,15 +463,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                 </section>
                 <section id="backwards-compatibility-with-zec-notes"><h4><span class="section-heading">Backwards Compatibility with ZEC Notes</span><span class="section-anchor"> <a rel="bookmark" href="#backwards-compatibility-with-zec-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-47" class="footnote_reference" href="#protocol-abstractcommit">16</a>. If the note is a ZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
+                    <p>The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">16</a>. If the note is a ZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
                 </section>
             </section>
         </section>
         <section id="orchard-zsa-transaction-structure"><h2><span class="section-heading">Orchard-ZSA Transaction Structure</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-transaction-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-48" class="footnote_reference" href="#zip-0230">10</a>.</p>
+            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-49" class="footnote_reference" href="#zip-0230">10</a>.</p>
         </section>
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-49" class="footnote_reference" href="#zip-0244">11</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">11</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values</p>
                 <pre>T.1: header_digest       (32-byte hash output)
@@ -465,7 +479,7 @@ T.2: transparent_digest  (32-byte hash output)
 T.3: sapling_digest      (32-byte hash output)
 T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
 T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">11</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0244">11</a>.</p>
                 <section id="t-4-orchard-digest"><h4><span class="section-heading">T.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>When Orchard Actions are present in the transaction, this digest is a BLAKE2b-256 hash of the following values</p>
                     <pre>T.4a: orchard_actions_compact_digest      (32-byte hash output)          [UPDATED FOR ZSA]
@@ -476,7 +490,7 @@ T.4e: flagsOrchard                        (1 byte)
 T.4f: valueBalanceOrchard                 (64-bit signed little-endian)
 T.4g: anchorOrchard                       (32 bytes)</pre>
                     <section id="t-4a-orchard-actions-compact-digest"><h5><span class="section-heading">T.4a: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                         <pre>T.4a.i  : nullifier            (field encoding bytes)
 T.4a.ii : cmx                  (field encoding bytes)
 T.4a.iii: ephemeralKey         (field encoding bytes)
@@ -491,7 +505,7 @@ T.4a.iv : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR 
                         <pre>"ZTxIdOrcActMHash"</pre>
                     </section>
                     <section id="t-4c-orchard-actions-noncompact-digest"><h5><span class="section-heading">T.4c: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4c-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                         <pre>T.4d.i  : cv                    (field encoding bytes)
 T.4d.ii : rk                    (field encoding bytes)
 T.4d.iii: encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
@@ -520,12 +534,12 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                     </section>
                 </section>
                 <section id="t-5-issuance-digest"><h4><span class="section-heading">T.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0227-txiddigest">7</a>.</p>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0227-txiddigest">7</a>.</p>
                 </section>
             </section>
         </section>
         <section id="signature-digest-and-authorizing-data-commitment"><h2><span class="section-heading">Signature Digest and Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest-and-authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0227-sigdigest">8</a> <a id="footnote-reference-55" class="footnote_reference" href="#zip-0227-authcommitment">9</a>.</p>
+            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0227-sigdigest">8</a> <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-authcommitment">9</a>.</p>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
@@ -538,7 +552,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-56" class="footnote_reference" href="#zip-0317b">13</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-57" class="footnote_reference" href="#zip-0317b">13</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and ZSA notes. As we specify above, there are three main reasons we can do this:</p>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -230,7 +230,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <li>Check that for every
                             <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!\)</span>
                         ,
-                            <span class="math">\(\mathsf{v} \leq \mathsf{issued\_assets(AssetDigest).balance}\!\)</span>
+                            <span class="math">\(\mathsf{v} \leq \mathsf{issued\_assets(AssetBase).balance}\!\)</span>
                         , where the map
                             <span class="math">\(\mathsf{issued\_assets}\)</span>
                          is defined in ZIP 227 <a id="footnote-reference-39" class="footnote_reference" href="#zip-0227-specification-global-issuance-state">6</a>. That is, it is not possible to burn more of an Asset than is currently in circulation.</li>
@@ -238,7 +238,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <p>If all these checks pass, then for every
                         <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!\)</span>
                     , reduce the value of
-                        <span class="math">\(\mathsf{issued\_assets(AssetDigest).balance}\)</span>
+                        <span class="math">\(\mathsf{issued\_assets(AssetBase).balance}\)</span>
                      in the global state by
                         <span class="math">\(\mathsf{v}\!\)</span>
                     .</p>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -32,7 +32,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <ul>
                 <li>Split Input: an Action input used to ensure that the output note of that Action is of a validly issued
                     <span class="math">\(\mathsf{AssetBase}\)</span>
-                 (see <a id="footnote-reference-5" class="footnote_reference" href="#zip-0227-assetidentifier">6</a>) when there is no corresponding real input note, in situations where the number of outputs are larger than the number of inputs. See formal definition in <a href="#split-notes">Split Notes</a>.</li>
+                 (see <a id="footnote-reference-5" class="footnote_reference" href="#zip-0227-assetidentifier">7</a>) when there is no corresponding real input note, in situations where the number of outputs are larger than the number of inputs. See formal definition in <a href="#split-notes">Split Notes</a>.</li>
                 <li>Split Action: an Action that contains a Split Input.</li>
             </ul>
         </section>
@@ -48,18 +48,18 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             . This Asset Identifier maps to an Asset Base
                 <span class="math">\(\mathsf{AssetBase}\)</span>
              that is stored in Orchard-based ZSA notes. These terms are formally defined in ZIP 227 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">5</a>.</p>
-            <p>The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description <a id="footnote-reference-10" class="footnote_reference" href="#protocol-actions">15</a> <a id="footnote-reference-11" class="footnote_reference" href="#protocol-actionencodingandconsensus">28</a> is preserved across Assets (see the Orchard Binding Signature <a id="footnote-reference-12" class="footnote_reference" href="#protocol-orchardbalance">18</a>), and by extension the balance of an Orchard transaction. That is, the sum of all the
+            <p>The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description <a id="footnote-reference-10" class="footnote_reference" href="#protocol-actions">16</a> <a id="footnote-reference-11" class="footnote_reference" href="#protocol-actionencodingandconsensus">29</a> is preserved across Assets (see the Orchard Binding Signature <a id="footnote-reference-12" class="footnote_reference" href="#protocol-orchardbalance">19</a>), and by extension the balance of an Orchard transaction. That is, the sum of all the
                 <span class="math">\(\mathsf{value^{net}}\)</span>
              from each Action Description, computed as
                 <span class="math">\(\mathsf{value^{old}} - \mathsf{value^{new}}\!\)</span>
             , must be balanced <strong>only with respect to the same Asset Identifier</strong>. This is especially important since we will allow different Action Descriptions to transfer notes of different Asset Identifiers, where the overall balance is checked without revealing which (or how many distinct) Assets are being transferred.</p>
-            <p>As was initially proposed by Jack Grigg and Daira-Emma Hopwood <a id="footnote-reference-13" class="footnote_reference" href="#initial-zsa-issue">29</a> <a id="footnote-reference-14" class="footnote_reference" href="#generalized-value-commitments">30</a>, we propose to make this happen by changing the value base point,
+            <p>As was initially proposed by Jack Grigg and Daira-Emma Hopwood <a id="footnote-reference-13" class="footnote_reference" href="#initial-zsa-issue">30</a> <a id="footnote-reference-14" class="footnote_reference" href="#generalized-value-commitments">31</a>, we propose to make this happen by changing the value base point,
                 <span class="math">\(\mathcal{V}^{\mathsf{Orchard}}\!\)</span>
             , in the Homomorphic Pedersen Commitment that derives the value commitment,
                 <span class="math">\(\mathsf{cv^{net}}\!\)</span>
             , of the <em>net value</em> in an Orchard Action.</p>
-            <p>Because in a single transaction all value commitments are balanced, there must be as many different value base points as there are Asset Identifiers for a given shielded protocol used in a transaction. We propose to make the Asset Base an auxiliary input to the proof for each Action statement <a id="footnote-reference-15" class="footnote_reference" href="#protocol-actionstatement">20</a>, represented already as a point on the Pallas curve. The circuit then should check that the same Asset Base is used in the old note commitment and the new note commitment <a id="footnote-reference-16" class="footnote_reference" href="#protocol-concretesinsemillacommit">25</a>, <strong>and</strong> as the base point in the value commitment <a id="footnote-reference-17" class="footnote_reference" href="#protocol-concretehomomorphiccommit">24</a>. This ensures (1) that the input and output notes are of the same Asset Base, and (2) that only Actions with the same Asset Base will balance out in the Orchard binding signature.</p>
-            <p>In order to ensure the security of the transfers, and as we will explain below, we are redefining input dummy notes <a id="footnote-reference-18" class="footnote_reference" href="#protocol-orcharddummynotes">17</a> for Custom Assets, as we need to enforce that the
+            <p>Because in a single transaction all value commitments are balanced, there must be as many different value base points as there are Asset Identifiers for a given shielded protocol used in a transaction. We propose to make the Asset Base an auxiliary input to the proof for each Action statement <a id="footnote-reference-15" class="footnote_reference" href="#protocol-actionstatement">21</a>, represented already as a point on the Pallas curve. The circuit then should check that the same Asset Base is used in the old note commitment and the new note commitment <a id="footnote-reference-16" class="footnote_reference" href="#protocol-concretesinsemillacommit">26</a>, <strong>and</strong> as the base point in the value commitment <a id="footnote-reference-17" class="footnote_reference" href="#protocol-concretehomomorphiccommit">25</a>. This ensures (1) that the input and output notes are of the same Asset Base, and (2) that only Actions with the same Asset Base will balance out in the Orchard binding signature.</p>
+            <p>In order to ensure the security of the transfers, and as we will explain below, we are redefining input dummy notes <a id="footnote-reference-18" class="footnote_reference" href="#protocol-orcharddummynotes">18</a> for Custom Assets, as we need to enforce that the
                 <span class="math">\(\mathsf{AssetBase}\)</span>
              of the output note of that Split Action is the output of a valid
                 <span class="math">\(\mathsf{ZSAValueBase}\)</span>
@@ -98,7 +98,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  be the type of a ZSA note, i.e.
                     <span class="math">\(\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}^*\!\)</span>
                 .</p>
-                <p>An Orchard ZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">14</a> by additionally including the Asset Base,
+                <p>An Orchard ZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">15</a> by additionally including the Asset Base,
                     <span class="math">\(\mathsf{AssetBase}\!\)</span>
                 . So a ZSA note is a tuple
                     <span class="math">\((\mathsf{g_d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!\)</span>
@@ -106,7 +106,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <ul>
                     <li>
                         <span class="math">\(\mathsf{AssetBase} : \mathbb{P}^*\)</span>
-                     is the unique element of the Pallas group <a id="footnote-reference-23" class="footnote_reference" href="#protocol-pallasandvesta">26</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0227">5</a>, a valid group element that is not the identity and is not
+                     is the unique element of the Pallas group <a id="footnote-reference-23" class="footnote_reference" href="#protocol-pallasandvesta">27</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0227">5</a>, a valid group element that is not the identity and is not
                         <span class="math">\(\bot\!\)</span>
                     . The byte representation of the Asset Base is defined as
                         <span class="math">\(\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})\!\)</span>
@@ -119,11 +119,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <div class="math">\(\mathsf{NoteCommit}^{\mathsf{OrchardZSA}} : \mathsf{NoteCommit}^{\mathsf{Orchard}}.\!\mathsf{Trapdoor} \times \mathbb{B}^{[\ell_{\mathbb{P}}]} \times \mathbb{B}^{[\ell_{\mathbb{P}}]} \times \{0 .. 2^{\ell_{\mathsf{value}}} - 1\} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{P}^* \to \mathsf{NoteCommit}^{\mathsf{Orchard}}.\!\mathsf{Output}\)</div>
                 <p>where
                     <span class="math">\(\mathbb{P}, \ell_{\mathbb{P}}, q_{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-25" class="footnote_reference" href="#protocol-pallasandvesta">26</a>, and where
+                 are as defined for the Pallas curve <a id="footnote-reference-25" class="footnote_reference" href="#protocol-pallasandvesta">27</a>, and where
                     <span class="math">\(\mathsf{NoteCommit^{Orchard}}.\!\mathsf{Trapdoor}\)</span>
                  and
                     <span class="math">\(\mathsf{Orchard}.\!\mathsf{Output}\)</span>
-                 are as defined in the Zcash protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-abstractcommit">16</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-27" class="footnote_reference" href="#protocol-concretesinsemillacommit">25</a> as follows:</p>
+                 are as defined in the Zcash protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-abstractcommit">17</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-27" class="footnote_reference" href="#protocol-concretesinsemillacommit">26</a> as follows:</p>
                 <div class="math">\(\begin{align}
 \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{g_d}\star, \mathsf{pk_d}\star, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})
 := \begin{cases}
@@ -141,21 +141,21 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{repr}_{\mathbb{P}}\)</span>
                  and
                     <span class="math">\(\mathsf{GroupHash}^{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-28" class="footnote_reference" href="#protocol-pallasandvesta">26</a>,
+                 are as defined for the Pallas curve <a id="footnote-reference-28" class="footnote_reference" href="#protocol-pallasandvesta">27</a>,
                     <span class="math">\(\ell^{\mathsf{Orchard}}_{\mathsf{base}}\)</span>
-                 is as defined in §5.3 <a id="footnote-reference-29" class="footnote_reference" href="#protocol-constants">22</a>, and
+                 is as defined in §5.3 <a id="footnote-reference-29" class="footnote_reference" href="#protocol-constants">23</a>, and
                     <span class="math">\(\mathsf{I2LEBSP}\)</span>
-                 is as defined in §5.1 <a id="footnote-reference-30" class="footnote_reference" href="#protocol-endian">21</a> of the Zcash protocol specification.</p>
-                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-31" class="footnote_reference" href="#protocol-commitmentsandnullifiers">19</a>.</p>
-                <p>The ZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-32" class="footnote_reference" href="#protocol-notept">27</a>. It consists of</p>
+                 is as defined in §5.1 <a id="footnote-reference-30" class="footnote_reference" href="#protocol-endian">22</a> of the Zcash protocol specification.</p>
+                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-31" class="footnote_reference" href="#protocol-commitmentsandnullifiers">20</a>.</p>
+                <p>The ZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-32" class="footnote_reference" href="#protocol-notept">28</a>. It consists of</p>
                 <div class="math">\((\mathsf{leadByte} : \mathbb{B}^{\mathbb{Y}}, \mathsf{d} : \mathbb{B}^{[\ell_{\mathsf{d}}]}, \mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}, \mathsf{rseed} : \mathbb{B}^{\mathbb{Y}[32]}, \mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}, \mathsf{memo} : \mathbb{B}^{\mathbb{Y}[512]})\)</div>
                 <section id="rationale-for-note-commitment"><h4><span class="section-heading">Rationale for Note Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-note-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>In the ZSA protocol, the instance of the note commitment scheme,
                         <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\!\)</span>
                     , differs from the Orchard note commitment
                         <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm}}\)</span>
-                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretesinsemillacommit">25</a> allows us to add the Asset Base as a final recursive step.</p>
-                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-34" class="footnote_reference" href="#protocol-concretesinsemillahash">23</a>. ZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
+                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretesinsemillacommit">26</a> allows us to add the Asset Base as a final recursive step.</p>
+                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-34" class="footnote_reference" href="#protocol-concretesinsemillahash">24</a>. ZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
                     <div class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase}) \in \mathsf{NoteCommit^{Orchard}}.\!\mathsf{Output}\)</div>
                     <p>This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and ZSA notes.</p>
                 </section>
@@ -186,7 +186,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{ValueCommit^{OrchardZSA}_{rcv}}(\mathcal{V}^{\mathsf{Orchard}}, \mathsf{v})\)</span>
                  here.</p>
                 <section id="rationale-for-value-commitment"><h4><span class="section-heading">Rationale for Value Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-value-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-38" class="footnote_reference" href="#protocol-concretehomomorphiccommit">24</a> to perform the value commitment, with fixed base points
+                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-38" class="footnote_reference" href="#protocol-concretehomomorphiccommit">25</a> to perform the value commitment, with fixed base points
                         <span class="math">\(\mathcal{V}^{\mathsf{Orchard}}\)</span>
                      and
                         <span class="math">\(\mathcal{R}^{\mathsf{Orchard}}\)</span>
@@ -233,7 +233,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                             <span class="math">\(\mathsf{v} \leq \mathsf{issued\_assets(AssetDigest).balance}\!\)</span>
                         , where the map
                             <span class="math">\(\mathsf{issued\_assets}\)</span>
-                         is defined in ZIP 227 <a id="footnote-reference-39" class="footnote_reference" href="#zip-0227">5</a>. That is, it is not possible to burn more of an Asset than is currently in circulation.</li>
+                         is defined in ZIP 227 <a id="footnote-reference-39" class="footnote_reference" href="#zip-0227-specification-global-issuance-state">6</a>. That is, it is not possible to burn more of an Asset than is currently in circulation.</li>
                     </ol>
                     <p>If all these checks pass, then for every
                         <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!\)</span>
@@ -246,7 +246,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="value-balance-verification"><h3><span class="section-heading">Value Balance Verification</span><span class="section-anchor"> <a rel="bookmark" href="#value-balance-verification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-40" class="footnote_reference" href="#protocol-orchardbalance">18</a>, with the addition of the burn information.</p>
+                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-40" class="footnote_reference" href="#protocol-orchardbalance">19</a>, with the addition of the burn information.</p>
                 <p>For a total of
                     <span class="math">\(n\)</span>
                  Actions in a transfer, the prover MUST still sign the SIGHASH transaction hash using the binding signature key
@@ -269,7 +269,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      the set of indices of Actions that are related to Custom Assets.</p>
                     <p>The right hand side of the value balance verification equation can be expanded to:</p>
                     <div class="math">\(((\sum_{i \in S_{\mathsf{ZEC}}} \mathsf{cv}^{\mathsf{net}}_i) + (\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j)) - ([\mathsf{v^{balanceOrchard}}]\,\mathcal{V}^{\mathsf{Orchard}} + [0]\,\mathcal{R}^{\mathsf{Orchard}}) - (\sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} + [0]\,\mathcal{R}^{\mathsf{Orchard}})\)</div>
-                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-41" class="footnote_reference" href="#protocol-orchardbalance">18</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
+                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-41" class="footnote_reference" href="#protocol-orchardbalance">19</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
                         <span class="math">\(\mathsf{assetBurn}\)</span>
                      set. As such, for a correctly constructed transaction, we will get
                         <span class="math">\(\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j - \sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} = \sum_{j \in S_{\mathsf{CA}}} [\mathsf{rcv}^{\mathsf{net}}_j]\,\mathcal{R}^{\mathsf{Orchard}}\!\)</span>
@@ -318,11 +318,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathbb{F}_{q_{\mathbb{P}}}\!\)</span>
                 ,
                     <span class="math">\(\mathcal{K}^{\mathsf{Orchard}}\)</span>
-                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-42" class="footnote_reference" href="#protocol-commitmentsandnullifiers">19</a>, and
+                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-42" class="footnote_reference" href="#protocol-commitmentsandnullifiers">20</a>, and
                     <span class="math">\(\mathcal{L}^{\mathsf{Orchard}} := \mathsf{GroupHash^{\mathbb{P}}}(\texttt{"z.cash:Orchard"}, \texttt{"L"})\!\)</span>
                 .</p>
                 <section id="rationale-for-split-notes"><h4><span class="section-heading">Rationale for Split Notes</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-split-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orcharddummynotes">17</a> to the Actions that have not been assigned input notes.</p>
+                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orcharddummynotes">18</a> to the Actions that have not been assigned input notes.</p>
                     <p>The Orchard technique requires modification for the ZSA protocol with multiple Asset Identifiers, as the output note of the split Actions <em>cannot</em> contain <em>just any</em> Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.</p>
                     <p>Therefore, for Custom Assets we enforce that <em>every</em> input note to an ZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the
                         <span class="math">\(\mathsf{split\_flag}\)</span>
@@ -331,8 +331,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="circuit-statement"><h3><span class="section-heading">Circuit Statement</span><span class="section-anchor"> <a rel="bookmark" href="#circuit-statement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Every <em>ZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">20</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
-                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-45" class="footnote_reference" href="#circuit-modifications">31</a>.</p>
+                <p>Every <em>ZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">21</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
+                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-45" class="footnote_reference" href="#circuit-modifications">32</a>.</p>
                 <section id="asset-base-equality"><h4><span class="section-heading">Asset Base Equality</span><span class="section-anchor"> <a rel="bookmark" href="#asset-base-equality"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>The following constraints must be added to ensure that the input and output note are of the same
                         <span class="math">\(\mathsf{AssetBase}\!\)</span>
@@ -341,12 +341,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <li>The Asset Base,
                             <span class="math">\(\mathsf{AssetBase_{AssetId}}\!\)</span>
                         , for the note is witnessed once, as an auxiliary input.</li>
-                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">20</a>,
+                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">21</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
                         .</li>
-                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-47" class="footnote_reference" href="#protocol-actionstatement">20</a>,
+                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-47" class="footnote_reference" href="#protocol-actionstatement">21</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
@@ -463,15 +463,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                 </section>
                 <section id="backwards-compatibility-with-zec-notes"><h4><span class="section-heading">Backwards Compatibility with ZEC Notes</span><span class="section-anchor"> <a rel="bookmark" href="#backwards-compatibility-with-zec-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">16</a>. If the note is a ZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
+                    <p>The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">17</a>. If the note is a ZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
                 </section>
             </section>
         </section>
         <section id="orchard-zsa-transaction-structure"><h2><span class="section-heading">Orchard-ZSA Transaction Structure</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-transaction-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-49" class="footnote_reference" href="#zip-0230">10</a>.</p>
+            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-49" class="footnote_reference" href="#zip-0230">11</a>.</p>
         </section>
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">11</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">12</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values</p>
                 <pre>T.1: header_digest       (32-byte hash output)
@@ -479,7 +479,7 @@ T.2: transparent_digest  (32-byte hash output)
 T.3: sapling_digest      (32-byte hash output)
 T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
 T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0244">11</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0244">12</a>.</p>
                 <section id="t-4-orchard-digest"><h4><span class="section-heading">T.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>When Orchard Actions are present in the transaction, this digest is a BLAKE2b-256 hash of the following values</p>
                     <pre>T.4a: orchard_actions_compact_digest      (32-byte hash output)          [UPDATED FOR ZSA]
@@ -490,7 +490,7 @@ T.4e: flagsOrchard                        (1 byte)
 T.4f: valueBalanceOrchard                 (64-bit signed little-endian)
 T.4g: anchorOrchard                       (32 bytes)</pre>
                     <section id="t-4a-orchard-actions-compact-digest"><h5><span class="section-heading">T.4a: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                         <pre>T.4a.i  : nullifier            (field encoding bytes)
 T.4a.ii : cmx                  (field encoding bytes)
 T.4a.iii: ephemeralKey         (field encoding bytes)
@@ -505,7 +505,7 @@ T.4a.iv : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR 
                         <pre>"ZTxIdOrcActMHash"</pre>
                     </section>
                     <section id="t-4c-orchard-actions-noncompact-digest"><h5><span class="section-heading">T.4c: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4c-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">12</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                         <pre>T.4d.i  : cv                    (field encoding bytes)
 T.4d.ii : rk                    (field encoding bytes)
 T.4d.iii: encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
@@ -534,12 +534,12 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                     </section>
                 </section>
                 <section id="t-5-issuance-digest"><h4><span class="section-heading">T.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0227-txiddigest">7</a>.</p>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0227-txiddigest">8</a>.</p>
                 </section>
             </section>
         </section>
         <section id="signature-digest-and-authorizing-data-commitment"><h2><span class="section-heading">Signature Digest and Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest-and-authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0227-sigdigest">8</a> <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-authcommitment">9</a>.</p>
+            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0227-sigdigest">9</a> <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-authcommitment">10</a>.</p>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
@@ -552,7 +552,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-57" class="footnote_reference" href="#zip-0317b">13</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-57" class="footnote_reference" href="#zip-0317b">14</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and ZSA notes. As we specify above, there are three main reasons we can do this:</p>
@@ -623,10 +623,18 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0227-assetidentifier" class="footnote">
+            <table id="zip-0227-specification-global-issuance-state" class="footnote">
                 <tbody>
                     <tr>
                         <th>6</th>
+                        <td><a href="zip-0227.html#specification-global-issuance-state">ZIP 227: Issuance of Zcash Shielded Assets: Specification: Global Issuance State</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0227-assetidentifier" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>7</th>
                         <td><a href="zip-0227.html#specification-asset-identifier">ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier</a></td>
                     </tr>
                 </tbody>
@@ -634,7 +642,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0227-txiddigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>7</th>
+                        <th>8</th>
                         <td><a href="zip-0227.html#txid-digest-issuance">ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance</a></td>
                     </tr>
                 </tbody>
@@ -642,7 +650,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0227-sigdigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>8</th>
+                        <th>9</th>
                         <td><a href="zip-0227.html#signature-digest">ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest</a></td>
                     </tr>
                 </tbody>
@@ -650,7 +658,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0227-authcommitment" class="footnote">
                 <tbody>
                     <tr>
-                        <th>9</th>
+                        <th>10</th>
                         <td><a href="zip-0227.html#authorizing-data-commitment">ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
@@ -658,7 +666,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0230" class="footnote">
                 <tbody>
                     <tr>
-                        <th>10</th>
+                        <th>11</th>
                         <td><a href="https://github.com/QED-it/zips/pull/36">ZIP 230: Version 6 Transaction Format</a></td>
                     </tr>
                 </tbody>
@@ -666,7 +674,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>11</th>
+                        <th>12</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -674,7 +682,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0307" class="footnote">
                 <tbody>
                     <tr>
-                        <th>12</th>
+                        <th>13</th>
                         <td><a href="zip-0307">ZIP 307: Light Client Protocol for Payment Detection</a></td>
                     </tr>
                 </tbody>
@@ -682,7 +690,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0317b" class="footnote">
                 <tbody>
                     <tr>
-                        <th>13</th>
+                        <th>14</th>
                         <td><a href="https://github.com/zcash/zips/pull/667">ZIP 317: Proportional Transfer Fee Mechanism - Pull Request #667 for ZSA Protocol ZIPs</a></td>
                     </tr>
                 </tbody>
@@ -690,7 +698,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-notes" class="footnote">
                 <tbody>
                     <tr>
-                        <th>14</th>
+                        <th>15</th>
                         <td><a href="protocol/protocol.pdf#notes">Zcash Protocol Specification, Version 2023.4.0. Section 3.2: Notes</a></td>
                     </tr>
                 </tbody>
@@ -698,7 +706,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-actions" class="footnote">
                 <tbody>
                     <tr>
-                        <th>15</th>
+                        <th>16</th>
                         <td><a href="protocol/protocol.pdf#actions">Zcash Protocol Specification, Version 2023.4.0. Section 3.7: Action Transfers and their Descriptions</a></td>
                     </tr>
                 </tbody>
@@ -706,7 +714,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-abstractcommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>17</th>
                         <td><a href="protocol/protocol.pdf#abstractcommit">Zcash Protocol Specification, Version 2023.4.0. Section 4.1.8: Commitment</a></td>
                     </tr>
                 </tbody>
@@ -714,7 +722,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-orcharddummynotes" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
+                        <th>18</th>
                         <td><a href="protocol/protocol.pdf#orcharddummynotes">Zcash Protocol Specification, Version 2023.4.0. Section 4.8.3: Dummy Notes (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -722,7 +730,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-orchardbalance" class="footnote">
                 <tbody>
                     <tr>
-                        <th>18</th>
+                        <th>19</th>
                         <td><a href="protocol/protocol.pdf#orchardbalance">Zcash Protocol Specification, Version 2023.4.0. Section 4.14: Balance and Binding Signature (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -730,7 +738,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-commitmentsandnullifiers" class="footnote">
                 <tbody>
                     <tr>
-                        <th>19</th>
+                        <th>20</th>
                         <td><a href="protocol/protocol.pdf#commitmentsandnullifiers">Zcash Protocol Specification, Version 2023.4.0. Section 4.16: Note Commitments and Nullifiers</a></td>
                     </tr>
                 </tbody>
@@ -738,7 +746,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-actionstatement" class="footnote">
                 <tbody>
                     <tr>
-                        <th>20</th>
+                        <th>21</th>
                         <td><a href="protocol/protocol.pdf#actionstatement">Zcash Protocol Specification, Version 2023.4.0. Section 4.17.4: Action Statement (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -746,7 +754,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-endian" class="footnote">
                 <tbody>
                     <tr>
-                        <th>21</th>
+                        <th>22</th>
                         <td><a href="protocol/protocol.pdf#endian">Zcash Protocol Specification, Version 2023.4.0. Section 5.1: Integers, Bit Sequences, and Endianness</a></td>
                     </tr>
                 </tbody>
@@ -754,7 +762,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-constants" class="footnote">
                 <tbody>
                     <tr>
-                        <th>22</th>
+                        <th>23</th>
                         <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2023.4.0. Section 5.3: Constants</a></td>
                     </tr>
                 </tbody>
@@ -762,7 +770,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-concretesinsemillahash" class="footnote">
                 <tbody>
                     <tr>
-                        <th>23</th>
+                        <th>24</th>
                         <td><a href="protocol/protocol.pdf#concretesinsemillahash">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.1.9: Sinsemilla hash function</a></td>
                     </tr>
                 </tbody>
@@ -770,7 +778,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-concretehomomorphiccommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>24</th>
+                        <th>25</th>
                         <td><a href="protocol/protocol.pdf#concretehomomorphiccommit">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -778,7 +786,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-concretesinsemillacommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>25</th>
+                        <th>26</th>
                         <td><a href="protocol/protocol.pdf#concretesinsemillacommit">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.8.4: Sinsemilla commitments</a></td>
                     </tr>
                 </tbody>
@@ -786,7 +794,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-pallasandvesta" class="footnote">
                 <tbody>
                     <tr>
-                        <th>26</th>
+                        <th>27</th>
                         <td><a href="protocol/protocol.pdf#pallasandvesta">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.9.6: Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
@@ -794,7 +802,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-notept" class="footnote">
                 <tbody>
                     <tr>
-                        <th>27</th>
+                        <th>28</th>
                         <td><a href="protocol/protocol.pdf#notept">Zcash Protocol Specification, Version 2023.4.0. Section 5.5: Encodings of Note Plaintexts and Memo Fields</a></td>
                     </tr>
                 </tbody>
@@ -802,7 +810,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-actionencodingandconsensus" class="footnote">
                 <tbody>
                     <tr>
-                        <th>28</th>
+                        <th>29</th>
                         <td><a href="protocol/protocol.pdf#actionencodingandconsensus">Zcash Protocol Specification, Version 2023.4.0. Section 7.5: Action Description Encoding and Consensus</a></td>
                     </tr>
                 </tbody>
@@ -810,7 +818,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="initial-zsa-issue" class="footnote">
                 <tbody>
                     <tr>
-                        <th>29</th>
+                        <th>30</th>
                         <td><a href="https://github.com/str4d/zips/blob/zip-udas/drafts/zip-user-defined-assets.rst">User-Defined Assets and Wrapped Assets</a></td>
                     </tr>
                 </tbody>
@@ -818,7 +826,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="generalized-value-commitments" class="footnote">
                 <tbody>
                     <tr>
-                        <th>30</th>
+                        <th>31</th>
                         <td><a href="https://github.com/zcash/zcash/issues/2277#issuecomment-321106819">Comment on Generalized Value Commitments</a></td>
                     </tr>
                 </tbody>
@@ -826,7 +834,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
             <table id="circuit-modifications" class="footnote">
                 <tbody>
                     <tr>
-                        <th>31</th>
+                        <th>32</th>
                         <td><a href="https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing">Modifications to the Orchard circuit for the ZSA Protocol</a></td>
                     </tr>
                 </tbody>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -314,8 +314,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>Issuance requires the following additions to the global state defined at block boundaries:</p>
             <p>A map,
                 <span class="math">\(\mathsf{issued\_assets}\!\)</span>
-            , from the Asset Digest,
-                <span class="math">\(\mathsf{AssetDigest}\)</span>
+            , from the Asset Base,
+                <span class="math">\(\mathsf{AssetBase}\)</span>
             , to a tuple
                 <span class="math">\((\mathsf{balance}, \mathsf{final})\!\)</span>
             , for every Asset that has been issued up until the block boundary. For each Asset:</p>
@@ -329,25 +329,24 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{finalize}\)</span>
                  flag has been set to
                     <span class="math">\(1\)</span>
-                 in some issuance transaction for the Asset preceding the block boundary).</li>
+                 in some issuance transaction for the Asset preceding the block boundary). The value of
+                    <span class="math">\(\mathsf{final}\)</span>
+                 for any Asset cannot be changed from
+                    <span class="math">\(1\)</span>
+                 to
+                    <span class="math">\(0\)</span>
+                .</li>
             </ul>
             <p>We use the notation
-                <span class="math">\(\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{balance}\)</span>
+                <span class="math">\(\mathsf{issued\_assets}(\mathsf{AssetBase}).\!\mathsf{balance}\)</span>
              and
-                <span class="math">\(\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{final}\)</span>
+                <span class="math">\(\mathsf{issued\_assets}(\mathsf{AssetBase}).\!\mathsf{final}\)</span>
              to access, respectively, the balance and finalization status of the Asset stored in the global state.</p>
             <section id="rationale-for-global-issuance-state"><h3><span class="section-heading">Rationale for Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0209">8</a>. However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issued and burnt amounts for a given Asset. Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record at the block boundary based on the issuance and burn transactions within the block. This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.</p>
                 <p>Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. The
                     <span class="math">\(\mathsf{issued\_assets}\)</span>
                  map allows nodes to store whether or not a given Asset has been finalized.</p>
-                <p>Note that while there is only a single pool for ZSAs, the
-                    <span class="math">\(\mathsf{issued\_assets}\)</span>
-                 map can be as specified above, but in future when there are multiple pools, the map will need to be extended to store the balance for the Asset in each pool. The map will be from a tuple of the Asset Digest and an identifier for a shielded pool that supports ZSAs,
-                    <span class="math">\((\mathsf{AssetDigest}, \mathsf{Pool})\!\)</span>
-                , to a tuple of the form
-                    <span class="math">\((\mathsf{balance}, \mathsf{final})\!\)</span>
-                , where the balance is for the specific shielded pool.</p>
             </section>
         </section>
         <section id="specification-issuance-action-issuance-bundle-and-issuance-protocol"><h2><span class="section-heading">Specification: Issuance Action, Issuance Bundle and Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-action-issuance-bundle-and-issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -365,21 +364,6 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{finalize}\)</span>
                      boolean that defines whether the issuance of that specific Custom Asset is finalized or not.</li>
                 </ul>
-                <p>The value of
-                    <span class="math">\(\mathsf{issued\_assets}(AssetDigest).final\)</span>
-                 is set to
-                    <span class="math">\(1\)</span>
-                 after a block that contains any issuance transaction for the Asset corresponding to
-                    <span class="math">\(\mathsf{AssetDigest}`\)</span>
-                 with
-                    <span class="math">\(\mathsf{finalize} = 1\!\)</span>
-                . The value of
-                    <span class="math">\(\mathsf{issued\_assets}(AssetDigest).final\)</span>
-                 cannot be changed from
-                    <span class="math">\(1\)</span>
-                 to
-                    <span class="math">\(0\)</span>
-                .</p>
                 <p>An asset's
                     <span class="math">\(\mathsf{AssetDigest}\)</span>
                  is added to the
@@ -593,7 +577,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{asset\_desc}\)</span>
                  as described in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
                 <li>check that
-                    <span class="math">\(\mathsf{issued\_assets(AssetDigest).final} \neq 1\)</span>
+                    <span class="math">\(\mathsf{issued\_assets(AssetBase).final} \neq 1\)</span>
                  in the global state.</li>
                 <li>check that every note in the <code>IssueAction</code> contains the same
                     <span class="math">\(\mathsf{AssetBase}\)</span>
@@ -612,7 +596,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                             <span class="math">\(\mathsf{cm}\)</span>
                          to the Merkle tree of note commitments.</li>
                         <li>Increase the value of
-                            <span class="math">\(\mathsf{issued\_assets(AssetDigest).balance}\)</span>
+                            <span class="math">\(\mathsf{issued\_assets(AssetBase).balance}\)</span>
                          by the value of the note,
                             <span class="math">\(\mathsf{v}\)</span>
                         .</li>
@@ -621,7 +605,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <li>If
                     <span class="math">\(\mathsf{finalize} = 1\!\)</span>
                 , set
-                    <span class="math">\(\mathsf{issued\_assets(AssetDigest).final}\)</span>
+                    <span class="math">\(\mathsf{issued\_assets(AssetBase).final}\)</span>
                  to
                     <span class="math">\(1\)</span>
                  in the global state immediately after the block in which this transaction occurs.</li>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -26,7 +26,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">7</a>.</p>
-            <p>The terms "Orchard" and "Action" in this document are to be interpreted as described in ZIP 224 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0224">8</a>.</p>
+            <p>The terms "Orchard" and "Action" in this document are to be interpreted as described in ZIP 224 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0224">9</a>.</p>
             <p>We define the following additional terms:</p>
             <ul>
                 <li>Asset: A type of note that can be transferred on the Zcash blockchain. Each Asset is identified by an Asset Identifier <a href="#specification-asset-identifier">Specification: Asset Identifier</a>.
@@ -43,10 +43,10 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </ul>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This ZIP (ZIP 227) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 226 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0226">9</a>. This protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of Custom Assets on the Zcash chain. The creation of such Assets is defined in this ZIP (ZIP 227), while the transfer and burn of such Assets is defined in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">9</a>. This ZIP must only be implemented in conjunction with ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">9</a>. The proposed issuance mechanism is only valid for the Orchard-ZSA transfer protocol, because it produces notes that can only be transferred under ZSA.</p>
+            <p>This ZIP (ZIP 227) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 226 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0226">10</a>. This protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of Custom Assets on the Zcash chain. The creation of such Assets is defined in this ZIP (ZIP 227), while the transfer and burn of such Assets is defined in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">10</a>. This ZIP must only be implemented in conjunction with ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">10</a>. The proposed issuance mechanism is only valid for the Orchard-ZSA transfer protocol, because it produces notes that can only be transferred under ZSA.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This ZIP introduces the issuance mechanism for Custom Assets on the Zcash chain. While originally part of a single ZSA ZIP, the issuance mechanism turned out to be substantial enough to stand on its own and justify the creation of this supporting ZIP for ZIP 226 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0226">9</a>.</p>
+            <p>This ZIP introduces the issuance mechanism for Custom Assets on the Zcash chain. While originally part of a single ZSA ZIP, the issuance mechanism turned out to be substantial enough to stand on its own and justify the creation of this supporting ZIP for ZIP 226 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0226">10</a>.</p>
             <p>This ZIP only enables <em>transparent</em> issuance. As a first step, transparency will allow for proper testing of the applications that will be most used in the Zcash ecosystem, and will enable the supply of Assets to be tracked.</p>
             <p>The issuance mechanism described in this ZIP is broad enough for issuers to either create Assets on Zcash (i.e. Assets that originate on the Zcash blockchain), as well as for institutions to create bridges from other chains and import Wrapped Assets. This enables what we hope will be a useful set of applications.</p>
         </section>
@@ -73,7 +73,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </ul>
         </section>
         <section id="specification-issuance-keys-and-issuance-authorization-signature-scheme"><h2><span class="section-heading">Specification: Issuance Keys and Issuance Authorization Signature Scheme</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-keys-and-issuance-authorization-signature-scheme"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The Orchard-ZSA Protocol adds the following keys to the key components <a id="footnote-reference-8" class="footnote_reference" href="#protocol-addressesandkeys">18</a> <a id="footnote-reference-9" class="footnote_reference" href="#protocol-orchardkeycomponents">19</a>:</p>
+            <p>The Orchard-ZSA Protocol adds the following keys to the key components <a id="footnote-reference-8" class="footnote_reference" href="#protocol-addressesandkeys">19</a> <a id="footnote-reference-9" class="footnote_reference" href="#protocol-orchardkeycomponents">20</a>:</p>
             <ol type="1">
                 <li>The issuance authorizing key, denoted as
                     <span class="math">\(\mathsf{isk}\!\)</span>
@@ -90,7 +90,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <section id="issuance-authorization-signature-scheme"><h3><span class="section-heading">Issuance Authorization Signature Scheme</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-authorization-signature-scheme"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>We instantiate the issuance authorization signature scheme
                     <span class="math">\(\mathsf{IssueAuthSig}\)</span>
-                 as a BIP-340 Schnorr signature over the secp256k1 curve. The signing and validation algorithms, signature encoding, and public key encoding MUST follow BIP 340 <a id="footnote-reference-10" class="footnote_reference" href="#bip-0340">16</a>.</p>
+                 as a BIP-340 Schnorr signature over the secp256k1 curve. The signing and validation algorithms, signature encoding, and public key encoding MUST follow BIP 340 <a id="footnote-reference-10" class="footnote_reference" href="#bip-0340">17</a>.</p>
                 <p>Batch verification MAY be used. Precomputation MAY be used if and only if it produces equivalent results; for example, for a given verification key
                     <span class="math">\(pk\)</span>
                  and
@@ -120,7 +120,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(k\)</span>
                  bytes, and
                     <span class="math">\(\mathbb{B}^{\mathbb{Y}^{[\mathbb{N}]}}\)</span>
-                 denotes the type of byte sequences of arbitrary length, as defined in the Zcash protocol specification <a id="footnote-reference-11" class="footnote_reference" href="#protocol-notation">17</a>.</p>
+                 denotes the type of byte sequences of arbitrary length, as defined in the Zcash protocol specification <a id="footnote-reference-11" class="footnote_reference" href="#protocol-notation">18</a>.</p>
                 <p>The issuance authorizing key generation algorithm and the issuance validating key derivation algorithm are defined in the <a href="#issuance-key-derivation">Issuance Key Derivation</a> section, while the corresponding signing and validation algorithms are defined in the <a href="#issuance-authorization-signing-and-validation">Issuance Authorization Signing and Validation</a> section.</p>
             </section>
             <section id="issuance-key-derivation"><h3><span class="section-heading">Issuance Key Derivation</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-key-derivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -184,7 +184,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                     <p>where the
                         <span class="math">\(\textit{PubKey}\)</span>
-                     algorithm is defined in BIP 340 <a id="footnote-reference-16" class="footnote_reference" href="#bip-0340">16</a>. Note that the byte representation of
+                     algorithm is defined in BIP 340 <a id="footnote-reference-16" class="footnote_reference" href="#bip-0340">17</a>. Note that the byte representation of
                         <span class="math">\(\mathsf{ik}\)</span>
                      is in big-endian order as defined in BIP 340.</p>
                     <p>It is possible for the
@@ -222,7 +222,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{Sign}\)</span>
                  algorithm is defined in BIP 340 and
                     <span class="math">\(a\)</span>
-                 denotes the auxiliary data used in BIP 340 <a id="footnote-reference-18" class="footnote_reference" href="#bip-0340">16</a>. Note that
+                 denotes the auxiliary data used in BIP 340 <a id="footnote-reference-18" class="footnote_reference" href="#bip-0340">17</a>. Note that
                     <span class="math">\(\mathsf{IssueAuthSig}.\!\mathsf{Sign}\)</span>
                  could return
                     <span class="math">\(\bot\)</span>
@@ -246,7 +246,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </ul>
                 <p>where the
                     <span class="math">\(\mathsf{Verify}\)</span>
-                 algorithm is defined in BIP 340 <a id="footnote-reference-19" class="footnote_reference" href="#bip-0340">16</a>.</p>
+                 algorithm is defined in BIP 340 <a id="footnote-reference-19" class="footnote_reference" href="#bip-0340">17</a>.</p>
             </section>
         </section>
         <section id="specification-asset-identifier"><h2><span class="section-heading">Specification: Asset Identifier</span><span class="section-anchor"> <a rel="bookmark" href="#specification-asset-identifier"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -291,7 +291,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <span class="math">\(\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})\)</span>
              where
                 <span class="math">\(\mathsf{GroupHash}^\mathbb{P}\)</span>
-             is defined as in <a id="footnote-reference-20" class="footnote_reference" href="#protocol-concretegrouphashpallasandvesta">20</a>.</p>
+             is defined as in <a id="footnote-reference-20" class="footnote_reference" href="#protocol-concretegrouphashpallasandvesta">21</a>.</p>
             <p>The relations between the Asset Identifier, Asset Digest, and Asset Base are shown in the following diagram:</p>
             <figure class="align-center" align="center">
                 <img width="600" src="assets/images/zip-0227-asset-identifier-relation.png" alt="" />
@@ -312,17 +312,31 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
         </section>
         <section id="specification-global-issuance-state"><h2><span class="section-heading">Specification: Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#specification-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Issuance requires the following additions to the global state defined at block boundaries:</p>
+            <p>A map,
+                <span class="math">\(\mathsf{issued\_assets}\!\)</span>
+            , from the Asset Base,
+                <span class="math">\(\mathsf{AssetBase_{AssetId}}\)</span>
+            , to a tuple
+                <span class="math">\((\mathsf{balance_{AssetId}}, \mathsf{final_{AssetId}})\)</span>
+            , for every Asset that has been issued up until the block boundary.</p>
             <ul>
-                <li>
-                    <span class="math">\(\mathsf{previously\_finalized}\!\)</span>
-                , a set of
-                    <span class="math">\(\mathsf{AssetId}\)</span>
-                 that have been finalized (i.e.: the
+                <li>The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in
+                    <span class="math">\(\mathsf{balance_{AssetId}}\)</span>
+                .</li>
+                <li>The boolean
+                    <span class="math">\(\mathsf{final_{AssetId}}\)</span>
+                 stores the finalization status of the Asset (i.e.: whether the
                     <span class="math">\(\mathsf{finalize}\)</span>
                  flag has been set to
                     <span class="math">\(1\)</span>
                  in some issuance transaction preceding the block boundary).</li>
             </ul>
+            <section id="rationale-for-global-issuance-state"><h3><span class="section-heading">Rationale for Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0209">8</a>. However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issuance and burnt amounts for a given Asset. Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record at the block boundary based on the issuance and burn transactions within the block. This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.</p>
+                <p>Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. The
+                    <span class="math">\(\mathsf{issued\_assets}\!\)</span>
+                 map allows nodes to store whether or not a given Asset has been finalized.</p>
+            </section>
         </section>
         <section id="specification-issuance-action-issuance-bundle-and-issuance-protocol"><h2><span class="section-heading">Specification: Issuance Action, Issuance Bundle and Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-action-issuance-bundle-and-issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="issuance-action-description"><h3><span class="section-heading">Issuance Action Description</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -429,7 +443,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{isk}\!\)</span>
                     , that validates the issuance.</li>
                 </ul>
-                <p>The issuance bundle is then added within the transaction format as a new bundle. That is, issuance requires the addition of the following information to the transaction format <a id="footnote-reference-21" class="footnote_reference" href="#protocol-txnencoding">22</a>.</p>
+                <p>The issuance bundle is then added within the transaction format as a new bundle. That is, issuance requires the addition of the following information to the transaction format <a id="footnote-reference-22" class="footnote_reference" href="#protocol-txnencoding">23</a>.</p>
                 <table>
                     <thead>
                         <tr>
@@ -566,7 +580,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <ul>
                 <li>For each note, compute the note commitment as
                     <span class="math">\(\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\)</span>
-                 as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0226-notestructure">10</a> and</li>
+                 as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0226-notestructure">11</a> and</li>
                 <li>Add
                     <span class="math">\(\mathsf{cm}\)</span>
                  to the Merkle tree of note commitments.</li>
@@ -607,7 +621,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <ul>
                     <li>By using the
                         <span class="math">\(\mathsf{finalize}\)</span>
-                     boolean and the burning mechanism defined in <a id="footnote-reference-23" class="footnote_reference" href="#zip-0226">9</a>, issuers can control the supply production of any Asset associated to their issuer keys. For example,
+                     boolean and the burning mechanism defined in <a id="footnote-reference-24" class="footnote_reference" href="#zip-0226">10</a>, issuers can control the supply production of any Asset associated to their issuer keys. For example,
                         <ul>
                             <li>by setting
                                 <span class="math">\(\mathsf{finalize} = 1\)</span>
@@ -643,7 +657,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="txid-digest-issuance"><h2><span class="section-heading">TxId Digest - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the Orchard-ZSA protocol can be found in ZIP 226 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0226-txiddigest">11</a>. As in ZIP 244 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0244">12</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
+            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the Orchard-ZSA protocol can be found in ZIP 226 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0226-txiddigest">12</a>. As in ZIP 244 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0244">13</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
             <p>A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below:</p>
             <pre>issuance_digest
 ├── issue_actions_digest
@@ -679,7 +693,7 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
                         <p>In case the transaction has no Issue Notes, ''issue_notes_digest'' is:</p>
                         <pre>BLAKE2b-256("ZTxIdIAcNoteHash", [])</pre>
                         <section id="t-5a-i-1-recipient"><h6><span class="section-heading">T.5a.i.1: recipient</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-1-recipient"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">21</a>.</p>
+                            <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-27" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">22</a>.</p>
                         </section>
                         <section id="t-5a-i-2-value"><h6><span class="section-heading">T.5a.i.2: value</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-2-value"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>Note value encoded as little-endian 8-byte representation of 64-bit unsigned integer (e.g. u64 in Rust) raw value.</p>
@@ -713,7 +727,7 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0244-sigdigest">13</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
+            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-28" class="footnote_reference" href="#zip-0244-sigdigest">14</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
             <p>The overall structure of the hash is as follows. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
             <pre>signature_digest
 ├── header_digest
@@ -728,14 +742,14 @@ S.2: transparent_sig_digest (32-byte hash output)
 S.3: sapling_digest         (32-byte hash output)
 S.4: orchard_digest         (32-byte hash output)
 S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-28" class="footnote_reference" href="#zip-0244">12</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0244">13</a>.</p>
                 <section id="s-5-issuance-digest"><h4><span class="section-heading">S.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>Identical to that specified for the transaction identifier.</p>
                 </section>
             </section>
         </section>
         <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0244-authcommitment">14</a> which commits to the authorizing data of a transaction is modified by the Orchard-ZSA protocol to have the following structure. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0244-authcommitment">15</a> which commits to the authorizing data of a transaction is modified by the Orchard-ZSA protocol to have the following structure. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
             <pre>auth_digest
 ├── transparent_scripts_digest
 ├── sapling_auth_digest
@@ -776,7 +790,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 </ul>
             </section>
             <section id="bridging-assets"><h3><span class="section-heading">Bridging Assets</span><span class="section-anchor"> <a rel="bookmark" href="#bridging-assets"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0226">9</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
+                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0226">10</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
             </section>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -790,7 +804,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                  in order to properly keep track of the total supply for different Asset Identifiers. This is useful for wallets and other applications that need to keep track of the total supply of Assets.</p>
             </section>
             <section id="fee-structures"><h3><span class="section-heading">Fee Structures</span><span class="section-anchor"> <a rel="bookmark" href="#fee-structures"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0317b">15</a>.</p>
+                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317 <a id="footnote-reference-32" class="footnote_reference" href="#zip-0317b">16</a>.</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -864,10 +878,18 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0224" class="footnote">
+            <table id="zip-0209" class="footnote">
                 <tbody>
                     <tr>
                         <th>8</th>
+                        <td><a href="zip-0209.html">ZIP 209: Prohibit Negative Shielded Chain Value Pool Balances</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0224" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>9</th>
                         <td><a href="zip-0224.html">ZIP 224: Orchard</a></td>
                     </tr>
                 </tbody>
@@ -875,7 +897,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0226" class="footnote">
                 <tbody>
                     <tr>
-                        <th>9</th>
+                        <th>10</th>
                         <td><a href="zip-0226.html">ZIP 226: Transfer and Burn of Zcash Shielded Assets</a></td>
                     </tr>
                 </tbody>
@@ -883,7 +905,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0226-notestructure" class="footnote">
                 <tbody>
                     <tr>
-                        <th>10</th>
+                        <th>11</th>
                         <td><a href="zip-0226.html#note-structure-commitment">ZIP 226: Transfer and Burn of Zcash Shielded Assets - Note Structure &amp; Commitment</a></td>
                     </tr>
                 </tbody>
@@ -891,7 +913,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0226-txiddigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>11</th>
+                        <th>12</th>
                         <td><a href="zip-0226.html#txid-digest">ZIP 226: Transfer and Burn of Zcash Shielded Assets - TxId Digest</a></td>
                     </tr>
                 </tbody>
@@ -899,7 +921,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>12</th>
+                        <th>13</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -907,7 +929,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244-sigdigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>13</th>
+                        <th>14</th>
                         <td><a href="zip-0244.html#signature-digest">ZIP 244: Transaction Identifier Non-Malleability: Signature Digest</a></td>
                     </tr>
                 </tbody>
@@ -915,7 +937,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244-authcommitment" class="footnote">
                 <tbody>
                     <tr>
-                        <th>14</th>
+                        <th>15</th>
                         <td><a href="zip-0244.html#authorizing-data-commitment">ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
@@ -923,7 +945,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0317b" class="footnote">
                 <tbody>
                     <tr>
-                        <th>15</th>
+                        <th>16</th>
                         <td><a href="https://github.com/zcash/zips/pull/667">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
                     </tr>
                 </tbody>
@@ -931,7 +953,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="bip-0340" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>17</th>
                         <td><a href="https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki">BIP 340: Schnorr Signatures for secp256k1</a></td>
                     </tr>
                 </tbody>
@@ -939,7 +961,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-notation" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
+                        <th>18</th>
                         <td><a href="protocol/protocol.pdf#notation">Zcash Protocol Specification, Version 2023.4.0. Section 2: Notation</a></td>
                     </tr>
                 </tbody>
@@ -947,7 +969,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-addressesandkeys" class="footnote">
                 <tbody>
                     <tr>
-                        <th>18</th>
+                        <th>19</th>
                         <td><a href="protocol/protocol.pdf#addressesandkeys">Zcash Protocol Specification, Version 2023.4.0. Section 3.1: Payment Addresses and Keys</a></td>
                     </tr>
                 </tbody>
@@ -955,7 +977,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-orchardkeycomponents" class="footnote">
                 <tbody>
                     <tr>
-                        <th>19</th>
+                        <th>20</th>
                         <td><a href="protocol/protocol.pdf#orchardkeycomponents">Zcash Protocol Specification, Version 2023.4.0. Section 4.2.3: Orchard Key Components</a></td>
                     </tr>
                 </tbody>
@@ -963,7 +985,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-concretegrouphashpallasandvesta" class="footnote">
                 <tbody>
                     <tr>
-                        <th>20</th>
+                        <th>21</th>
                         <td><a href="protocol/protocol.pdf#concretegrouphashpallasandvesta">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.9.8: Group Hash into Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
@@ -971,7 +993,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-orchardpaymentaddrencoding" class="footnote">
                 <tbody>
                     <tr>
-                        <th>21</th>
+                        <th>22</th>
                         <td><a href="protocol/protocol.pdf#orchardpaymentaddrencoding">Zcash Protocol Specification, Version 2023.4.0. Section 5.6.4.2: Orchard Raw Payment Addresses</a></td>
                     </tr>
                 </tbody>
@@ -979,7 +1001,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-txnencoding" class="footnote">
                 <tbody>
                     <tr>
-                        <th>22</th>
+                        <th>23</th>
                         <td><a href="protocol/protocol.pdf#txnencoding">Zcash Protocol Specification, Version 2023.4.0. Section 7.1: Transaction Encoding and Consensus (Transaction Version 5)</a></td>
                     </tr>
                 </tbody>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -314,28 +314,48 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>Issuance requires the following additions to the global state defined at block boundaries:</p>
             <p>A map,
                 <span class="math">\(\mathsf{issued\_assets}\!\)</span>
-            , from the Asset Base,
-                <span class="math">\(\mathsf{AssetBase_{AssetId}}\)</span>
+            , from the Asset Digest,
+                <span class="math">\(\mathsf{AssetDigest}\)</span>
+             corresponding to an Asset Identifier
+                <span class="math">\(\mathsf{AId}\)</span>
             , to a tuple
-                <span class="math">\((\mathsf{balance_{AssetId}}, \mathsf{final_{AssetId}})\)</span>
+                <span class="math">\((\mathsf{balance_{AId}}, \mathsf{final_{AId}})\)</span>
             , for every Asset that has been issued up until the block boundary.</p>
             <ul>
                 <li>The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in
-                    <span class="math">\(\mathsf{balance_{AssetId}}\)</span>
+                    <span class="math">\(\mathsf{balance_{AId}}\)</span>
                 .</li>
                 <li>The boolean
-                    <span class="math">\(\mathsf{final_{AssetId}}\)</span>
+                    <span class="math">\(\mathsf{final_{AId}}\)</span>
                  stores the finalization status of the Asset (i.e.: whether the
                     <span class="math">\(\mathsf{finalize}\)</span>
                  flag has been set to
                     <span class="math">\(1\)</span>
-                 in some issuance transaction preceding the block boundary).</li>
+                 in some issuance transaction for Asset
+                    <span class="math">\(\mathsf{AId}\)</span>
+                 preceding the block boundary).</li>
             </ul>
+            <p>We use the notation
+                <span class="math">\(\mathsf{issued\_assets}(AssetDigest)\)</span>
+             to refer to the tuple,
+                <span class="math">\((\mathsf{balance_{AId}}, \mathsf{final_{AId}})\)</span>
+            . Further, we use the notation
+                <span class="math">\(\mathsf{issued\_assets}(AssetDigest).balance\)</span>
+             and
+                <span class="math">\(\mathsf{issued\_assets}(AssetDigest).final\)</span>
+             to refer to the balance and finalization status of the Asset, respectively.</p>
             <section id="rationale-for-global-issuance-state"><h3><span class="section-heading">Rationale for Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0209">8</a>. However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issuance and burnt amounts for a given Asset. Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record at the block boundary based on the issuance and burn transactions within the block. This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.</p>
+                <p>It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0209">8</a>. However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issued and burnt amounts for a given Asset. Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record at the block boundary based on the issuance and burn transactions within the block. This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.</p>
                 <p>Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. The
                     <span class="math">\(\mathsf{issued\_assets}\!\)</span>
                  map allows nodes to store whether or not a given Asset has been finalized.</p>
+                <p>Note that while there is only a single pool for ZSAs, the
+                    <span class="math">\(\mathsf{issued\_assets}\)</span>
+                 map can be as specified above, but in future when there are multiple pools, the map will need to be extended to store the balance for the Asset in each pool. That is, the map will be from the Asset Digest
+                    <span class="math">\(\mathsf{AssetDigest}\)</span>
+                 to a tuple of the form
+                    <span class="math">\(((\mathsf{balance_{AId}^{OrchardZSA}}, \mathsf{balance_{AId}^{NewPool}}, \ldots), \mathsf{final_{AId}})\)</span>
+                , with one balance entry for each pool that supports ZSAs.</p>
             </section>
         </section>
         <section id="specification-issuance-action-issuance-bundle-and-issuance-protocol"><h2><span class="section-heading">Specification: Issuance Action, Issuance Bundle and Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-action-issuance-bundle-and-issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -353,6 +373,21 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{finalize}\)</span>
                      boolean that defines whether the issuance of that specific Custom Asset is finalized or not.</li>
                 </ul>
+                <p>The value of
+                    <span class="math">\(\mathsf{issued\_assets}(AssetDigest).final\)</span>
+                 is set to
+                    <span class="math">\(1\)</span>
+                 after a block that contains any issuance transaction for the Asset corresponding to
+                    <span class="math">\(\mathsf{AssetDigest}`\)</span>
+                 with
+                    <span class="math">\(\mathsf{finalize} = 1\!\)</span>
+                . The value of
+                    <span class="math">\(\mathsf{issued\_assets}(AssetDigest).final\)</span>
+                 cannot be changed from
+                    <span class="math">\(1\)</span>
+                 to
+                    <span class="math">\(0\)</span>
+                .</p>
                 <p>An asset's
                     <span class="math">\(\mathsf{AssetDigest}\)</span>
                  is added to the
@@ -565,11 +600,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  and
                     <span class="math">\(\mathsf{asset\_desc}\)</span>
                  as described in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
-                <li>check that the
-                    <span class="math">\(\mathsf{AssetDigest}\)</span>
-                 does not exist in the
-                    <span class="math">\(\mathsf{previously\_finalized}\)</span>
-                 set in the global state.</li>
+                <li>check that
+                    <span class="math">\(\mathsf{issued\_assets(AssetDigest).final} \neq 1\)</span>
+                 in the global state.</li>
                 <li>check that every note in the <code>IssueAction</code> contains the same
                     <span class="math">\(\mathsf{AssetBase}\)</span>
                  and is properly constructed as
@@ -578,19 +611,28 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </ul>
             <p>If all of the above checks pass, do the following:</p>
             <ul>
-                <li>For each note, compute the note commitment as
-                    <span class="math">\(\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\)</span>
-                 as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0226-notestructure">11</a> and</li>
-                <li>Add
-                    <span class="math">\(\mathsf{cm}\)</span>
-                 to the Merkle tree of note commitments.</li>
+                <li>For each note,
+                    <ul>
+                        <li>compute the note commitment as
+                            <span class="math">\(\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\)</span>
+                         as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0226-notestructure">11</a>.</li>
+                        <li>Add
+                            <span class="math">\(\mathsf{cm}\)</span>
+                         to the Merkle tree of note commitments.</li>
+                        <li>Increase the value of
+                            <span class="math">\(\mathsf{issued\_assets(AssetDigest).balance}\)</span>
+                         by the value of the note,
+                            <span class="math">\(\mathsf{v}\)</span>
+                        .</li>
+                    </ul>
+                </li>
                 <li>If
                     <span class="math">\(\mathsf{finalize} = 1\!\)</span>
-                , add
-                    <span class="math">\(\mathsf{AssetDigest}\)</span>
-                 to the
-                    <span class="math">\(\mathsf{previously\_finalized}\)</span>
-                 set immediately after the block in which this transaction occurs.</li>
+                , set
+                    <span class="math">\(\mathsf{issued\_assets(AssetDigest).final}\)</span>
+                 to
+                    <span class="math">\(1\)</span>
+                 in the global state immediately after the block in which this transaction occurs.</li>
                 <li>(Replay Protection) If issue bundle is present, the fees MUST be greater than zero.</li>
             </ul>
         </section>
@@ -612,8 +654,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <li>We require a check whether the
                     <span class="math">\(\mathsf{finalize}\)</span>
                  flag only has been set in a previous block rather than a previous transaction in the same block. In other words, we only update the
-                    <span class="math">\(\mathsf{previously\_finalized}`\)</span>
-                 set at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.</li>
+                    <span class="math">\(\mathsf{issued\_assets}\)</span>
+                 map at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.</li>
                 <li>We require non-zero fees in the presence of an issue bundle, in order to preclude the possibility of a transaction containing only an issue bundle. If a transaction includes only an issue bundle, the SIGHASH transaction hash would be computed solely based on the issue bundle. A duplicate bundle would have the same SIGHASH transaction hash, potentially allowing for a replay attack.</li>
             </ul>
             <section id="concrete-applications"><h3><span class="section-heading">Concrete Applications</span><span class="section-anchor"> <a rel="bookmark" href="#concrete-applications"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -316,46 +316,38 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <span class="math">\(\mathsf{issued\_assets}\!\)</span>
             , from the Asset Digest,
                 <span class="math">\(\mathsf{AssetDigest}\)</span>
-             corresponding to an Asset Identifier
-                <span class="math">\(\mathsf{AId}\)</span>
             , to a tuple
-                <span class="math">\((\mathsf{balance_{AId}}, \mathsf{final_{AId}})\)</span>
-            , for every Asset that has been issued up until the block boundary.</p>
+                <span class="math">\((\mathsf{balance}, \mathsf{final})\!\)</span>
+            , for every Asset that has been issued up until the block boundary. For each Asset:</p>
             <ul>
                 <li>The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in
-                    <span class="math">\(\mathsf{balance_{AId}}\)</span>
+                    <span class="math">\(\mathsf{balance}\!\)</span>
                 .</li>
                 <li>The boolean
-                    <span class="math">\(\mathsf{final_{AId}}\)</span>
+                    <span class="math">\(\mathsf{final}\)</span>
                  stores the finalization status of the Asset (i.e.: whether the
                     <span class="math">\(\mathsf{finalize}\)</span>
                  flag has been set to
                     <span class="math">\(1\)</span>
-                 in some issuance transaction for Asset
-                    <span class="math">\(\mathsf{AId}\)</span>
-                 preceding the block boundary).</li>
+                 in some issuance transaction for the Asset preceding the block boundary).</li>
             </ul>
             <p>We use the notation
-                <span class="math">\(\mathsf{issued\_assets}(AssetDigest)\)</span>
-             to refer to the tuple,
-                <span class="math">\((\mathsf{balance_{AId}}, \mathsf{final_{AId}})\)</span>
-            . Further, we use the notation
-                <span class="math">\(\mathsf{issued\_assets}(AssetDigest).balance\)</span>
+                <span class="math">\(\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{balance}\)</span>
              and
-                <span class="math">\(\mathsf{issued\_assets}(AssetDigest).final\)</span>
-             to refer to the balance and finalization status of the Asset, respectively.</p>
+                <span class="math">\(\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{final}\)</span>
+             to access, respectively, the balance and finalization status of the Asset stored in the global state.</p>
             <section id="rationale-for-global-issuance-state"><h3><span class="section-heading">Rationale for Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0209">8</a>. However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issued and burnt amounts for a given Asset. Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record at the block boundary based on the issuance and burn transactions within the block. This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.</p>
                 <p>Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. The
-                    <span class="math">\(\mathsf{issued\_assets}\!\)</span>
+                    <span class="math">\(\mathsf{issued\_assets}\)</span>
                  map allows nodes to store whether or not a given Asset has been finalized.</p>
                 <p>Note that while there is only a single pool for ZSAs, the
                     <span class="math">\(\mathsf{issued\_assets}\)</span>
-                 map can be as specified above, but in future when there are multiple pools, the map will need to be extended to store the balance for the Asset in each pool. That is, the map will be from the Asset Digest
-                    <span class="math">\(\mathsf{AssetDigest}\)</span>
-                 to a tuple of the form
-                    <span class="math">\(((\mathsf{balance_{AId}^{OrchardZSA}}, \mathsf{balance_{AId}^{NewPool}}, \ldots), \mathsf{final_{AId}})\)</span>
-                , with one balance entry for each pool that supports ZSAs.</p>
+                 map can be as specified above, but in future when there are multiple pools, the map will need to be extended to store the balance for the Asset in each pool. The map will be from a tuple of the Asset Digest and an identifier for a shielded pool that supports ZSAs,
+                    <span class="math">\((\mathsf{AssetDigest}, \mathsf{Pool})\!\)</span>
+                , to a tuple of the form
+                    <span class="math">\((\mathsf{balance}, \mathsf{final})\!\)</span>
+                , where the balance is for the specific shielded pool.</p>
             </section>
         </section>
         <section id="specification-issuance-action-issuance-bundle-and-issuance-protocol"><h2><span class="section-heading">Specification: Issuance Action, Issuance Bundle and Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-action-issuance-bundle-and-issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -185,9 +185,9 @@ Additional Consensus Rules
 1. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{AssetBase} \neq \mathcal{V}^{\mathsf{Orchard}}\!`. That is, ZEC or TAZ is not allowed to be burnt by this mechanism.
 2. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{v} \neq 0\!`.
 3. Check that there is no duplication of Custom Assets in the :math:`\mathsf{assetBurn}` set. That is, every :math:`\mathsf{AssetBase}` has at most one entry in :math:`\mathsf{assetBurn}\!`.
-4. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, :math:`\mathsf{v} \leq \mathsf{issued\_assets(AssetDigest).balance}\!`, where the map :math:`\mathsf{issued\_assets}` is defined in ZIP 227 [#zip-0227-specification-global-issuance-state]_. That is, it is not possible to burn more of an Asset than is currently in circulation.
+4. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, :math:`\mathsf{v} \leq \mathsf{issued\_assets(AssetBase).balance}\!`, where the map :math:`\mathsf{issued\_assets}` is defined in ZIP 227 [#zip-0227-specification-global-issuance-state]_. That is, it is not possible to burn more of an Asset than is currently in circulation.
 
-If all these checks pass, then for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, reduce the value of :math:`\mathsf{issued\_assets(AssetDigest).balance}` in the global state by :math:`\mathsf{v}\!`.
+If all these checks pass, then for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, reduce the value of :math:`\mathsf{issued\_assets(AssetBase).balance}` in the global state by :math:`\mathsf{v}\!`.
 
 **Note:** Even if this mechanism allows having transparent ↔ shielded Asset transfers in theory, the transparent protocol will not be changed with this ZIP to adapt to a multiple Asset structure. This means that unless future consensus rules changes do allow it, unshielding will not be possible for Custom Assets.
 

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -182,9 +182,12 @@ We denote by :math:`L` the cardinality of the :math:`\mathsf{assetBurn}` set.
 Additional Consensus Rules
 ``````````````````````````
 
-1. We require that for every :math:`(\mathsf{AssetBase_{AssetId}}, \mathsf{v_{AssetId}}) \in \mathsf{assetBurn}, \mathsf{AssetBase_{AssetId}} \neq \mathcal{V}^{\mathsf{Orchard}}\!`. That is, ZEC or TAZ is not allowed to be burnt by this mechanism.
-2. We require that for every :math:`(\mathsf{AssetBase_{AssetId}}, \mathsf{v_{AssetId}}) \in \mathsf{assetBurn}, \mathsf{v_{AssetId}} \neq 0\!`.
-3. We require that there be no duplication of Custom Assets in the :math:`\mathsf{assetBurn}` set. That is, every :math:`\mathsf{AssetBase_{AssetId}}` has at most one entry in :math:`\mathsf{assetBurn}\!`.
+1. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{AssetBase} \neq \mathcal{V}^{\mathsf{Orchard}}\!`. That is, ZEC or TAZ is not allowed to be burnt by this mechanism.
+2. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{v} \neq 0\!`.
+3. Check that there is no duplication of Custom Assets in the :math:`\mathsf{assetBurn}` set. That is, every :math:`\mathsf{AssetBase}` has at most one entry in :math:`\mathsf{assetBurn}\!`.
+4. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, :math:`\mathsf{v} \leq \mathsf{issued\_assets(AssetDigest).balance}\!`, where the map :math:`\mathsf{issued\_assets}` is defined in ZIP 227 [#zip-0227]_. That is, it is not possible to burn more of an Asset than is currently in circulation.
+
+If all these checks pass, then for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, reduce the value of :math:`\mathsf{issued\_assets(AssetDigest).balance}` in the global state by :math:`\mathsf{v}\!`.
 
 **Note:** Even if this mechanism allows having transparent ↔ shielded Asset transfers in theory, the transparent protocol will not be changed with this ZIP to adapt to a multiple Asset structure. This means that unless future consensus rules changes do allow it, unshielding will not be possible for Custom Assets.
 

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -185,7 +185,7 @@ Additional Consensus Rules
 1. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{AssetBase} \neq \mathcal{V}^{\mathsf{Orchard}}\!`. That is, ZEC or TAZ is not allowed to be burnt by this mechanism.
 2. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{v} \neq 0\!`.
 3. Check that there is no duplication of Custom Assets in the :math:`\mathsf{assetBurn}` set. That is, every :math:`\mathsf{AssetBase}` has at most one entry in :math:`\mathsf{assetBurn}\!`.
-4. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, :math:`\mathsf{v} \leq \mathsf{issued\_assets(AssetDigest).balance}\!`, where the map :math:`\mathsf{issued\_assets}` is defined in ZIP 227 [#zip-0227]_. That is, it is not possible to burn more of an Asset than is currently in circulation.
+4. Check that for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, :math:`\mathsf{v} \leq \mathsf{issued\_assets(AssetDigest).balance}\!`, where the map :math:`\mathsf{issued\_assets}` is defined in ZIP 227 [#zip-0227-specification-global-issuance-state]_. That is, it is not possible to burn more of an Asset than is currently in circulation.
 
 If all these checks pass, then for every :math:`(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!`, reduce the value of :math:`\mathsf{issued\_assets(AssetDigest).balance}` in the global state by :math:`\mathsf{v}\!`.
 
@@ -494,6 +494,7 @@ References
 .. [#zip-0209] `ZIP 209: Prohibit Negative Shielded Chain Value Pool Balances <zip-0209.html>`_
 .. [#zip-0224] `ZIP 224: Orchard <zip-0224.html>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.html>`_
+.. [#zip-0227-specification-global-issuance-state] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Global Issuance State <zip-0227.html#specification-global-issuance-state>`_
 .. [#zip-0227-assetidentifier] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier <zip-0227.html#specification-asset-identifier>`_
 .. [#zip-0227-txiddigest] `ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance <zip-0227.html#txid-digest-issuance>`_
 .. [#zip-0227-sigdigest] `ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest <zip-0227.html#signature-digest>`_

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -221,13 +221,12 @@ Specification: Global Issuance State
 
 Issuance requires the following additions to the global state defined at block boundaries:
 
-A map, :math:`\mathsf{issued\_assets}\!`, from the Asset Digest, :math:`\mathsf{AssetDigest}` corresponding to an Asset Identifier :math:`\mathsf{AId}`, to a tuple :math:`(\mathsf{balance_{AId}}, \mathsf{final_{AId}})`, for every Asset that has been issued up until the block boundary.
+A map, :math:`\mathsf{issued\_assets}\!`, from the Asset Digest, :math:`\mathsf{AssetDigest}`, to a tuple :math:`(\mathsf{balance}, \mathsf{final})\!`, for every Asset that has been issued up until the block boundary. For each Asset:
 
-- The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in :math:`\mathsf{balance_{AId}}`.
-- The boolean :math:`\mathsf{final_{AId}}` stores the finalization status of the Asset (i.e.: whether the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction for Asset :math:`\mathsf{AId}` preceding the block boundary).
+- The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in :math:`\mathsf{balance}\!`.
+- The boolean :math:`\mathsf{final}` stores the finalization status of the Asset (i.e.: whether the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction for the Asset preceding the block boundary).
 
-We use the notation :math:`\mathsf{issued\_assets}(AssetDigest)` to refer to the tuple, :math:`(\mathsf{balance_{AId}}, \mathsf{final_{AId}})`.
-Further, we use the notation :math:`\mathsf{issued\_assets}(AssetDigest).balance` and :math:`\mathsf{issued\_assets}(AssetDigest).final` to refer to the balance and finalization status of the Asset, respectively.
+We use the notation :math:`\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{balance}` and :math:`\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{final}` to access, respectively, the balance and finalization status of the Asset stored in the global state.
 
 Rationale for Global Issuance State
 -----------------------------------
@@ -238,10 +237,10 @@ Therefore, we require that all nodes maintain a record of the current amount in 
 This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.
 
 Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. 
-The :math:`\mathsf{issued\_assets}\!` map allows nodes to store whether or not a given Asset has been finalized. 
+The :math:`\mathsf{issued\_assets}` map allows nodes to store whether or not a given Asset has been finalized. 
 
 Note that while there is only a single pool for ZSAs, the :math:`\mathsf{issued\_assets}` map can be as specified above, but in future when there are multiple pools, the map will need to be extended to store the balance for the Asset in each pool.
-That is, the map will be from the Asset Digest :math:`\mathsf{AssetDigest}` to a tuple of the form :math:`((\mathsf{balance_{AId}^{OrchardZSA}}, \mathsf{balance_{AId}^{NewPool}}, \ldots), \mathsf{final_{AId}})`, with one balance entry for each pool that supports ZSAs.
+The map will be from a tuple of the Asset Digest and an identifier for a shielded pool that supports ZSAs, :math:`(\mathsf{AssetDigest}, \mathsf{Pool})\!`, to a tuple of the form :math:`(\mathsf{balance}, \mathsf{final})\!`, where the balance is for the specific shielded pool.
 
 Specification: Issuance Action, Issuance Bundle and Issuance Protocol
 =====================================================================

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -221,12 +221,13 @@ Specification: Global Issuance State
 
 Issuance requires the following additions to the global state defined at block boundaries:
 
-A map, :math:`\mathsf{issued\_assets}\!`, from the Asset Digest, :math:`\mathsf{AssetDigest}`, to a tuple :math:`(\mathsf{balance}, \mathsf{final})\!`, for every Asset that has been issued up until the block boundary. For each Asset:
+A map, :math:`\mathsf{issued\_assets}\!`, from the Asset Base, :math:`\mathsf{AssetBase}`, to a tuple :math:`(\mathsf{balance}, \mathsf{final})\!`, for every Asset that has been issued up until the block boundary. For each Asset:
 
 - The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in :math:`\mathsf{balance}\!`.
-- The boolean :math:`\mathsf{final}` stores the finalization status of the Asset (i.e.: whether the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction for the Asset preceding the block boundary).
+- The boolean :math:`\mathsf{final}` stores the finalization status of the Asset (i.e.: whether the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction for the Asset preceding the block boundary). The value of :math:`\mathsf{final}` for any Asset cannot be changed from :math:`1` to :math:`0`.
 
-We use the notation :math:`\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{balance}` and :math:`\mathsf{issued\_assets}(\mathsf{AssetDigest}).\!\mathsf{final}` to access, respectively, the balance and finalization status of the Asset stored in the global state.
+
+We use the notation :math:`\mathsf{issued\_assets}(\mathsf{AssetBase}).\!\mathsf{balance}` and :math:`\mathsf{issued\_assets}(\mathsf{AssetBase}).\!\mathsf{final}` to access, respectively, the balance and finalization status of the Asset stored in the global state.
 
 Rationale for Global Issuance State
 -----------------------------------
@@ -238,9 +239,6 @@ This allows for efficient detection of balance violations for any Asset, in whic
 
 Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. 
 The :math:`\mathsf{issued\_assets}` map allows nodes to store whether or not a given Asset has been finalized. 
-
-Note that while there is only a single pool for ZSAs, the :math:`\mathsf{issued\_assets}` map can be as specified above, but in future when there are multiple pools, the map will need to be extended to store the balance for the Asset in each pool.
-The map will be from a tuple of the Asset Digest and an identifier for a shielded pool that supports ZSAs, :math:`(\mathsf{AssetDigest}, \mathsf{Pool})\!`, to a tuple of the form :math:`(\mathsf{balance}, \mathsf{final})\!`, where the balance is for the specific shielded pool.
 
 Specification: Issuance Action, Issuance Bundle and Issuance Protocol
 =====================================================================
@@ -254,10 +252,6 @@ An issuance action, ``IssueAction``, is the instance of issuing a specific Custo
 - ``asset_desc``: the Asset description, a byte string of up to 512 bytes as defined in the `Specification: Asset Identifier`_ section.
 - ``vNotes``: an array of ``Note`` containing the unencrypted output notes of the recipients of the Asset.
 - ``flagsIssuance``: a byte that stores the :math:`\mathsf{finalize}` boolean that defines whether the issuance of that specific Custom Asset is finalized or not.
-
-The value of :math:`\mathsf{issued\_assets}(AssetDigest).final` is set to :math:`1` after a block that contains any issuance transaction for the Asset corresponding to :math:`\mathsf{AssetDigest}`` with :math:`\mathsf{finalize} = 1\!`.
-The value of :math:`\mathsf{issued\_assets}(AssetDigest).final` cannot be changed from :math:`1` to :math:`0`.
-
 
 An asset's :math:`\mathsf{AssetDigest}` is added to the :math:`\mathsf{previously\_finalized}` set after a block that contains any issuance transaction for that asset with :math:`\mathsf{finalize} = 1\!`. It then cannot be removed from this set. For Assets with :math:`\mathsf{AssetDigest} \in \mathsf{previously\_finalized}\!`, no further tokens can be issued, so as seen below, the validators will reject the transaction. For Assets with :math:`\mathsf{AssetDigest} \not\in \mathsf{previously\_finalized}\!`, new issuance actions can be issued in future transactions. These must use the same Asset description, :math:`\mathsf{asset\_desc}\!`, and can either maintain :math:`\mathsf{finalize} = 0` or change it to :math:`\mathsf{finalize} = 1\!`, denoting that this Custom Asset cannot be issued after the containing block.
 
@@ -350,7 +344,7 @@ For each ``IssueAction`` in ``IssueBundle``:
 - check that :math:`\mathsf{asset\_desc}` is a string of length :math:`\mathtt{assetDescSize}` bytes.
 
 - retrieve :math:`\mathsf{AssetBase}` from the first note in the sequence and check that :math:`\mathsf{AssetBase}` is derived from the issuance validating key :math:`\mathsf{ik}` and :math:`\mathsf{asset\_desc}` as described in the `Specification: Asset Identifier`_ section.
-- check that :math:`\mathsf{issued\_assets(AssetDigest).final} \neq 1` in the global state.
+- check that :math:`\mathsf{issued\_assets(AssetBase).final} \neq 1` in the global state.
 - check that every note in the ``IssueAction`` contains the same :math:`\mathsf{AssetBase}` and is properly constructed as :math:`\mathsf{note} = (\mathsf{g_d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \mathsf{rseed}, \mathsf{AssetBase})\!`.
 
 If all of the above checks pass, do the following:
@@ -359,9 +353,9 @@ If all of the above checks pass, do the following:
 
   - compute the note commitment as :math:`\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})` as defined in the Note Structure and Commitment section of ZIP 226 [#zip-0226-notestructure]_.
   - Add :math:`\mathsf{cm}` to the Merkle tree of note commitments.
-  - Increase the value of :math:`\mathsf{issued\_assets(AssetDigest).balance}` by the value of the note, :math:`\mathsf{v}`.
+  - Increase the value of :math:`\mathsf{issued\_assets(AssetBase).balance}` by the value of the note, :math:`\mathsf{v}`.
 
-- If :math:`\mathsf{finalize} = 1\!`, set :math:`\mathsf{issued\_assets(AssetDigest).final}` to :math:`1` in the global state immediately after the block in which this transaction occurs.
+- If :math:`\mathsf{finalize} = 1\!`, set :math:`\mathsf{issued\_assets(AssetBase).final}` to :math:`1` in the global state immediately after the block in which this transaction occurs.
 
 - (Replay Protection) If issue bundle is present, the fees MUST be greater than zero.
 

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -221,21 +221,27 @@ Specification: Global Issuance State
 
 Issuance requires the following additions to the global state defined at block boundaries:
 
-A map, :math:`\mathsf{issued\_assets}\!`, from the Asset Base, :math:`\mathsf{AssetBase_{AssetId}}`, to a tuple :math:`(\mathsf{balance_{AssetId}}, \mathsf{final_{AssetId}})`, for every Asset that has been issued up until the block boundary.
+A map, :math:`\mathsf{issued\_assets}\!`, from the Asset Digest, :math:`\mathsf{AssetDigest}` corresponding to an Asset Identifier :math:`\mathsf{AId}`, to a tuple :math:`(\mathsf{balance_{AId}}, \mathsf{final_{AId}})`, for every Asset that has been issued up until the block boundary.
 
-- The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in :math:`\mathsf{balance_{AssetId}}`.
-- The boolean :math:`\mathsf{final_{AssetId}}` stores the finalization status of the Asset (i.e.: whether the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction preceding the block boundary).
+- The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in :math:`\mathsf{balance_{AId}}`.
+- The boolean :math:`\mathsf{final_{AId}}` stores the finalization status of the Asset (i.e.: whether the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction for Asset :math:`\mathsf{AId}` preceding the block boundary).
+
+We use the notation :math:`\mathsf{issued\_assets}(AssetDigest)` to refer to the tuple, :math:`(\mathsf{balance_{AId}}, \mathsf{final_{AId}})`.
+Further, we use the notation :math:`\mathsf{issued\_assets}(AssetDigest).balance` and :math:`\mathsf{issued\_assets}(AssetDigest).final` to refer to the balance and finalization status of the Asset, respectively.
 
 Rationale for Global Issuance State
 -----------------------------------
 
 It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 [#zip-0209]_. 
-However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issuance and burnt amounts for a given Asset.
+However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issued and burnt amounts for a given Asset.
 Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record at the block boundary based on the issuance and burn transactions within the block. 
 This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.
 
 Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. 
 The :math:`\mathsf{issued\_assets}\!` map allows nodes to store whether or not a given Asset has been finalized. 
+
+Note that while there is only a single pool for ZSAs, the :math:`\mathsf{issued\_assets}` map can be as specified above, but in future when there are multiple pools, the map will need to be extended to store the balance for the Asset in each pool.
+That is, the map will be from the Asset Digest :math:`\mathsf{AssetDigest}` to a tuple of the form :math:`((\mathsf{balance_{AId}^{OrchardZSA}}, \mathsf{balance_{AId}^{NewPool}}, \ldots), \mathsf{final_{AId}})`, with one balance entry for each pool that supports ZSAs.
 
 Specification: Issuance Action, Issuance Bundle and Issuance Protocol
 =====================================================================
@@ -250,6 +256,8 @@ An issuance action, ``IssueAction``, is the instance of issuing a specific Custo
 - ``vNotes``: an array of ``Note`` containing the unencrypted output notes of the recipients of the Asset.
 - ``flagsIssuance``: a byte that stores the :math:`\mathsf{finalize}` boolean that defines whether the issuance of that specific Custom Asset is finalized or not.
 
+The value of :math:`\mathsf{issued\_assets}(AssetDigest).final` is set to :math:`1` after a block that contains any issuance transaction for the Asset corresponding to :math:`\mathsf{AssetDigest}`` with :math:`\mathsf{finalize} = 1\!`.
+The value of :math:`\mathsf{issued\_assets}(AssetDigest).final` cannot be changed from :math:`1` to :math:`0`.
 
 
 An asset's :math:`\mathsf{AssetDigest}` is added to the :math:`\mathsf{previously\_finalized}` set after a block that contains any issuance transaction for that asset with :math:`\mathsf{finalize} = 1\!`. It then cannot be removed from this set. For Assets with :math:`\mathsf{AssetDigest} \in \mathsf{previously\_finalized}\!`, no further tokens can be issued, so as seen below, the validators will reject the transaction. For Assets with :math:`\mathsf{AssetDigest} \not\in \mathsf{previously\_finalized}\!`, new issuance actions can be issued in future transactions. These must use the same Asset description, :math:`\mathsf{asset\_desc}\!`, and can either maintain :math:`\mathsf{finalize} = 0` or change it to :math:`\mathsf{finalize} = 1\!`, denoting that this Custom Asset cannot be issued after the containing block.
@@ -343,14 +351,19 @@ For each ``IssueAction`` in ``IssueBundle``:
 - check that :math:`\mathsf{asset\_desc}` is a string of length :math:`\mathtt{assetDescSize}` bytes.
 
 - retrieve :math:`\mathsf{AssetBase}` from the first note in the sequence and check that :math:`\mathsf{AssetBase}` is derived from the issuance validating key :math:`\mathsf{ik}` and :math:`\mathsf{asset\_desc}` as described in the `Specification: Asset Identifier`_ section.
-- check that the :math:`\mathsf{AssetDigest}` does not exist in the :math:`\mathsf{previously\_finalized}` set in the global state.
+- check that :math:`\mathsf{issued\_assets(AssetDigest).final} \neq 1` in the global state.
 - check that every note in the ``IssueAction`` contains the same :math:`\mathsf{AssetBase}` and is properly constructed as :math:`\mathsf{note} = (\mathsf{g_d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \mathsf{rseed}, \mathsf{AssetBase})\!`.
 
 If all of the above checks pass, do the following:
 
-- For each note, compute the note commitment as :math:`\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})` as defined in the Note Structure and Commitment section of ZIP 226 [#zip-0226-notestructure]_ and
-- Add :math:`\mathsf{cm}` to the Merkle tree of note commitments.
-- If :math:`\mathsf{finalize} = 1\!`, add :math:`\mathsf{AssetDigest}` to the :math:`\mathsf{previously\_finalized}` set immediately after the block in which this transaction occurs.
+- For each note, 
+
+  - compute the note commitment as :math:`\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})` as defined in the Note Structure and Commitment section of ZIP 226 [#zip-0226-notestructure]_.
+  - Add :math:`\mathsf{cm}` to the Merkle tree of note commitments.
+  - Increase the value of :math:`\mathsf{issued\_assets(AssetDigest).balance}` by the value of the note, :math:`\mathsf{v}`.
+
+- If :math:`\mathsf{finalize} = 1\!`, set :math:`\mathsf{issued\_assets(AssetDigest).final}` to :math:`1` in the global state immediately after the block in which this transaction occurs.
+
 - (Replay Protection) If issue bundle is present, the fees MUST be greater than zero.
 
 
@@ -368,7 +381,7 @@ The following is a list of rationale for different decisions made in the proposa
     - bridging information for Wrapped Assets (chain of origin, issuer name, etc)
     - information to be committed by the issuer, though not enforceable by the protocol.
 
-- We require a check whether the :math:`\mathsf{finalize}` flag only has been set in a previous block rather than a previous transaction in the same block. In other words, we only update the :math:`\mathsf{previously\_finalized}`` set at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.
+- We require a check whether the :math:`\mathsf{finalize}` flag only has been set in a previous block rather than a previous transaction in the same block. In other words, we only update the :math:`\mathsf{issued\_assets}` map at the block boundary. This is in keeping with the current property which allows for a miner to reorder transactions in a block without changing the meaning, which we aim to preserve.
 - We require non-zero fees in the presence of an issue bundle, in order to preclude the possibility of a transaction containing only an issue bundle. If a transaction includes only an issue bundle, the SIGHASH transaction hash would be computed solely based on the issue bundle. A duplicate bundle would have the same SIGHASH transaction hash, potentially allowing for a replay attack.
 
 Concrete Applications

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -221,8 +221,21 @@ Specification: Global Issuance State
 
 Issuance requires the following additions to the global state defined at block boundaries:
 
-- :math:`\mathsf{previously\_finalized}\!`, a set of :math:`\mathsf{AssetId}` that have been finalized (i.e.: the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction preceding the block boundary).
+A map, :math:`\mathsf{issued\_assets}\!`, from the Asset Base, :math:`\mathsf{AssetBase_{AssetId}}`, to a tuple :math:`(\mathsf{balance_{AssetId}}, \mathsf{final_{AssetId}})`, for every Asset that has been issued up until the block boundary.
 
+- The amount of the Asset in circulation, computed as the amount of the Asset that has been issued less the amount of the Asset that has been burnt, is stored in :math:`\mathsf{balance_{AssetId}}`.
+- The boolean :math:`\mathsf{final_{AssetId}}` stores the finalization status of the Asset (i.e.: whether the :math:`\mathsf{finalize}` flag has been set to :math:`1` in some issuance transaction preceding the block boundary).
+
+Rationale for Global Issuance State
+-----------------------------------
+
+It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 [#zip-0209]_. 
+However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issuance and burnt amounts for a given Asset.
+Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record at the block boundary based on the issuance and burn transactions within the block. 
+This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the block.
+
+Nodes also need to ensure the rejection of blocks in which issuance of Custom Assets that have been previously finalized. 
+The :math:`\mathsf{issued\_assets}\!` map allows nodes to store whether or not a given Asset has been finalized. 
 
 Specification: Issuance Action, Issuance Bundle and Issuance Protocol
 =====================================================================
@@ -236,6 +249,8 @@ An issuance action, ``IssueAction``, is the instance of issuing a specific Custo
 - ``asset_desc``: the Asset description, a byte string of up to 512 bytes as defined in the `Specification: Asset Identifier`_ section.
 - ``vNotes``: an array of ``Note`` containing the unencrypted output notes of the recipients of the Asset.
 - ``flagsIssuance``: a byte that stores the :math:`\mathsf{finalize}` boolean that defines whether the issuance of that specific Custom Asset is finalized or not.
+
+
 
 An asset's :math:`\mathsf{AssetDigest}` is added to the :math:`\mathsf{previously\_finalized}` set after a block that contains any issuance transaction for that asset with :math:`\mathsf{finalize} = 1\!`. It then cannot be removed from this set. For Assets with :math:`\mathsf{AssetDigest} \in \mathsf{previously\_finalized}\!`, no further tokens can be issued, so as seen below, the validators will reject the transaction. For Assets with :math:`\mathsf{AssetDigest} \not\in \mathsf{previously\_finalized}\!`, new issuance actions can be issued in future transactions. These must use the same Asset description, :math:`\mathsf{asset\_desc}\!`, and can either maintain :math:`\mathsf{finalize} = 0` or change it to :math:`\mathsf{finalize} = 1\!`, denoting that this Custom Asset cannot be issued after the containing block.
 
@@ -606,6 +621,7 @@ References
 .. [#zip-0032-key-path-levels] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Key path levels <zip-0032.html#key-path-levels>`_
 .. [#zip-0032-orchard-key-path] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Orchard key path <zip-0032.html#orchard-key-path>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.html>`_
+.. [#zip-0209] `ZIP 209: Prohibit Negative Shielded Chain Value Pool Balances <zip-0209.html>`_
 .. [#zip-0224] `ZIP 224: Orchard <zip-0224.html>`_
 .. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zip-0226.html>`_
 .. [#zip-0226-notestructure] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Note Structure & Commitment <zip-0226.html#note-structure-commitment>`_


### PR DESCRIPTION
This PR adds a map called `issued_assets` to the global state. This is used to track ZSA balances in the shielded pool along the lines of ZIP 209. 

This should resolve https://github.com/zcash/zips/issues/844.