### PR TITLE
[ZSA][Fees] Refactoring the ZSA Fees

### DIFF
--- a/rendered/zip-0317.html
+++ b/rendered/zip-0317.html
@@ -19,7 +19,7 @@ Credits: Madars Virza
          Jonathan Rouach
          Pablo Kogan
          Vivek Arte
-Status: Draft
+Status: Revision 0: Active, Revision 1: Draft
 Category: Standards / Wallet
 Obsoletes: ZIP 313
 Created: 2022-08-15
@@ -39,15 +39,17 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The goal of this ZIP is to change the conventional fees for transactions by making them dependent on the number of inputs and outputs in a transaction, and to get buy-in for this change from wallet developers, miners and Zcash users.</p>
-            <p>This ZIP also explicitly defines the fee mechanism associated with the Zcash Shielded Assets (ZSA) protocol as described in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">7</a>.</p>
+            <p>Revision 1 of this ZIP additionally defines the fee mechanism associated with the Zcash Shielded Assets (ZSA) protocol as described in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">7</a>.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>In light of recent Mainnet network activity, it is time to review and update the standard 1,000 zatoshi transaction fee set in ZIP 313 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0313">8</a>.</p>
             <p>The conventional transaction fee presently is 0.00001 ZEC or 1,000 zatoshis, as specified in ZIP 313. This allowed exploration of novel use cases of the Zcash blockchain. The Zcash network has operated for almost 2 years at a conventional transaction fee of 1,000 zatoshis, without consideration for the total number of inputs and outputs in each transaction. Under this conventional fee, some usage of the chain has been characterized by high-output transactions with 1,100 outputs, paying the same conventional fee as a transaction with 2 outputs.</p>
             <p>The objective of the new fee policy, once it is enforced, is for fees paid by transactions to fairly reflect the processing costs that their inputs and outputs impose on various participants in the network. This will tend to discourage usage patterns that cause either intentional or unintentional denial of service, while still allowing low fees for regular transaction use cases.</p>
-            <p>The proposed upgrade to the ZSA protocol will also need to define a fee structure consistent with the above objectives. This involves adaptation for the transfer protocol <a id="footnote-reference-8" class="footnote_reference" href="#zip-0226">6</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">7</a> such as fees for asset issuance.</p>
-            <p>Specifically, the ZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, we believe that there should be a disincentive that will stop users from flooding the chain with useless asset identifiers.</p>
-            <p>In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-10" class="footnote_reference" href="#zip-0227">7</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
+            <section id="revision-1"><h3><span class="section-heading">Revision 1:</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The upgrade to the ZSA protocol will also need to define a fee structure consistent with the above objectives. This involves adaptation for the transfer protocol <a id="footnote-reference-8" class="footnote_reference" href="#zip-0226">6</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">7</a> such as fees for asset issuance.</p>
+                <p>Specifically, the ZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers.</p>
+                <p>In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-10" class="footnote_reference" href="#zip-0227">7</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
+            </section>
         </section>
         <section id="requirements"><h2><span class="section-heading">Requirements</span><span class="section-anchor"> <a rel="bookmark" href="#requirements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
@@ -55,11 +57,16 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 <li>The fee for a transaction should scale linearly with the number of inputs and/or outputs.</li>
                 <li>Users should not be penalised for sending transactions constructed with padding of inputs and outputs to reduce information leakage. (The default policy employed by zcashd and the mobile SDKs pads to two inputs and two outputs for each shielded pool used by the transaction).</li>
                 <li>Users should be able to spend a small number of UTXOs or notes with value below the marginal fee per input.</li>
-                <li>Post the upgrade to the ZSA protocol, users should be discouraged from issuing new “garbage” custom Assets.</li>
-                <li>Post the upgrade to the ZSA protocol, users should be discouraged from finalizing Assets frivolously.</li>
+                <li>Revision 1: Users should be discouraged from issuing new “garbage” custom Assets. The fee should reflect the cost of adding new data to the global state.</li>
             </ul>
         </section>
         <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <section id="revisions"><h3><span class="section-heading">Revisions</span><span class="section-anchor"> <a rel="bookmark" href="#revisions"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <ul>
+                    <li>Revision 0: The initial version of this specification.</li>
+                    <li>Revision 1: This version adds to the fees mechanism post the adoption of the ZSA Protocol. It adds additional fee considerations for the issuance and finalization of custom Zcash Shielded Assets.</li>
+                </ul>
+            </section>
             <section id="notation"><h3><span class="section-heading">Notation</span><span class="section-anchor"> <a rel="bookmark" href="#notation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>Let
                     <span class="math">\(\mathsf{min}(a, b)\)</span>
@@ -285,7 +292,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                     </details></section>
                 </section>
             </section>
-            <section id="zsa-fee-calculation"><h3><span class="section-heading">ZSA Fee calculation</span><span class="section-anchor"> <a rel="bookmark" href="#zsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+            <section id="revision-1-zsa-fee-calculation"><h3><span class="section-heading">Revision 1: ZSA Fee calculation</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-zsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In addition to the parameters defined in the <a href="#fee-calculation">Fee calculation</a> section, the ZSA protocol upgrade defines the following additional parameters:</p>
                 <table>
                     <thead>
@@ -301,7 +308,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                                 <span class="math">\(issuance\_fee\)</span>
                             </td>
                             <td>
-                                <span class="math">\(1000000\)</span>
+                                <span class="math">\(100 \cdot marginal\_fee\)</span>
                             </td>
                             <td>zatoshis per issuance action (as defined below)</td>
                         </tr>
@@ -310,7 +317,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                                 <span class="math">\(finalize\_fee\)</span>
                             </td>
                             <td>
-                                <span class="math">\(1000000\)</span>
+                                <span class="math">\(20 \cdot marginal\_fee\)</span>
                             </td>
                             <td>zatoshis per issuance action (as defined below)</td>
                         </tr>
@@ -323,7 +330,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
   zsa\_logical\_actions  &amp;=&amp; logical\_actions \;+ \\
                     &amp; &amp; nTotalOutputsZsaIssuance \\
   zsa\_conventional\_fee &amp;=&amp; marginal\_fee \cdot \mathsf{max}(grace\_actions, zsa\_logical\_actions) \;+ \\
-                    &amp; &amp; issuance\_fee \cdot nIssueActions \;+ \\
+                    &amp; &amp; issuance\_fee \cdot nIssueActions \;- \\
                     &amp; &amp; finalize\_fee \cdot nFinalizeActions
 \end{array}\)</div>
                 <p>The inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-13" class="footnote_reference" href="#protocol-txnencoding">3</a>. They are defined in the <a href="#fee-calculation">Fee calculation</a> section above, with additional definitions in the table below. Note that
@@ -562,8 +569,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 </ul>
                 <p><cite>zebra</cite> uses a similar relay threshold rule to <cite>zcashd</cite>, but additionally enforces a minimum fee of 100 zatoshis (this differs from <cite>zcashd</cite> only for valid transactions of less than 1000 bytes, assuming that <cite>zcashd</cite> uses its default value for <code>-minrelaytxfee</code>).</p>
             </section>
-            <section id="deployment-of-zsa-changes"><h3><span class="section-heading">Deployment of ZSA changes</span><span class="section-anchor"> <a rel="bookmark" href="#deployment-of-zsa-changes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of the deployment of the ZSA protocol (ZIP 226 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0227">7</a>), which is currently projected to be with Network Upgrade 6.</p>
+            <section id="revision-1-deployment-of-zsa-changes"><h3><span class="section-heading">Revision 1: Deployment of ZSA changes</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-deployment-of-zsa-changes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of the deployment of the ZSA protocol (ZIP 226 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0227">7</a>), which is currently projected to be with Network Upgrade 7.</p>
             </section>
         </section>
         <section id="considered-alternatives"><h2><span class="section-heading">Considered Alternatives</span><span class="section-anchor"> <a rel="bookmark" href="#considered-alternatives"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -592,7 +599,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 <span class="math">\(grace\_actions\)</span>
              threshold. This is no longer expressible with the formula specified above.)</p>
         </section>
-        <section id="zsa-fee-considerations"><h2><span class="section-heading">ZSA Fee Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#zsa-fee-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+        <section id="revision-1-zsa-fee-considerations"><h2><span class="section-heading">Revision 1: ZSA Fee Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-zsa-fee-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>We choose to maintain the native ZEC Asset as the primary token for the Zcash blockchain, similar to how ETH is needed for ERC20 transactions to the benefit of the Ethereum ecosystem.</p>
             <p>An alternative proposal for the ZSA fee mechanism that was not adopted was to adopt a new type of fee, denominated in the custom Asset being issued or transferred. In the context of transparent transactions, such a fee allows miners to “tap into” the ZSA value of the transactions, rather than the ZEC value of transactions. However when transactions are shielded, any design that lifts value from the transaction would also leak information about it.</p>
         </section>

--- a/rendered/zip-0317.html
+++ b/rendered/zip-0317.html
@@ -299,7 +299,6 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                         <tr>
                             <th>Parameter</th>
                             <th>Value</th>
-                            <th>Units</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -309,17 +308,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                             </td>
                             <td>
                                 <span class="math">\(100 \cdot marginal\_fee\)</span>
-                            </td>
-                            <td>zatoshis per issuance action (as defined below)</td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span class="math">\(finalize\_fee\)</span>
-                            </td>
-                            <td>
-                                <span class="math">\(20 \cdot marginal\_fee\)</span>
-                            </td>
-                            <td>zatoshis per issuance action (as defined below)</td>
+                             per issuance action (as defined below)</td>
                         </tr>
                     </tbody>
                 </table>
@@ -330,12 +319,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
   zsa\_logical\_actions  &amp;=&amp; logical\_actions \;+ \\
                     &amp; &amp; nTotalOutputsZsaIssuance \\
   zsa\_conventional\_fee &amp;=&amp; marginal\_fee \cdot \mathsf{max}(grace\_actions, zsa\_logical\_actions) \;+ \\
-                    &amp; &amp; issuance\_fee \cdot nIssueActions \;- \\
-                    &amp; &amp; finalize\_fee \cdot nFinalizeActions
+                    &amp; &amp; issuance\_fee \cdot nCreateActions
 \end{array}\)</div>
-                <p>The inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-13" class="footnote_reference" href="#protocol-txnencoding">3</a>. They are defined in the <a href="#fee-calculation">Fee calculation</a> section above, with additional definitions in the table below. Note that
+                <p>The inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-13" class="footnote_reference" href="#protocol-txnencoding">3</a> and the global . They are defined in the <a href="#fee-calculation">Fee calculation</a> section above, with additional definitions in the table below. Note that
                     <span class="math">\(nOrchardActions\)</span>
-                 is redefined and now combines both the Orchard actions for ZEC values as well as ZSA transfer actions for transfer of Assets.</p>
+                 is redefined and now combines the actions for native ZEC as well as ZSA transfer actions for Custom Assets.</p>
                 <table>
                     <thead>
                         <tr>
@@ -350,7 +338,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                                 <span class="math">\(nOrchardActions\)</span>
                             </td>
                             <td>number</td>
-                            <td>the number of ZSA transfer actions (including ZEC actions)</td>
+                            <td>the number of OrchardZSA transfer actions (including ZEC actions)</td>
                         </tr>
                         <tr>
                             <td>
@@ -361,21 +349,18 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                         </tr>
                         <tr>
                             <td>
-                                <span class="math">\(nIssueActions\)</span>
+                                <span class="math">\(nCreateActions\)</span>
                             </td>
                             <td>number</td>
-                            <td>the number of ZSA issuance actions</td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span class="math">\(nFinalizeActions\)</span>
-                            </td>
-                            <td>number</td>
-                            <td>the number of ZSA issuance actions that set the <code>finalize</code> flag</td>
+                            <td>the number of ZSA issuance actions that issue a Custom Asset that is not present in the Global Issuance State</td>
                         </tr>
                     </tbody>
                 </table>
                 <p>It is not a consensus requirement that fees follow this formula; however, wallets SHOULD create transactions that pay this fee, in order to reduce information leakage, unless overridden by the user.</p>
+                <section id="rationale-for-zsa-fee-calculation"><h4><span class="section-heading">Rationale for ZSA Fee calculation</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-zsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>The ZSA fee calculation accounts for the additions to the Global Issuance State that are required for the ZSA protocol. Every newly created Custom Asset adds a new row to the Global Issuance State. Subsequent issuance, finalization, or burn of existing Custom Assets only changes the values in the corresponding row.</p>
+                    <p>This explains the need for a higher fee for the creation of entirely new Custom Assets, in order to disincentivize the creation of "junk" assets.</p>
+                </section>
             </section>
             <section id="transaction-relaying"><h3><span class="section-heading">Transaction relaying</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-relaying"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>zcashd, zebrad, and potentially other node implementations, implement fee-based restrictions on relaying of mempool transactions. Nodes that normally relay transactions are expected to do so for transactions that pay at least the conventional fee as specified in this ZIP, unless there are other reasons not to do so for robustness or denial-of-service mitigation.</p>
@@ -570,7 +555,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 <p><cite>zebra</cite> uses a similar relay threshold rule to <cite>zcashd</cite>, but additionally enforces a minimum fee of 100 zatoshis (this differs from <cite>zcashd</cite> only for valid transactions of less than 1000 bytes, assuming that <cite>zcashd</cite> uses its default value for <code>-minrelaytxfee</code>).</p>
             </section>
             <section id="revision-1-deployment-of-zsa-changes"><h3><span class="section-heading">Revision 1: Deployment of ZSA changes</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-deployment-of-zsa-changes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of the deployment of the ZSA protocol (ZIP 226 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0227">7</a>), which is currently projected to be with Network Upgrade 7.</p>
+                <p>The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of deployment of the ZSA protocol (ZIP 226 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0227">7</a>), which is currently projected to be with Network Upgrade 7.</p>
             </section>
         </section>
         <section id="considered-alternatives"><h2><span class="section-heading">Considered Alternatives</span><span class="section-anchor"> <a rel="bookmark" href="#considered-alternatives"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/rendered/zip-0317.html
+++ b/rendered/zip-0317.html
@@ -39,15 +39,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The goal of this ZIP is to change the conventional fees for transactions by making them dependent on the number of inputs and outputs in a transaction, and to get buy-in for this change from wallet developers, miners and Zcash users.</p>
-            <p>Revision 1 of this ZIP additionally defines the fee mechanism associated with the Zcash Shielded Assets (ZSA) protocol as described in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">7</a>.</p>
+            <p>Revision 1 of this ZIP additionally defines the fee mechanism associated with the Orchard Zcash Shielded Assets (OrchardZSA) protocol as described in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">7</a>.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>In light of recent Mainnet network activity, it is time to review and update the standard 1,000 zatoshi transaction fee set in ZIP 313 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0313">8</a>.</p>
             <p>The conventional transaction fee presently is 0.00001 ZEC or 1,000 zatoshis, as specified in ZIP 313. This allowed exploration of novel use cases of the Zcash blockchain. The Zcash network has operated for almost 2 years at a conventional transaction fee of 1,000 zatoshis, without consideration for the total number of inputs and outputs in each transaction. Under this conventional fee, some usage of the chain has been characterized by high-output transactions with 1,100 outputs, paying the same conventional fee as a transaction with 2 outputs.</p>
             <p>The objective of the new fee policy, once it is enforced, is for fees paid by transactions to fairly reflect the processing costs that their inputs and outputs impose on various participants in the network. This will tend to discourage usage patterns that cause either intentional or unintentional denial of service, while still allowing low fees for regular transaction use cases.</p>
             <section id="revision-1"><h3><span class="section-heading">Revision 1:</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The upgrade to the ZSA protocol will also need to define a fee structure consistent with the above objectives. This involves adaptation for the transfer protocol <a id="footnote-reference-8" class="footnote_reference" href="#zip-0226">6</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">7</a> such as fees for asset issuance.</p>
-                <p>Specifically, the ZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers.</p>
+                <p>The upgrade to the OrchardZSA protocol will also need to define a fee structure consistent with the above objectives. This involves adaptation for the transfer protocol <a id="footnote-reference-8" class="footnote_reference" href="#zip-0226">6</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">7</a> such as fees for asset issuance.</p>
+                <p>Specifically, the OrchardZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers.</p>
                 <p>In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-10" class="footnote_reference" href="#zip-0227">7</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
             </section>
         </section>
@@ -57,6 +57,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 <li>The fee for a transaction should scale linearly with the number of inputs and/or outputs.</li>
                 <li>Users should not be penalised for sending transactions constructed with padding of inputs and outputs to reduce information leakage. (The default policy employed by zcashd and the mobile SDKs pads to two inputs and two outputs for each shielded pool used by the transaction).</li>
                 <li>Users should be able to spend a small number of UTXOs or notes with value below the marginal fee per input.</li>
+                <li>The conventional fee should not leak private information used in constructing the transaction; that is, it should be computable from only the public data of the transaction.</li>
                 <li>Revision 1: Users should be discouraged from issuing new “garbage” custom Assets. The fee should reflect the cost of adding new data to the global state.</li>
             </ul>
         </section>
@@ -64,7 +65,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
             <section id="revisions"><h3><span class="section-heading">Revisions</span><span class="section-anchor"> <a rel="bookmark" href="#revisions"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <ul>
                     <li>Revision 0: The initial version of this specification.</li>
-                    <li>Revision 1: This version adds to the fees mechanism post the adoption of the ZSA Protocol. It adds additional fee considerations for the issuance and finalization of custom Zcash Shielded Assets.</li>
+                    <li>Revision 1: This version adds to the fees mechanism post the adoption of the OrchardZSA Protocol. It adds additional fee considerations for the issuance and finalization of custom Zcash Shielded Assets.</li>
                 </ul>
             </section>
             <section id="notation"><h3><span class="section-heading">Notation</span><span class="section-anchor"> <a rel="bookmark" href="#notation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -292,8 +293,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                     </details></section>
                 </section>
             </section>
-            <section id="revision-1-zsa-fee-calculation"><h3><span class="section-heading">Revision 1: ZSA Fee calculation</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-zsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In addition to the parameters defined in the <a href="#fee-calculation">Fee calculation</a> section, the ZSA protocol upgrade defines the following additional parameters:</p>
+            <section id="revision-1-orchardzsa-fee-calculation"><h3><span class="section-heading">Revision 1: OrchardZSA Fee calculation</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>In addition to the parameters defined in the <a href="#fee-calculation">Fee calculation</a> section, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
                 <table>
                     <thead>
                         <tr>
@@ -323,7 +324,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
 \end{array}\)</div>
                 <p>The inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-13" class="footnote_reference" href="#protocol-txnencoding">3</a> and the global . They are defined in the <a href="#fee-calculation">Fee calculation</a> section above, with additional definitions in the table below. Note that
                     <span class="math">\(nOrchardActions\)</span>
-                 is redefined and now combines the actions for native ZEC as well as ZSA transfer actions for Custom Assets.</p>
+                 is redefined and now combines the actions for native ZEC as well as OrchardZSA transfer actions for Custom Assets.</p>
                 <table>
                     <thead>
                         <tr>
@@ -345,20 +346,20 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                                 <span class="math">\(nTotalOutputsZsaIssuance\)</span>
                             </td>
                             <td>number</td>
-                            <td>the total number of ZSA issuance outputs (added across issuance actions)</td>
+                            <td>the total number of OrchardZSA issuance outputs (added across issuance actions)</td>
                         </tr>
                         <tr>
                             <td>
                                 <span class="math">\(nCreateActions\)</span>
                             </td>
                             <td>number</td>
-                            <td>the number of ZSA issuance actions that issue a Custom Asset that is not present in the Global Issuance State</td>
+                            <td>the number of OrchardZSA issuance actions that issue a Custom Asset that is not present in the Global Issuance State</td>
                         </tr>
                     </tbody>
                 </table>
                 <p>It is not a consensus requirement that fees follow this formula; however, wallets SHOULD create transactions that pay this fee, in order to reduce information leakage, unless overridden by the user.</p>
-                <section id="rationale-for-zsa-fee-calculation"><h4><span class="section-heading">Rationale for ZSA Fee calculation</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-zsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The ZSA fee calculation accounts for the additions to the Global Issuance State that are required for the ZSA protocol. Every newly created Custom Asset adds a new row to the Global Issuance State. Subsequent issuance, finalization, or burn of existing Custom Assets only changes the values in the corresponding row.</p>
+                <section id="rationale-for-orchardzsa-fee-calculation"><h4><span class="section-heading">Rationale for OrchardZSA Fee calculation</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>The OrchardZSA fee calculation accounts for the additions to the Global Issuance State that are required for the OrchardZSA protocol. Every newly created Custom Asset adds a new row to the Global Issuance State. Subsequent issuance, finalization, or burn of existing Custom Assets only changes the values in the corresponding row.</p>
                     <p>This explains the need for a higher fee for the creation of entirely new Custom Assets, in order to disincentivize the creation of "junk" assets.</p>
                 </section>
             </section>
@@ -554,8 +555,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 </ul>
                 <p><cite>zebra</cite> uses a similar relay threshold rule to <cite>zcashd</cite>, but additionally enforces a minimum fee of 100 zatoshis (this differs from <cite>zcashd</cite> only for valid transactions of less than 1000 bytes, assuming that <cite>zcashd</cite> uses its default value for <code>-minrelaytxfee</code>).</p>
             </section>
-            <section id="revision-1-deployment-of-zsa-changes"><h3><span class="section-heading">Revision 1: Deployment of ZSA changes</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-deployment-of-zsa-changes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of deployment of the ZSA protocol (ZIP 226 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0227">7</a>), which is currently projected to be with Network Upgrade 7.</p>
+            <section id="revision-1-deployment-of-orchardzsa-changes"><h3><span class="section-heading">Revision 1: Deployment of OrchardZSA changes</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-deployment-of-orchardzsa-changes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The parts of this ZIP that list out changes to the fee mechanism for the OrchardZSA protocol SHOULD be deployed at the time of deployment of the OrchardZSA protocol (ZIP 226 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0226">6</a> and ZIP 227 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0227">7</a>), which is currently projected to be with Network Upgrade 7.</p>
             </section>
         </section>
         <section id="considered-alternatives"><h2><span class="section-heading">Considered Alternatives</span><span class="section-anchor"> <a rel="bookmark" href="#considered-alternatives"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -584,9 +585,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 <span class="math">\(grace\_actions\)</span>
              threshold. This is no longer expressible with the formula specified above.)</p>
         </section>
-        <section id="revision-1-zsa-fee-considerations"><h2><span class="section-heading">Revision 1: ZSA Fee Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-zsa-fee-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+        <section id="revision-1-orchardzsa-fee-considerations"><h2><span class="section-heading">Revision 1: OrchardZSA Fee Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#revision-1-orchardzsa-fee-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>We choose to maintain the native ZEC Asset as the primary token for the Zcash blockchain, similar to how ETH is needed for ERC20 transactions to the benefit of the Ethereum ecosystem.</p>
-            <p>An alternative proposal for the ZSA fee mechanism that was not adopted was to adopt a new type of fee, denominated in the custom Asset being issued or transferred. In the context of transparent transactions, such a fee allows miners to “tap into” the ZSA value of the transactions, rather than the ZEC value of transactions. However when transactions are shielded, any design that lifts value from the transaction would also leak information about it.</p>
+            <p>An alternative proposal for the OrchardZSA fee mechanism that was not adopted was to adopt a new type of fee, denominated in the custom Asset being issued or transferred. In the context of transparent transactions, such a fee allows miners to “tap into” the ZSA value of the transactions, rather than the ZEC value of transactions. However when transactions are shielded, any design that lifts value from the transaction would also leak information about it.</p>
         </section>
         <section id="endorsements"><h2><span class="section-heading">Endorsements</span><span class="section-anchor"> <a rel="bookmark" href="#endorsements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The following entities and developers of the listed software expressed their support for the updated fee mechanism:</p>

--- a/zips/zip-0317.rst
+++ b/zips/zip-0317.rst
@@ -78,7 +78,7 @@ while still allowing low fees for regular transaction use cases.
 Revision 1:
 -----------
 
-The upgrade to the ZSA protocol will also need to define a fee structure consistent with the above objectives. 
+The upgrade introducing the ZSA protocol will also need to define a fee structure consistent with the above objectives. 
 This involves adaptation for the transfer protocol [#zip-0226]_, as well as additional considerations for the issuance protocol [#zip-0227]_ such as fees for asset issuance. 
 
 Specifically, the ZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. 

--- a/zips/zip-0317.rst
+++ b/zips/zip-0317.rst
@@ -309,12 +309,11 @@ Revision 1: ZSA Fee calculation
 -------------------------------
 In addition to the parameters defined in the `Fee calculation`_ section, the ZSA protocol upgrade defines the following additional parameters:
 
-===================================== ================================ ===============================================
-Parameter                             Value                            Units
-===================================== ================================ ===============================================
-:math:`issuance\_fee`                 :math:`100 \cdot marginal\_fee`  zatoshis per issuance action (as defined below)
-:math:`finalize\_fee`                 :math:`20 \cdot marginal\_fee`   zatoshis per issuance action (as defined below)
-===================================== ================================ ===============================================
+===================================== ==========================================================================
+Parameter                             Value                          
+===================================== ==========================================================================
+:math:`issuance\_fee`                 :math:`100 \cdot marginal\_fee` per issuance action (as defined below)
+===================================== ==========================================================================
 
 Wallets implementing this specification SHOULD use a conventional fee, viz. :math:`zsa\_conventional\_fee`, that is
 calculated in zatoshis per the following formula:
@@ -325,25 +324,33 @@ calculated in zatoshis per the following formula:
      zsa\_logical\_actions  &=& logical\_actions \;+ \\
                        & & nTotalOutputsZsaIssuance \\
      zsa\_conventional\_fee &=& marginal\_fee \cdot \mathsf{max}(grace\_actions, zsa\_logical\_actions) \;+ \\
-                       & & issuance\_fee \cdot nIssueActions \;- \\
-                       & & finalize\_fee \cdot nFinalizeActions
+                       & & issuance\_fee \cdot nCreateActions
    \end{array}
 
 The inputs to this formula are taken from transaction fields defined in the Zcash protocol
-specification [#protocol-txnencoding]_. They are defined in the `Fee calculation`_ section above, with additional definitions in the table below. Note that :math:`nOrchardActions` is redefined and now combines both the Orchard actions for ZEC values as well as ZSA transfer actions for transfer of Assets. 
+specification [#protocol-txnencoding]_ and the global . They are defined in the `Fee calculation`_ section above, with additional definitions in the table below. 
+Note that :math:`nOrchardActions` is redefined and now combines the actions for native ZEC as well as ZSA transfer actions for Custom Assets. 
 
-================================ ====== ========================================================================
+================================ ====== =============================================================================================================
 Input                            Units  Description
-================================ ====== ========================================================================
-:math:`nOrchardActions`          number the number of ZSA transfer actions (including ZEC actions)
+================================ ====== =============================================================================================================
+:math:`nOrchardActions`          number the number of OrchardZSA transfer actions (including ZEC actions)
 :math:`nTotalOutputsZsaIssuance` number the total number of ZSA issuance outputs (added across issuance actions)
-:math:`nIssueActions`            number the number of ZSA issuance actions
-:math:`nFinalizeActions`         number the number of ZSA issuance actions that set the ``finalize`` flag
-================================ ====== ========================================================================
+:math:`nCreateActions`           number the number of ZSA issuance actions that issue a Custom Asset that is not present in the Global Issuance State
+================================ ====== =============================================================================================================
 
 It is not a consensus requirement that fees follow this formula; however,
 wallets SHOULD create transactions that pay this fee, in order to reduce
 information leakage, unless overridden by the user.
+
+Rationale for ZSA Fee calculation
+'''''''''''''''''''''''''''''''''
+
+The ZSA fee calculation accounts for the additions to the Global Issuance State that are required for the ZSA protocol.
+Every newly created Custom Asset adds a new row to the Global Issuance State. 
+Subsequent issuance, finalization, or burn of existing Custom Assets only changes the values in the corresponding row.
+ 
+This explains the need for a higher fee for the creation of entirely new Custom Assets, in order to disincentivize the creation of "junk" assets. 
 
 
 Transaction relaying
@@ -607,7 +614,8 @@ default value for ``-minrelaytxfee``).
 Revision 1: Deployment of ZSA changes
 -------------------------------------
 
-The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of the deployment of the ZSA protocol (ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_), which is currently projected to be with Network Upgrade 7.
+The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of deployment 
+of the ZSA protocol (ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_), which is currently projected to be with Network Upgrade 7.
 
 
 Considered Alternatives

--- a/zips/zip-0317.rst
+++ b/zips/zip-0317.rst
@@ -52,7 +52,7 @@ The goal of this ZIP is to change the conventional fees for transactions
 by making them dependent on the number of inputs and outputs in a transaction,
 and to get buy-in for this change from wallet developers, miners and Zcash users.
 
-Revision 1 of this ZIP additionally defines the fee mechanism associated with the Zcash Shielded Assets (ZSA) protocol as described in ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_.
+Revision 1 of this ZIP additionally defines the fee mechanism associated with the Orchard Zcash Shielded Assets (OrchardZSA) protocol as described in ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_.
 
 
 Motivation
@@ -78,10 +78,10 @@ while still allowing low fees for regular transaction use cases.
 Revision 1:
 -----------
 
-The upgrade introducing the ZSA protocol will also need to define a fee structure consistent with the above objectives. 
+The upgrade to the OrchardZSA protocol will also need to define a fee structure consistent with the above objectives. 
 This involves adaptation for the transfer protocol [#zip-0226]_, as well as additional considerations for the issuance protocol [#zip-0227]_ such as fees for asset issuance. 
 
-Specifically, the ZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. 
+Specifically, the OrchardZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. 
 When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers.
 
 In the case of Issuance, the computational power needed to verify the bundle is not large. 
@@ -118,7 +118,7 @@ Revisions
 ---------
 
 * Revision 0: The initial version of this specification.
-* Revision 1: This version adds to the fees mechanism post the adoption of the ZSA Protocol.
+* Revision 1: This version adds to the fees mechanism post the adoption of the OrchardZSA Protocol.
   It adds additional fee considerations for the issuance and finalization of custom Zcash Shielded Assets.
 
 Notation
@@ -308,9 +308,9 @@ potential denial-of-service attacks.
    </details>
 
 
-Revision 1: ZSA Fee calculation
--------------------------------
-In addition to the parameters defined in the `Fee calculation`_ section, the ZSA protocol upgrade defines the following additional parameters:
+Revision 1: OrchardZSA Fee calculation
+--------------------------------------
+In addition to the parameters defined in the `Fee calculation`_ section, the OrchardZSA protocol upgrade defines the following additional parameters:
 
 ===================================== ==========================================================================
 Parameter                             Value                          
@@ -332,24 +332,24 @@ calculated in zatoshis per the following formula:
 
 The inputs to this formula are taken from transaction fields defined in the Zcash protocol
 specification [#protocol-txnencoding]_ and the global . They are defined in the `Fee calculation`_ section above, with additional definitions in the table below. 
-Note that :math:`nOrchardActions` is redefined and now combines the actions for native ZEC as well as ZSA transfer actions for Custom Assets. 
+Note that :math:`nOrchardActions` is redefined and now combines the actions for native ZEC as well as OrchardZSA transfer actions for Custom Assets. 
 
 ================================ ====== =============================================================================================================
 Input                            Units  Description
 ================================ ====== =============================================================================================================
 :math:`nOrchardActions`          number the number of OrchardZSA transfer actions (including ZEC actions)
-:math:`nTotalOutputsZsaIssuance` number the total number of ZSA issuance outputs (added across issuance actions)
-:math:`nCreateActions`           number the number of ZSA issuance actions that issue a Custom Asset that is not present in the Global Issuance State
+:math:`nTotalOutputsZsaIssuance` number the total number of OrchardZSA issuance outputs (added across issuance actions)
+:math:`nCreateActions`           number the number of OrchardZSA issuance actions that issue a Custom Asset that is not present in the Global Issuance State
 ================================ ====== =============================================================================================================
 
 It is not a consensus requirement that fees follow this formula; however,
 wallets SHOULD create transactions that pay this fee, in order to reduce
 information leakage, unless overridden by the user.
 
-Rationale for ZSA Fee calculation
-'''''''''''''''''''''''''''''''''
+Rationale for OrchardZSA Fee calculation
+''''''''''''''''''''''''''''''''''''''''
 
-The ZSA fee calculation accounts for the additions to the Global Issuance State that are required for the ZSA protocol.
+The OrchardZSA fee calculation accounts for the additions to the Global Issuance State that are required for the OrchardZSA protocol.
 Every newly created Custom Asset adds a new row to the Global Issuance State. 
 Subsequent issuance, finalization, or burn of existing Custom Assets only changes the values in the corresponding row.
  
@@ -614,11 +614,11 @@ enforces a minimum fee of 100 zatoshis (this differs from `zcashd` only for
 valid transactions of less than 1000 bytes, assuming that `zcashd` uses its
 default value for ``-minrelaytxfee``).
 
-Revision 1: Deployment of ZSA changes
--------------------------------------
+Revision 1: Deployment of OrchardZSA changes
+--------------------------------------------
 
-The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of deployment 
-of the ZSA protocol (ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_), which is currently projected to be with Network Upgrade 7.
+The parts of this ZIP that list out changes to the fee mechanism for the OrchardZSA protocol SHOULD be deployed at the time of deployment 
+of the OrchardZSA protocol (ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_), which is currently projected to be with Network Upgrade 7.
 
 
 Considered Alternatives
@@ -644,12 +644,12 @@ Possible alternatives for the parameters:
 of inputs/outputs to be non-proportional above the :math:`grace\_actions`
 threshold. This is no longer expressible with the formula specified above.)
 
-Revision 1: ZSA Fee Considerations
-==================================
+Revision 1: OrchardZSA Fee Considerations
+=========================================
 
 We choose to maintain the native ZEC Asset as the primary token for the Zcash blockchain, similar to how ETH is needed for ERC20 transactions to the benefit of the Ethereum ecosystem.
 
-An alternative proposal for the ZSA fee mechanism that was not adopted was to adopt a new type of fee, denominated in the custom Asset being issued or transferred.
+An alternative proposal for the OrchardZSA fee mechanism that was not adopted was to adopt a new type of fee, denominated in the custom Asset being issued or transferred.
 In the context of transparent transactions, such a fee allows miners to “tap into” the ZSA value of the transactions, rather than the ZEC value of transactions.
 However when transactions are shielded, any design that lifts value from the transaction would also leak information about it.
 

--- a/zips/zip-0317.rst
+++ b/zips/zip-0317.rst
@@ -12,7 +12,7 @@
            Jonathan Rouach
            Pablo Kogan
            Vivek Arte
-  Status: Draft
+  Status: Revision 0: Active, Revision 1: Draft
   Category: Standards / Wallet
   Obsoletes: ZIP 313
   Created: 2022-08-15
@@ -52,7 +52,7 @@ The goal of this ZIP is to change the conventional fees for transactions
 by making them dependent on the number of inputs and outputs in a transaction,
 and to get buy-in for this change from wallet developers, miners and Zcash users.
 
-This ZIP also explicitly defines the fee mechanism associated with the Zcash Shielded Assets (ZSA) protocol as described in ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_.
+Revision 1 of this ZIP additionally defines the fee mechanism associated with the Zcash Shielded Assets (ZSA) protocol as described in ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_.
 
 
 Motivation
@@ -75,11 +75,19 @@ impose on various participants in the network. This will tend to discourage
 usage patterns that cause either intentional or unintentional denial of service,
 while still allowing low fees for regular transaction use cases.
 
-The proposed upgrade to the ZSA protocol will also need to define a fee structure consistent with the above objectives. This involves adaptation for the transfer protocol [#zip-0226]_, as well as additional considerations for the issuance protocol [#zip-0227]_ such as fees for asset issuance.
+Revision 1:
+-----------
 
-Specifically, the ZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, we believe that there should be a disincentive that will stop users from flooding the chain with useless asset identifiers.
+The upgrade to the ZSA protocol will also need to define a fee structure consistent with the above objectives. 
+This involves adaptation for the transfer protocol [#zip-0226]_, as well as additional considerations for the issuance protocol [#zip-0227]_ such as fees for asset issuance. 
 
-In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 [#zip-0227]_, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.
+Specifically, the ZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. 
+When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers.
+
+In the case of Issuance, the computational power needed to verify the bundle is not large. 
+The transaction size, however, can be an issue as the number of output notes can be large. 
+Furthermore, as defined in ZIP 227 [#zip-0227]_, there is an additional data structure in the global state that needs to be maintained as part of the consensus. 
+This motivates further the addition of an Issuance-specific fee.
 
 
 Requirements
@@ -95,13 +103,20 @@ Requirements
   two inputs and two outputs for each shielded pool used by the transaction).
 * Users should be able to spend a small number of UTXOs or notes with value
   below the marginal fee per input.
-* Post the upgrade to the ZSA protocol, users should be discouraged from issuing new “garbage” custom Assets.
-* Post the upgrade to the ZSA protocol, users should be discouraged from finalizing Assets frivolously.
+* Revision 1: Users should be discouraged from issuing new “garbage” custom Assets. 
+  The fee should reflect the cost of adding new data to the global state.
 
 
 
 Specification
 =============
+
+Revisions
+---------
+
+* Revision 0: The initial version of this specification.
+* Revision 1: This version adds to the fees mechanism post the adoption of the ZSA Protocol.
+  It adds additional fee considerations for the issuance and finalization of custom Zcash Shielded Assets.
 
 Notation
 --------
@@ -290,16 +305,16 @@ potential denial-of-service attacks.
    </details>
 
 
-ZSA Fee calculation
--------------------
+Revision 1: ZSA Fee calculation
+-------------------------------
 In addition to the parameters defined in the `Fee calculation`_ section, the ZSA protocol upgrade defines the following additional parameters:
 
-===================================== =============== ===============================================
-Parameter                                 Value         Units
-===================================== =============== ===============================================
-:math:`issuance\_fee`                 :math:`1000000` zatoshis per issuance action (as defined below)
-:math:`finalize\_fee`                 :math:`1000000` zatoshis per issuance action (as defined below)
-===================================== =============== ===============================================
+===================================== ================================ ===============================================
+Parameter                             Value                            Units
+===================================== ================================ ===============================================
+:math:`issuance\_fee`                 :math:`100 \cdot marginal\_fee`  zatoshis per issuance action (as defined below)
+:math:`finalize\_fee`                 :math:`20 \cdot marginal\_fee`   zatoshis per issuance action (as defined below)
+===================================== ================================ ===============================================
 
 Wallets implementing this specification SHOULD use a conventional fee, viz. :math:`zsa\_conventional\_fee`, that is
 calculated in zatoshis per the following formula:
@@ -310,7 +325,7 @@ calculated in zatoshis per the following formula:
      zsa\_logical\_actions  &=& logical\_actions \;+ \\
                        & & nTotalOutputsZsaIssuance \\
      zsa\_conventional\_fee &=& marginal\_fee \cdot \mathsf{max}(grace\_actions, zsa\_logical\_actions) \;+ \\
-                       & & issuance\_fee \cdot nIssueActions \;+ \\
+                       & & issuance\_fee \cdot nIssueActions \;- \\
                        & & finalize\_fee \cdot nFinalizeActions
    \end{array}
 
@@ -589,10 +604,10 @@ enforces a minimum fee of 100 zatoshis (this differs from `zcashd` only for
 valid transactions of less than 1000 bytes, assuming that `zcashd` uses its
 default value for ``-minrelaytxfee``).
 
-Deployment of ZSA changes
--------------------------
+Revision 1: Deployment of ZSA changes
+-------------------------------------
 
-The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of the deployment of the ZSA protocol (ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_), which is currently projected to be with Network Upgrade 6.
+The parts of this ZIP that list out changes to the fee mechanism for the ZSA protocol SHOULD be deployed at the time of the deployment of the ZSA protocol (ZIP 226 [#zip-0226]_ and ZIP 227 [#zip-0227]_), which is currently projected to be with Network Upgrade 7.
 
 
 Considered Alternatives
@@ -618,8 +633,8 @@ Possible alternatives for the parameters:
 of inputs/outputs to be non-proportional above the :math:`grace\_actions`
 threshold. This is no longer expressible with the formula specified above.)
 
-ZSA Fee Considerations
-======================
+Revision 1: ZSA Fee Considerations
+==================================
 
 We choose to maintain the native ZEC Asset as the primary token for the Zcash blockchain, similar to how ETH is needed for ERC20 transactions to the benefit of the Ethereum ecosystem.
 

--- a/zips/zip-0317.rst
+++ b/zips/zip-0317.rst
@@ -103,6 +103,9 @@ Requirements
   two inputs and two outputs for each shielded pool used by the transaction).
 * Users should be able to spend a small number of UTXOs or notes with value
   below the marginal fee per input.
+* The conventional fee should not leak private information used in
+  constructing the transaction; that is, it should be computable from only
+  the public data of the transaction.
 * Revision 1: Users should be discouraged from issuing new “garbage” custom Assets. 
   The fee should reflect the cost of adding new data to the global state.
 


### PR DESCRIPTION
- This PR rewrites ZIP 317 in order to specify which are the revisions made for the ZSA Protocol.
- It also rewrites the issuance_fee as a multiple of the marginal_fee for easier analysis.
- The finalization fee is also removed, based on our discussions.
