### PR TITLE
Adding symbolic link from the rendered folder to the docs folder

### DIFF
--- a/docs
+++ b/docs
@@ -1,0 +1,1 @@
+rendered

--- a/rendered/index.html
+++ b/rendered/index.html
@@ -254,4 +254,4 @@
 </table></embed></section>
     </section>
 </body>
-</html>
+</html> 

--- a/rendered/index.html
+++ b/rendered/index.html
@@ -254,4 +254,4 @@
 </table></embed></section>
     </section>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
This PR adds the symbolic link above in order to allow the [qed-it.github.io/zips](qed-it.github.io/zips) website to work correctly post the upstream repository restructure.