### PR TITLE
[ZSA] Issuance Key Derivation update to match with ZIP 32

### DIFF
--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -125,15 +125,31 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
             <section id="issuance-key-derivation"><h3><span class="section-heading">Issuance Key Derivation</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-key-derivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <section id="issuance-authorizing-key-generation-for-hierarchical-deterministic-wallets"><h4><span class="section-heading">Issuance authorizing key generation for hierarchical deterministic wallets</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-authorizing-key-generation-for-hierarchical-deterministic-wallets"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The issuance authorizing key is generated using the Orchard master key derivation procedure defined in ZIP 32 <a id="footnote-reference-12" class="footnote_reference" href="#zip-0032-orchard-master">3</a>. We reuse the functions defined there in what follows in this section.</p>
+                    <p>The issuance authorizing key is generated using the Hardened-only key derivation process defined in ZIP 32 <a id="footnote-reference-12" class="footnote_reference" href="#zip-0032-hardened-only-key-derivation">3</a>. For the
+                        <span class="math">\(\mathsf{Issuance}\)</span>
+                     context, we define the following constants:</p>
+                    <ul>
+                        <li>
+                            <span class="math">\(\mathsf{Issuance.\!MKGDomain} := \texttt{"ZIP32ZSAIssue_V1"}\)</span>
+                        </li>
+                        <li>
+                            <span class="math">\(\mathsf{Issuance.\!CKDDomain} := \mathtt{0x81}\!\)</span>
+                        </li>
+                    </ul>
                     <p>Let
                         <span class="math">\(S\)</span>
                      be a seed byte sequence of a chosen length, which MUST be at least 32 and at most 252 bytes. We define the master extended issuance key
-                        <span class="math">\(m_{\mathsf{Issuance}} := \mathsf{MasterKeyGen}(\texttt{"ZIP32ZSAIssue_V1"}, S)\!\)</span>
+                        <span class="math">\(m_{\mathsf{Issuance}} := \mathsf{MKGh}^{\mathsf{Issuance}}(S)\!\)</span>
                     .</p>
-                    <p>As in ZIP 32 for Orchard <a id="footnote-reference-13" class="footnote_reference" href="#zip-0032-orchard-child-key-derivation">4</a>, we only use hardened child key derivation for the issuance authorizing key. We reuse the
-                        <span class="math">\(\mathsf{CDKsk}\)</span>
-                     function for Orchard child key derivation from ZIP 32.</p>
+                    <p>We use hardened-only child key derivation as defined in ZIP 32 <a id="footnote-reference-13" class="footnote_reference" href="#zip-0032-hardened-only-child-key-derivation">4</a> for the issuance authorizing key.</p>
+                    <p>
+                        <span class="math">\(\mathsf{CDKsk}((\mathsf{sk}_{par},\mathsf{c}_{par}), i) \rightarrow (\mathsf{sk}_{i}, \mathsf{c}_{i})\)</span>
+                    </p>
+                    <ul>
+                        <li>Return
+                            <span class="math">\(\mathsf{CKDh}^{\mathsf{Issuance}}((\mathsf{sk}_{par},\mathsf{c}_{par}), i)\!\)</span>
+                        </li>
+                    </ul>
                     <p>We use the notation of ZIP 32 <a id="footnote-reference-14" class="footnote_reference" href="#zip-0032-orchard-key-path">6</a> for shielded HD paths, and define the issuance authorizing key path as
                         <span class="math">\(m_{\mathsf{Issuance}} / \mathit{purpose}' / \mathit{coin\_type}' / \mathit{account}'\!\)</span>
                     . We fix the path levels as follows:</p>
@@ -859,19 +875,19 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0032-orchard-master" class="footnote">
+            <table id="zip-0032-hardened-only-key-derivation" class="footnote">
                 <tbody>
                     <tr>
                         <th>3</th>
-                        <td><a href="zip-0032.html#orchard-master-key-generation">ZIP 32: Shielded Hierarchical Deterministic Wallets - Orchard master key generation</a></td>
+                        <td><a href="zip-0032.html#specification-hardened-only-key-derivation">ZIP 32: Shielded Hierarchical Deterministic Wallets - Specification: Hardened-only key derivation</a></td>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0032-orchard-child-key-derivation" class="footnote">
+            <table id="zip-0032-hardened-only-child-key-derivation" class="footnote">
                 <tbody>
                     <tr>
                         <th>4</th>
-                        <td><a href="zip-0032.html#orchard-child-key-derivation">ZIP 32: Shielded Hierarchical Deterministic Wallets - Orchard child key derivation</a></td>
+                        <td><a href="zip-0032.html#hardened-only-child-key-derivation">ZIP 32: Shielded Hierarchical Deterministic Wallets - Hardened-only child key derivation</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -123,13 +123,20 @@ Issuance Key Derivation
 Issuance authorizing key generation for hierarchical deterministic wallets
 ``````````````````````````````````````````````````````````````````````````
 
-The issuance authorizing key is generated using the Orchard master key derivation procedure defined in ZIP 32 [#zip-0032-orchard-master]_. We reuse the functions defined there in what follows in this section.
+The issuance authorizing key is generated using the Hardened-only key derivation process defined in ZIP 32 [#zip-0032-hardened-only-key-derivation]_. 
+For the :math:`\mathsf{Issuance}` context, we define the following constants:
+
+- :math:`\mathsf{Issuance.\!MKGDomain} := \texttt{"ZIP32ZSAIssue_V1"}`
+- :math:`\mathsf{Issuance.\!CKDDomain} := \mathtt{0x81}\!`
 
 Let :math:`S` be a seed byte sequence of a chosen length, which MUST be at least 32 and at most 252 bytes.
-We define the master extended issuance key :math:`m_{\mathsf{Issuance}} := \mathsf{MasterKeyGen}(\texttt{"ZIP32ZSAIssue_V1"}, S)\!`.
+We define the master extended issuance key :math:`m_{\mathsf{Issuance}} := \mathsf{MKGh}^{\mathsf{Issuance}}(S)\!`.
 
-As in ZIP 32 for Orchard [#zip-0032-orchard-child-key-derivation]_, we only use hardened child key derivation for the issuance authorizing key.
-We reuse the :math:`\mathsf{CDKsk}` function for Orchard child key derivation from ZIP 32.
+We use hardened-only child key derivation as defined in ZIP 32 [#zip-0032-hardened-only-child-key-derivation]_ for the issuance authorizing key.
+
+:math:`\mathsf{CDKsk}((\mathsf{sk}_{par},\mathsf{c}_{par}), i) \rightarrow (\mathsf{sk}_{i}, \mathsf{c}_{i})` 
+
+- Return :math:`\mathsf{CKDh}^{\mathsf{Issuance}}((\mathsf{sk}_{par},\mathsf{c}_{par}), i)\!`
 
 We use the notation of ZIP 32 [#zip-0032-orchard-key-path]_ for shielded HD paths, and define the issuance authorizing key path as :math:`m_{\mathsf{Issuance}} / \mathit{purpose}' / \mathit{coin\_type}' / \mathit{account}'\!`. We fix the path levels as follows:
 
@@ -624,8 +631,8 @@ References
 
 .. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0032] `ZIP 32: Shielded Hierarchical Deterministic Wallets <zip-0032.html>`_
-.. [#zip-0032-orchard-master] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Orchard master key generation <zip-0032.html#orchard-master-key-generation>`_
-.. [#zip-0032-orchard-child-key-derivation] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Orchard child key derivation <zip-0032.html#orchard-child-key-derivation>`_
+.. [#zip-0032-hardened-only-key-derivation] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Specification: Hardened-only key derivation <zip-0032.html#specification-hardened-only-key-derivation>`_
+.. [#zip-0032-hardened-only-child-key-derivation] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Hardened-only child key derivation <zip-0032.html#hardened-only-child-key-derivation>`_
 .. [#zip-0032-key-path-levels] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Key path levels <zip-0032.html#key-path-levels>`_
 .. [#zip-0032-orchard-key-path] `ZIP 32: Shielded Hierarchical Deterministic Wallets - Orchard key path <zip-0032.html#orchard-key-path>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.html>`_


### PR DESCRIPTION
This PR makes the changes to align with the change in notation for ZIP 32 done in #908.