### PR TITLE
Updating references to protocol spec, and fixing some old links

### DIFF
--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -699,7 +699,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>15</th>
-                        <td><a href="protocol/protocol.pdf#notes">Zcash Protocol Specification, Version 2023.4.0. Section 3.2: Notes</a></td>
+                        <td><a href="protocol/protocol.pdf#notes">Zcash Protocol Specification, Version 2024.5.1. Section 3.2: Notes</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -707,7 +707,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>16</th>
-                        <td><a href="protocol/protocol.pdf#actions">Zcash Protocol Specification, Version 2023.4.0. Section 3.7: Action Transfers and their Descriptions</a></td>
+                        <td><a href="protocol/protocol.pdf#actions">Zcash Protocol Specification, Version 2024.5.1. Section 3.7: Action Transfers and their Descriptions</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -715,7 +715,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>17</th>
-                        <td><a href="protocol/protocol.pdf#abstractcommit">Zcash Protocol Specification, Version 2023.4.0. Section 4.1.8: Commitment</a></td>
+                        <td><a href="protocol/protocol.pdf#abstractcommit">Zcash Protocol Specification, Version 2024.5.1. Section 4.1.8: Commitment</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -723,7 +723,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>18</th>
-                        <td><a href="protocol/protocol.pdf#orcharddummynotes">Zcash Protocol Specification, Version 2023.4.0. Section 4.8.3: Dummy Notes (Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#orcharddummynotes">Zcash Protocol Specification, Version 2024.5.1. Section 4.8.3: Dummy Notes (Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -731,7 +731,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>19</th>
-                        <td><a href="protocol/protocol.pdf#orchardbalance">Zcash Protocol Specification, Version 2023.4.0. Section 4.14: Balance and Binding Signature (Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#orchardbalance">Zcash Protocol Specification, Version 2024.5.1. Section 4.14: Balance and Binding Signature (Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -739,7 +739,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>20</th>
-                        <td><a href="protocol/protocol.pdf#commitmentsandnullifiers">Zcash Protocol Specification, Version 2023.4.0. Section 4.16: Note Commitments and Nullifiers</a></td>
+                        <td><a href="protocol/protocol.pdf#commitmentsandnullifiers">Zcash Protocol Specification, Version 2024.5.1. Section 4.16: Computing ρ values and Nullifiers</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -747,7 +747,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>21</th>
-                        <td><a href="protocol/protocol.pdf#actionstatement">Zcash Protocol Specification, Version 2023.4.0. Section 4.17.4: Action Statement (Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#actionstatement">Zcash Protocol Specification, Version 2024.5.1. Section 4.18.4: Action Statement (Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -755,7 +755,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>22</th>
-                        <td><a href="protocol/protocol.pdf#endian">Zcash Protocol Specification, Version 2023.4.0. Section 5.1: Integers, Bit Sequences, and Endianness</a></td>
+                        <td><a href="protocol/protocol.pdf#endian">Zcash Protocol Specification, Version 2024.5.1. Section 5.1: Integers, Bit Sequences, and Endianness</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -763,7 +763,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>23</th>
-                        <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2023.4.0. Section 5.3: Constants</a></td>
+                        <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2024.5.1. Section 5.3: Constants</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -771,7 +771,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>24</th>
-                        <td><a href="protocol/protocol.pdf#concretesinsemillahash">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.1.9: Sinsemilla hash function</a></td>
+                        <td><a href="protocol/protocol.pdf#concretesinsemillahash">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.1.9: Sinsemilla hash function</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -779,7 +779,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>25</th>
-                        <td><a href="protocol/protocol.pdf#concretehomomorphiccommit">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#concretehomomorphiccommit">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -787,7 +787,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>26</th>
-                        <td><a href="protocol/protocol.pdf#concretesinsemillacommit">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.8.4: Sinsemilla commitments</a></td>
+                        <td><a href="protocol/protocol.pdf#concretesinsemillacommit">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.4: Sinsemilla commitments</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -795,7 +795,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>27</th>
-                        <td><a href="protocol/protocol.pdf#pallasandvesta">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.9.6: Pallas and Vesta</a></td>
+                        <td><a href="protocol/protocol.pdf#pallasandvesta">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.6: Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -803,7 +803,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>28</th>
-                        <td><a href="protocol/protocol.pdf#notept">Zcash Protocol Specification, Version 2023.4.0. Section 5.5: Encodings of Note Plaintexts and Memo Fields</a></td>
+                        <td><a href="protocol/protocol.pdf#notept">Zcash Protocol Specification, Version 2024.5.1. Section 5.5: Encodings of Note Plaintexts and Memo Fields</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -811,7 +811,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>29</th>
-                        <td><a href="protocol/protocol.pdf#actionencodingandconsensus">Zcash Protocol Specification, Version 2023.4.0. Section 7.5: Action Description Encoding and Consensus</a></td>
+                        <td><a href="protocol/protocol.pdf#actionencodingandconsensus">Zcash Protocol Specification, Version 2024.5.1. Section 7.5: Action Description Encoding and Consensus</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -667,7 +667,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>11</th>
-                        <td><a href="https://github.com/QED-it/zips/pull/36">ZIP 230: Version 6 Transaction Format</a></td>
+                        <td><a href="zip-0230.html">ZIP 230: Version 6 Transaction Format</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -699,7 +699,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>15</th>
-                        <td><a href="protocol/protocol.pdf#notes">Zcash Protocol Specification, Version 2024.5.1. Section 3.2: Notes</a></td>
+                        <td><a href="protocol/protocol.pdf#notes">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.2: Notes</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -707,7 +707,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>16</th>
-                        <td><a href="protocol/protocol.pdf#actions">Zcash Protocol Specification, Version 2024.5.1. Section 3.7: Action Transfers and their Descriptions</a></td>
+                        <td><a href="protocol/protocol.pdf#actions">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.7: Action Transfers and their Descriptions</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -715,7 +715,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>17</th>
-                        <td><a href="protocol/protocol.pdf#abstractcommit">Zcash Protocol Specification, Version 2024.5.1. Section 4.1.8: Commitment</a></td>
+                        <td><a href="protocol/protocol.pdf#abstractcommit">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.1.8: Commitment</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -723,7 +723,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>18</th>
-                        <td><a href="protocol/protocol.pdf#orcharddummynotes">Zcash Protocol Specification, Version 2024.5.1. Section 4.8.3: Dummy Notes (Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#orcharddummynotes">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.8.3: Dummy Notes (Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -731,7 +731,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>19</th>
-                        <td><a href="protocol/protocol.pdf#orchardbalance">Zcash Protocol Specification, Version 2024.5.1. Section 4.14: Balance and Binding Signature (Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#orchardbalance">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.14: Balance and Binding Signature (Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -739,7 +739,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>20</th>
-                        <td><a href="protocol/protocol.pdf#commitmentsandnullifiers">Zcash Protocol Specification, Version 2024.5.1. Section 4.16: Computing ρ values and Nullifiers</a></td>
+                        <td><a href="protocol/protocol.pdf#commitmentsandnullifiers">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.16: Computing ρ values and Nullifiers</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -747,7 +747,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>21</th>
-                        <td><a href="protocol/protocol.pdf#actionstatement">Zcash Protocol Specification, Version 2024.5.1. Section 4.18.4: Action Statement (Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#actionstatement">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.18.4: Action Statement (Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -755,7 +755,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>22</th>
-                        <td><a href="protocol/protocol.pdf#endian">Zcash Protocol Specification, Version 2024.5.1. Section 5.1: Integers, Bit Sequences, and Endianness</a></td>
+                        <td><a href="protocol/protocol.pdf#endian">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.1: Integers, Bit Sequences, and Endianness</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -763,7 +763,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>23</th>
-                        <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2024.5.1. Section 5.3: Constants</a></td>
+                        <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.3: Constants</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -771,7 +771,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>24</th>
-                        <td><a href="protocol/protocol.pdf#concretesinsemillahash">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.1.9: Sinsemilla hash function</a></td>
+                        <td><a href="protocol/protocol.pdf#concretesinsemillahash">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.1.9: Sinsemilla hash function</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -779,7 +779,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>25</th>
-                        <td><a href="protocol/protocol.pdf#concretehomomorphiccommit">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)</a></td>
+                        <td><a href="protocol/protocol.pdf#concretehomomorphiccommit">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -787,7 +787,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>26</th>
-                        <td><a href="protocol/protocol.pdf#concretesinsemillacommit">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.4: Sinsemilla commitments</a></td>
+                        <td><a href="protocol/protocol.pdf#concretesinsemillacommit">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.8.4: Sinsemilla commitments</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -795,7 +795,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>27</th>
-                        <td><a href="protocol/protocol.pdf#pallasandvesta">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.6: Pallas and Vesta</a></td>
+                        <td><a href="protocol/protocol.pdf#pallasandvesta">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.6: Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -803,7 +803,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>28</th>
-                        <td><a href="protocol/protocol.pdf#notept">Zcash Protocol Specification, Version 2024.5.1. Section 5.5: Encodings of Note Plaintexts and Memo Fields</a></td>
+                        <td><a href="protocol/protocol.pdf#notept">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.5: Encodings of Note Plaintexts and Memo Fields</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -811,7 +811,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>29</th>
-                        <td><a href="protocol/protocol.pdf#actionencodingandconsensus">Zcash Protocol Specification, Version 2024.5.1. Section 7.5: Action Description Encoding and Consensus</a></td>
+                        <td><a href="protocol/protocol.pdf#actionencodingandconsensus">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.5: Action Description Encoding and Consensus</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -975,7 +975,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>17</th>
-                        <td><a href="https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki">BIP 340: Schnorr Signatures for secp256k1</a></td>
+                        <td><a href="https://github.com/bitcoin/bips/blob/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb/bip-0340.mediawiki">BIP 340: Schnorr Signatures for secp256k1</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -983,7 +983,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>18</th>
-                        <td><a href="protocol/protocol.pdf#notation">Zcash Protocol Specification, Version 2023.4.0. Section 2: Notation</a></td>
+                        <td><a href="protocol/protocol.pdf#notation">Zcash Protocol Specification, Version 2024.5.1. Section 2: Notation</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -991,7 +991,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>19</th>
-                        <td><a href="protocol/protocol.pdf#addressesandkeys">Zcash Protocol Specification, Version 2023.4.0. Section 3.1: Payment Addresses and Keys</a></td>
+                        <td><a href="protocol/protocol.pdf#addressesandkeys">Zcash Protocol Specification, Version 2024.5.1. Section 3.1: Payment Addresses and Keys</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -999,7 +999,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>20</th>
-                        <td><a href="protocol/protocol.pdf#orchardkeycomponents">Zcash Protocol Specification, Version 2023.4.0. Section 4.2.3: Orchard Key Components</a></td>
+                        <td><a href="protocol/protocol.pdf#orchardkeycomponents">Zcash Protocol Specification, Version 2024.5.1. Section 4.2.3: Orchard Key Components</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -1007,7 +1007,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>21</th>
-                        <td><a href="protocol/protocol.pdf#concretegrouphashpallasandvesta">Zcash Protocol Specification, Version 2023.4.0. Section 5.4.9.8: Group Hash into Pallas and Vesta</a></td>
+                        <td><a href="protocol/protocol.pdf#concretegrouphashpallasandvesta">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.8: Group Hash into Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -1015,7 +1015,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>22</th>
-                        <td><a href="protocol/protocol.pdf#orchardpaymentaddrencoding">Zcash Protocol Specification, Version 2023.4.0. Section 5.6.4.2: Orchard Raw Payment Addresses</a></td>
+                        <td><a href="protocol/protocol.pdf#orchardpaymentaddrencoding">Zcash Protocol Specification, Version 2024.5.1. Section 5.6.4.2: Orchard Raw Payment Addresses</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -1023,7 +1023,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>23</th>
-                        <td><a href="protocol/protocol.pdf#txnencoding">Zcash Protocol Specification, Version 2023.4.0. Section 7.1: Transaction Encoding and Consensus (Transaction Version 5)</a></td>
+                        <td><a href="protocol/protocol.pdf#txnencoding">Zcash Protocol Specification, Version 2024.5.1. Section 7.1: Transaction Encoding and Consensus</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -983,7 +983,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>18</th>
-                        <td><a href="protocol/protocol.pdf#notation">Zcash Protocol Specification, Version 2024.5.1. Section 2: Notation</a></td>
+                        <td><a href="protocol/protocol.pdf#notation">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 2: Notation</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -991,7 +991,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>19</th>
-                        <td><a href="protocol/protocol.pdf#addressesandkeys">Zcash Protocol Specification, Version 2024.5.1. Section 3.1: Payment Addresses and Keys</a></td>
+                        <td><a href="protocol/protocol.pdf#addressesandkeys">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.1: Payment Addresses and Keys</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -999,7 +999,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>20</th>
-                        <td><a href="protocol/protocol.pdf#orchardkeycomponents">Zcash Protocol Specification, Version 2024.5.1. Section 4.2.3: Orchard Key Components</a></td>
+                        <td><a href="protocol/protocol.pdf#orchardkeycomponents">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.2.3: Orchard Key Components</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -1007,7 +1007,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>21</th>
-                        <td><a href="protocol/protocol.pdf#concretegrouphashpallasandvesta">Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.8: Group Hash into Pallas and Vesta</a></td>
+                        <td><a href="protocol/protocol.pdf#concretegrouphashpallasandvesta">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.8: Group Hash into Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -1015,7 +1015,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>22</th>
-                        <td><a href="protocol/protocol.pdf#orchardpaymentaddrencoding">Zcash Protocol Specification, Version 2024.5.1. Section 5.6.4.2: Orchard Raw Payment Addresses</a></td>
+                        <td><a href="protocol/protocol.pdf#orchardpaymentaddrencoding">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.6.4.2: Orchard Raw Payment Addresses</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -1023,7 +1023,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <tbody>
                     <tr>
                         <th>23</th>
-                        <td><a href="protocol/protocol.pdf#txnencoding">Zcash Protocol Specification, Version 2024.5.1. Section 7.1: Transaction Encoding and Consensus</a></td>
+                        <td><a href="protocol/protocol.pdf#txnencoding">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.1: Transaction Encoding and Consensus</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -633,7 +633,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <tbody>
                     <tr>
                         <th>2</th>
-                        <td><a href="protocol/protocol.pdf">Zcash Protocol Specification, Version 2023.4.0 or later [NU5 proposal]</a></td>
+                        <td><a href="protocol/protocol.pdf">Zcash Protocol Specification, Version 2024.5.1 or later [NU6]</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -641,7 +641,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <tbody>
                     <tr>
                         <th>3</th>
-                        <td><a href="protocol/protocol.pdf#spenddesc">Zcash Protocol Specification, Version 2023.4.0 [NU5 proposal]. Section 4.4: Spend Descriptions</a></td>
+                        <td><a href="protocol/protocol.pdf#spenddesc">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.4: Spend Descriptions</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -649,7 +649,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <tbody>
                     <tr>
                         <th>4</th>
-                        <td><a href="protocol/protocol.pdf#outputdesc">Zcash Protocol Specification, Version 2023.4.0 [NU5 proposal]. Section 4.5: Output Descriptions</a></td>
+                        <td><a href="protocol/protocol.pdf#outputdesc">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.5: Output Descriptions</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -657,7 +657,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <tbody>
                     <tr>
                         <th>5</th>
-                        <td><a href="protocol/protocol.pdf#actiondesc">Zcash Protocol Specification, Version 2023.4.0 [NU5 proposal]. Section 4.6: Action Descriptions</a></td>
+                        <td><a href="protocol/protocol.pdf#actiondesc">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.6: Action Descriptions</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -505,21 +505,21 @@ References
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_
 .. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism - Pull Request #667 for ZSA Protocol ZIPs <https://github.com/zcash/zips/pull/667>`_
-.. [#protocol-notes] `Zcash Protocol Specification, Version 2023.4.0. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
-.. [#protocol-actions] `Zcash Protocol Specification, Version 2023.4.0. Section 3.7: Action Transfers and their Descriptions <protocol/protocol.pdf#actions>`_
-.. [#protocol-abstractcommit] `Zcash Protocol Specification, Version 2023.4.0. Section 4.1.8: Commitment <protocol/protocol.pdf#abstractcommit>`_
-.. [#protocol-orcharddummynotes] `Zcash Protocol Specification, Version 2023.4.0. Section 4.8.3: Dummy Notes (Orchard) <protocol/protocol.pdf#orcharddummynotes>`_
-.. [#protocol-orchardbalance] `Zcash Protocol Specification, Version 2023.4.0. Section 4.14: Balance and Binding Signature (Orchard) <protocol/protocol.pdf#orchardbalance>`_
-.. [#protocol-commitmentsandnullifiers] `Zcash Protocol Specification, Version 2023.4.0. Section 4.16: Note Commitments and Nullifiers <protocol/protocol.pdf#commitmentsandnullifiers>`_
-.. [#protocol-actionstatement] `Zcash Protocol Specification, Version 2023.4.0. Section 4.17.4: Action Statement (Orchard) <protocol/protocol.pdf#actionstatement>`_
-.. [#protocol-endian] `Zcash Protocol Specification, Version 2023.4.0. Section 5.1: Integers, Bit Sequences, and Endianness <protocol/protocol.pdf#endian>`_
-.. [#protocol-constants] `Zcash Protocol Specification, Version 2023.4.0. Section 5.3: Constants <protocol/protocol.pdf#constants>`_
-.. [#protocol-concretesinsemillahash] `Zcash Protocol Specification, Version 2023.4.0. Section 5.4.1.9: Sinsemilla hash function <protocol/protocol.pdf#concretesinsemillahash>`_
-.. [#protocol-concretehomomorphiccommit] `Zcash Protocol Specification, Version 2023.4.0. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard) <protocol/protocol.pdf#concretehomomorphiccommit>`_
-.. [#protocol-concretesinsemillacommit] `Zcash Protocol Specification, Version 2023.4.0. Section 5.4.8.4: Sinsemilla commitments <protocol/protocol.pdf#concretesinsemillacommit>`_
-.. [#protocol-pallasandvesta] `Zcash Protocol Specification, Version 2023.4.0. Section 5.4.9.6: Pallas and Vesta <protocol/protocol.pdf#pallasandvesta>`_
-.. [#protocol-notept] `Zcash Protocol Specification, Version 2023.4.0. Section 5.5: Encodings of Note Plaintexts and Memo Fields <protocol/protocol.pdf#notept>`_
-.. [#protocol-actionencodingandconsensus] `Zcash Protocol Specification, Version 2023.4.0. Section 7.5: Action Description Encoding and Consensus  <protocol/protocol.pdf#actionencodingandconsensus>`_
+.. [#protocol-notes] `Zcash Protocol Specification, Version 2024.5.1. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
+.. [#protocol-actions] `Zcash Protocol Specification, Version 2024.5.1. Section 3.7: Action Transfers and their Descriptions <protocol/protocol.pdf#actions>`_
+.. [#protocol-abstractcommit] `Zcash Protocol Specification, Version 2024.5.1. Section 4.1.8: Commitment <protocol/protocol.pdf#abstractcommit>`_
+.. [#protocol-orcharddummynotes] `Zcash Protocol Specification, Version 2024.5.1. Section 4.8.3: Dummy Notes (Orchard) <protocol/protocol.pdf#orcharddummynotes>`_
+.. [#protocol-orchardbalance] `Zcash Protocol Specification, Version 2024.5.1. Section 4.14: Balance and Binding Signature (Orchard) <protocol/protocol.pdf#orchardbalance>`_
+.. [#protocol-commitmentsandnullifiers] `Zcash Protocol Specification, Version 2024.5.1. Section 4.16: Computing ρ values and Nullifiers <protocol/protocol.pdf#commitmentsandnullifiers>`_
+.. [#protocol-actionstatement] `Zcash Protocol Specification, Version 2024.5.1. Section 4.18.4: Action Statement (Orchard) <protocol/protocol.pdf#actionstatement>`_
+.. [#protocol-endian] `Zcash Protocol Specification, Version 2024.5.1. Section 5.1: Integers, Bit Sequences, and Endianness <protocol/protocol.pdf#endian>`_
+.. [#protocol-constants] `Zcash Protocol Specification, Version 2024.5.1. Section 5.3: Constants <protocol/protocol.pdf#constants>`_
+.. [#protocol-concretesinsemillahash] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.1.9: Sinsemilla hash function <protocol/protocol.pdf#concretesinsemillahash>`_
+.. [#protocol-concretehomomorphiccommit] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard) <protocol/protocol.pdf#concretehomomorphiccommit>`_
+.. [#protocol-concretesinsemillacommit] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.4: Sinsemilla commitments <protocol/protocol.pdf#concretesinsemillacommit>`_
+.. [#protocol-pallasandvesta] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.6: Pallas and Vesta <protocol/protocol.pdf#pallasandvesta>`_
+.. [#protocol-notept] `Zcash Protocol Specification, Version 2024.5.1. Section 5.5: Encodings of Note Plaintexts and Memo Fields <protocol/protocol.pdf#notept>`_
+.. [#protocol-actionencodingandconsensus] `Zcash Protocol Specification, Version 2024.5.1. Section 7.5: Action Description Encoding and Consensus  <protocol/protocol.pdf#actionencodingandconsensus>`_
 .. [#initial-zsa-issue] `User-Defined Assets and Wrapped Assets <https://github.com/str4d/zips/blob/zip-udas/drafts/zip-user-defined-assets.rst>`_
 .. [#generalized-value-commitments] `Comment on Generalized Value Commitments <https://github.com/zcash/zcash/issues/2277#issuecomment-321106819>`_
 .. [#circuit-modifications] `Modifications to the Orchard circuit for the ZSA Protocol <https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing>`_

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -505,21 +505,21 @@ References
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_
 .. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism - Pull Request #667 for ZSA Protocol ZIPs <https://github.com/zcash/zips/pull/667>`_
-.. [#protocol-notes] `Zcash Protocol Specification, Version 2024.5.1. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
-.. [#protocol-actions] `Zcash Protocol Specification, Version 2024.5.1. Section 3.7: Action Transfers and their Descriptions <protocol/protocol.pdf#actions>`_
-.. [#protocol-abstractcommit] `Zcash Protocol Specification, Version 2024.5.1. Section 4.1.8: Commitment <protocol/protocol.pdf#abstractcommit>`_
-.. [#protocol-orcharddummynotes] `Zcash Protocol Specification, Version 2024.5.1. Section 4.8.3: Dummy Notes (Orchard) <protocol/protocol.pdf#orcharddummynotes>`_
-.. [#protocol-orchardbalance] `Zcash Protocol Specification, Version 2024.5.1. Section 4.14: Balance and Binding Signature (Orchard) <protocol/protocol.pdf#orchardbalance>`_
-.. [#protocol-commitmentsandnullifiers] `Zcash Protocol Specification, Version 2024.5.1. Section 4.16: Computing ρ values and Nullifiers <protocol/protocol.pdf#commitmentsandnullifiers>`_
-.. [#protocol-actionstatement] `Zcash Protocol Specification, Version 2024.5.1. Section 4.18.4: Action Statement (Orchard) <protocol/protocol.pdf#actionstatement>`_
-.. [#protocol-endian] `Zcash Protocol Specification, Version 2024.5.1. Section 5.1: Integers, Bit Sequences, and Endianness <protocol/protocol.pdf#endian>`_
-.. [#protocol-constants] `Zcash Protocol Specification, Version 2024.5.1. Section 5.3: Constants <protocol/protocol.pdf#constants>`_
-.. [#protocol-concretesinsemillahash] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.1.9: Sinsemilla hash function <protocol/protocol.pdf#concretesinsemillahash>`_
-.. [#protocol-concretehomomorphiccommit] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard) <protocol/protocol.pdf#concretehomomorphiccommit>`_
-.. [#protocol-concretesinsemillacommit] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.8.4: Sinsemilla commitments <protocol/protocol.pdf#concretesinsemillacommit>`_
-.. [#protocol-pallasandvesta] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.6: Pallas and Vesta <protocol/protocol.pdf#pallasandvesta>`_
-.. [#protocol-notept] `Zcash Protocol Specification, Version 2024.5.1. Section 5.5: Encodings of Note Plaintexts and Memo Fields <protocol/protocol.pdf#notept>`_
-.. [#protocol-actionencodingandconsensus] `Zcash Protocol Specification, Version 2024.5.1. Section 7.5: Action Description Encoding and Consensus  <protocol/protocol.pdf#actionencodingandconsensus>`_
+.. [#protocol-notes] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
+.. [#protocol-actions] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.7: Action Transfers and their Descriptions <protocol/protocol.pdf#actions>`_
+.. [#protocol-abstractcommit] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.1.8: Commitment <protocol/protocol.pdf#abstractcommit>`_
+.. [#protocol-orcharddummynotes] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.8.3: Dummy Notes (Orchard) <protocol/protocol.pdf#orcharddummynotes>`_
+.. [#protocol-orchardbalance] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.14: Balance and Binding Signature (Orchard) <protocol/protocol.pdf#orchardbalance>`_
+.. [#protocol-commitmentsandnullifiers] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.16: Computing ρ values and Nullifiers <protocol/protocol.pdf#commitmentsandnullifiers>`_
+.. [#protocol-actionstatement] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.18.4: Action Statement (Orchard) <protocol/protocol.pdf#actionstatement>`_
+.. [#protocol-endian] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.1: Integers, Bit Sequences, and Endianness <protocol/protocol.pdf#endian>`_
+.. [#protocol-constants] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.3: Constants <protocol/protocol.pdf#constants>`_
+.. [#protocol-concretesinsemillahash] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.1.9: Sinsemilla hash function <protocol/protocol.pdf#concretesinsemillahash>`_
+.. [#protocol-concretehomomorphiccommit] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard) <protocol/protocol.pdf#concretehomomorphiccommit>`_
+.. [#protocol-concretesinsemillacommit] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.8.4: Sinsemilla commitments <protocol/protocol.pdf#concretesinsemillacommit>`_
+.. [#protocol-pallasandvesta] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.6: Pallas and Vesta <protocol/protocol.pdf#pallasandvesta>`_
+.. [#protocol-notept] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.5: Encodings of Note Plaintexts and Memo Fields <protocol/protocol.pdf#notept>`_
+.. [#protocol-actionencodingandconsensus] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.5: Action Description Encoding and Consensus  <protocol/protocol.pdf#actionencodingandconsensus>`_
 .. [#initial-zsa-issue] `User-Defined Assets and Wrapped Assets <https://github.com/str4d/zips/blob/zip-udas/drafts/zip-user-defined-assets.rst>`_
 .. [#generalized-value-commitments] `Comment on Generalized Value Commitments <https://github.com/zcash/zcash/issues/2277#issuecomment-321106819>`_
 .. [#circuit-modifications] `Modifications to the Orchard circuit for the ZSA Protocol <https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing>`_

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -501,7 +501,7 @@ References
 .. [#zip-0227-txiddigest] `ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance <zip-0227.html#txid-digest-issuance>`_
 .. [#zip-0227-sigdigest] `ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest <zip-0227.html#signature-digest>`_
 .. [#zip-0227-authcommitment] `ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment <zip-0227.html#authorizing-data-commitment>`_
-.. [#zip-0230] `ZIP 230: Version 6 Transaction Format <https://github.com/QED-it/zips/pull/36>`_
+.. [#zip-0230] `ZIP 230: Version 6 Transaction Format <zip-0230.html>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_
 .. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism - Pull Request #667 for ZSA Protocol ZIPs <https://github.com/zcash/zips/pull/667>`_

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -638,7 +638,7 @@ References
 .. [#zip-0244-sigdigest] `ZIP 244: Transaction Identifier Non-Malleability: Signature Digest <zip-0244.html#signature-digest>`_
 .. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_
 .. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism <https://github.com/zcash/zips/pull/667>`_
-.. [#bip-0340] `BIP 340: Schnorr Signatures for secp256k1 <https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki>`_
+.. [#bip-0340] `BIP 340: Schnorr Signatures for secp256k1 <https://github.com/bitcoin/bips/blob/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb/bip-0340.mediawiki>`_
 .. [#protocol-notation] `Zcash Protocol Specification, Version 2024.5.1. Section 2: Notation <protocol/protocol.pdf#notation>`_
 .. [#protocol-addressesandkeys] `Zcash Protocol Specification, Version 2024.5.1. Section 3.1: Payment Addresses and Keys <protocol/protocol.pdf#addressesandkeys>`_
 .. [#protocol-orchardkeycomponents] `Zcash Protocol Specification, Version 2024.5.1. Section 4.2.3: Orchard Key Components <protocol/protocol.pdf#orchardkeycomponents>`_

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -639,9 +639,9 @@ References
 .. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_
 .. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism <https://github.com/zcash/zips/pull/667>`_
 .. [#bip-0340] `BIP 340: Schnorr Signatures for secp256k1 <https://github.com/bitcoin/bips/blob/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb/bip-0340.mediawiki>`_
-.. [#protocol-notation] `Zcash Protocol Specification, Version 2024.5.1. Section 2: Notation <protocol/protocol.pdf#notation>`_
-.. [#protocol-addressesandkeys] `Zcash Protocol Specification, Version 2024.5.1. Section 3.1: Payment Addresses and Keys <protocol/protocol.pdf#addressesandkeys>`_
-.. [#protocol-orchardkeycomponents] `Zcash Protocol Specification, Version 2024.5.1. Section 4.2.3: Orchard Key Components <protocol/protocol.pdf#orchardkeycomponents>`_
-.. [#protocol-concretegrouphashpallasandvesta] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.8: Group Hash into Pallas and Vesta <protocol/protocol.pdf#concretegrouphashpallasandvesta>`_
-.. [#protocol-orchardpaymentaddrencoding] `Zcash Protocol Specification, Version 2024.5.1. Section 5.6.4.2: Orchard Raw Payment Addresses <protocol/protocol.pdf#orchardpaymentaddrencoding>`_
-.. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2024.5.1. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
+.. [#protocol-notation] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 2: Notation <protocol/protocol.pdf#notation>`_
+.. [#protocol-addressesandkeys] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.1: Payment Addresses and Keys <protocol/protocol.pdf#addressesandkeys>`_
+.. [#protocol-orchardkeycomponents] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.2.3: Orchard Key Components <protocol/protocol.pdf#orchardkeycomponents>`_
+.. [#protocol-concretegrouphashpallasandvesta] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.8: Group Hash into Pallas and Vesta <protocol/protocol.pdf#concretegrouphashpallasandvesta>`_
+.. [#protocol-orchardpaymentaddrencoding] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.6.4.2: Orchard Raw Payment Addresses <protocol/protocol.pdf#orchardpaymentaddrencoding>`_
+.. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -639,9 +639,9 @@ References
 .. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_
 .. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism <https://github.com/zcash/zips/pull/667>`_
 .. [#bip-0340] `BIP 340: Schnorr Signatures for secp256k1 <https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki>`_
-.. [#protocol-notation] `Zcash Protocol Specification, Version 2023.4.0. Section 2: Notation <protocol/protocol.pdf#notation>`_
-.. [#protocol-addressesandkeys] `Zcash Protocol Specification, Version 2023.4.0. Section 3.1: Payment Addresses and Keys <protocol/protocol.pdf#addressesandkeys>`_
-.. [#protocol-orchardkeycomponents] `Zcash Protocol Specification, Version 2023.4.0. Section 4.2.3: Orchard Key Components <protocol/protocol.pdf#orchardkeycomponents>`_
-.. [#protocol-concretegrouphashpallasandvesta] `Zcash Protocol Specification, Version 2023.4.0. Section 5.4.9.8: Group Hash into Pallas and Vesta <protocol/protocol.pdf#concretegrouphashpallasandvesta>`_
-.. [#protocol-orchardpaymentaddrencoding] `Zcash Protocol Specification, Version 2023.4.0. Section 5.6.4.2: Orchard Raw Payment Addresses <protocol/protocol.pdf#orchardpaymentaddrencoding>`_
-.. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2023.4.0. Section 7.1: Transaction Encoding and Consensus (Transaction Version 5) <protocol/protocol.pdf#txnencoding>`_
+.. [#protocol-notation] `Zcash Protocol Specification, Version 2024.5.1. Section 2: Notation <protocol/protocol.pdf#notation>`_
+.. [#protocol-addressesandkeys] `Zcash Protocol Specification, Version 2024.5.1. Section 3.1: Payment Addresses and Keys <protocol/protocol.pdf#addressesandkeys>`_
+.. [#protocol-orchardkeycomponents] `Zcash Protocol Specification, Version 2024.5.1. Section 4.2.3: Orchard Key Components <protocol/protocol.pdf#orchardkeycomponents>`_
+.. [#protocol-concretegrouphashpallasandvesta] `Zcash Protocol Specification, Version 2024.5.1. Section 5.4.9.8: Group Hash into Pallas and Vesta <protocol/protocol.pdf#concretegrouphashpallasandvesta>`_
+.. [#protocol-orchardpaymentaddrencoding] `Zcash Protocol Specification, Version 2024.5.1. Section 5.6.4.2: Orchard Raw Payment Addresses <protocol/protocol.pdf#orchardpaymentaddrencoding>`_
+.. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2024.5.1. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -368,10 +368,10 @@ References
 ==========
 
 .. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
-.. [#protocol] `Zcash Protocol Specification, Version 2023.4.0 or later [NU5 proposal] <protocol/protocol.pdf>`_
-.. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2023.4.0 [NU5 proposal]. Section 4.4: Spend Descriptions <protocol/protocol.pdf#spenddesc>`_
-.. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2023.4.0 [NU5 proposal]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_
-.. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2023.4.0 [NU5 proposal]. Section 4.6: Action Descriptions <protocol/protocol.pdf#actiondesc>`_
+.. [#protocol] `Zcash Protocol Specification, Version 2024.5.1 or later [NU6] <protocol/protocol.pdf>`_
+.. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.4: Spend Descriptions <protocol/protocol.pdf#spenddesc>`_
+.. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_
+.. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.6: Action Descriptions <protocol/protocol.pdf#actiondesc>`_
 .. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <https://qed-it.github.io/zips/zip-0226>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <https://qed-it.github.io/zips/zip-0227>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.rst>`_


### PR DESCRIPTION
This PR updates the protocol spec references from 2023.4.0 [NU5] to 2024.5.1 [NU6], along with some minor section changes and renumbering.
It also fixes some old links in favour of updated ones.

This resolves https://github.com/zcash/zips/issues/751 for the present.