### PR TITLE
[ZSAs] Updates to include Action Groups in TxV6

### DIFF
--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -497,6 +497,8 @@ T.4a.iii: orchard_actions_noncompact_digest   (32-byte hash output)
 T.4a.iv : flagsOrchard                        (1 byte)
 T.4a.v  : anchorOrchard                       (32 bytes)
 T.4a.vi : timeLimit                           (4 bytes)</pre>
+                        <p>The personalization field of this hash is set to:</p>
+                        <pre>"ZTxIdOrcActGHash"</pre>
                         <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.i.1 : nullifier            (field encoding bytes)

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -473,7 +473,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">12</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>A BLAKE2b-256 hash of the following values</p>
+                <p>A BLAKE2b-256 hash of the following values:</p>
                 <pre>T.1: header_digest       (32-byte hash output)
 T.2: transparent_digest  (32-byte hash output)
 T.3: sapling_digest      (32-byte hash output)
@@ -481,65 +481,74 @@ T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
 T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0244">12</a>.</p>
                 <section id="t-4-orchard-digest"><h4><span class="section-heading">T.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>When Orchard Actions are present in the transaction, this digest is a BLAKE2b-256 hash of the following values</p>
-                    <pre>T.4a: orchard_actions_compact_digest      (32-byte hash output)          [UPDATED FOR ZSA]
-T.4b: orchard_actions_memos_digest        (32-byte hash output)          [UPDATED FOR ZSA]
-T.4c: orchard_actions_noncompact_digest   (32-byte hash output)          [UPDATED FOR ZSA]
-T.4d: orchard_zsa_burn_digest             (32-byte hash output)          [ADDED FOR ZSA]
-T.4e: flagsOrchard                        (1 byte)
-T.4f: valueBalanceOrchard                 (64-bit signed little-endian)
-T.4g: anchorOrchard                       (32 bytes)</pre>
-                    <section id="t-4a-orchard-actions-compact-digest"><h5><span class="section-heading">T.4a: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
-                        <pre>T.4a.i  : nullifier            (field encoding bytes)
-T.4a.ii : cmx                  (field encoding bytes)
-T.4a.iii: ephemeralKey         (field encoding bytes)
-T.4a.iv : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR ZSA]</pre>
-                        <p>The personalization field of this hash is the same as in ZIP 244:</p>
-                        <pre>"ZTxIdOrcActCHash"</pre>
+                    <p>When Orchard Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values:</p>
+                    <pre>T.4a: orchard_action_groups_digest   (32-byte hash output)          [ADDED FOR ZSA]
+T.4b: orchard_zsa_burn_digest        (32-byte hash output)          [ADDED FOR ZSA]
+T.4c: valueBalanceOrchard            (64-bit signed little-endian)</pre>
+                    <p>The personalization field of this hash is the same as in ZIP 244 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0244">12</a></p>
+                    <pre>"ZTxIdOrchardHash"</pre>
+                    <p>In the case that the transaction has no Orchard Action Groups, <code>orchard_digest</code> is</p>
+                    <pre>BLAKE2b-256("ZTxIdOrchardHash", [])</pre>
+                    <section id="t-4a-orchard-action-groups-digest"><h5><span class="section-heading">T.4a: orchard_action_groups_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-action-groups-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                        <p>A BLAKE2b-256 hash of the subset of Orchard Action Groups information for all Orchard Action Groups belonging to the transaction. For each Action Group, the following elements are included in the hash:</p>
+                        <pre>T.4a.i  : orchard_actions_compact_digest      (32-byte hash output)
+T.4a.ii : orchard_actions_memos_digest        (32-byte hash output)
+T.4a.iii: orchard_actions_noncompact_digest   (32-byte hash output)
+T.4a.iv : flagsOrchard                        (1 byte)
+T.4a.v  : anchorOrchard                       (32 bytes)
+T.4a.vi : timeLimit                           (4 bytes)</pre>
+                        <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                            <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <pre>T.4a.i.1 : nullifier            (field encoding bytes)
+T.4a.i.2 : cmx                  (field encoding bytes)
+T.4a.i.3 : ephemeralKey         (field encoding bytes)
+T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR ZSA]</pre>
+                            <p>The personalization field of this hash is the same as in ZIP 244:</p>
+                            <pre>"ZTxIdOrcActCHash"</pre>
+                        </section>
+                        <section id="t-4a-ii-orchard-actions-memos-digest"><h6><span class="section-heading">T.4a.ii: orchard_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-ii-orchard-actions-memos-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                            <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <pre>T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]</pre>
+                            <p>The personalization field of this hash remains identical to ZIP 244:</p>
+                            <pre>"ZTxIdOrcActMHash"</pre>
+                        </section>
+                        <section id="t-4a-iii-orchard-actions-noncompact-digest"><h6><span class="section-heading">T.4a.iii: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iii-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                            <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <pre>T.4a.iii.1 : cv                    (field encoding bytes)
+T.4a.iii.2 : rk                    (field encoding bytes)
+T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
+T.4a.iii.4 : outCiphertext         (field encoding bytes)</pre>
+                            <p>The personalization field of this hash is defined identically to ZIP 244:</p>
+                            <pre>"ZTxIdOrcActNHash"</pre>
+                        </section>
                     </section>
-                    <section id="t-4b-orchard-actions-memos-digest"><h5><span class="section-heading">T.4b: orchard_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4b-orchard-actions-memos-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
-                        <pre>T.4b.i: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]</pre>
-                        <p>The personalization field of this hash remains identical to ZIP 244:</p>
-                        <pre>"ZTxIdOrcActMHash"</pre>
-                    </section>
-                    <section id="t-4c-orchard-actions-noncompact-digest"><h5><span class="section-heading">T.4c: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4c-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
-                        <pre>T.4d.i  : cv                    (field encoding bytes)
-T.4d.ii : rk                    (field encoding bytes)
-T.4d.iii: encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
-T.4d.iv : outCiphertext         (field encoding bytes)</pre>
-                        <p>The personalization field of this hash is defined identically to ZIP 244:</p>
-                        <pre>"ZTxIdOrcActNHash"</pre>
-                    </section>
-                    <section id="t-4d-orchard-zsa-burn-digest"><h5><span class="section-heading">T.4d: orchard_zsa_burn_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4d-orchard-zsa-burn-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                    <section id="t-4b-orchard-zsa-burn-digest"><h5><span class="section-heading">T.4b: orchard_zsa_burn_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4b-orchard-zsa-burn-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>A BLAKE2b-256 hash of the data from the burn fields of the transaction. For each tuple in the
                             <span class="math">\(\mathsf{assetBurn}\)</span>
                          set, the following elements are included in the hash:</p>
-                        <pre>T.4d.i : assetBase    (field encoding bytes)
-T.4d.ii: valueBurn    (field encoding bytes)</pre>
+                        <pre>T.4b.i : assetBase    (field encoding bytes)
+T.4b.ii: valueBurn    (field encoding bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcBurnHash"</pre>
                         <p>In case the transaction does not perform the burning of any Assets (i.e. the
                             <span class="math">\(\mathsf{assetBurn}\)</span>
                          set is empty), the ''orchard_zsa_burn_digest'' is:</p>
                         <pre>BLAKE2b-256("ZTxIdOrcBurnHash", [])</pre>
-                        <section id="t-4d-i-assetbase"><h6><span class="section-heading">T.4d.i: assetBase</span><span class="section-anchor"> <a rel="bookmark" href="#t-4d-i-assetbase"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                        <section id="t-4b-i-assetbase"><h6><span class="section-heading">T.4b.i: assetBase</span><span class="section-anchor"> <a rel="bookmark" href="#t-4b-i-assetbase"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>The Asset Base being burnt encoded as the 32-byte representation of a point on the Pallas curve.</p>
                         </section>
-                        <section id="t-4d-ii-valueburn"><h6><span class="section-heading">T.4d.ii: valueBurn</span><span class="section-anchor"> <a rel="bookmark" href="#t-4d-ii-valueburn"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                        <section id="t-4b-ii-valueburn"><h6><span class="section-heading">T.4b.ii: valueBurn</span><span class="section-anchor"> <a rel="bookmark" href="#t-4b-ii-valueburn"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>Value of the Asset Base being burnt encoded as little-endian 8-byte representation of 64-bit unsigned integer (e.g. u64 in Rust) raw value.</p>
                         </section>
                     </section>
                 </section>
                 <section id="t-5-issuance-digest"><h4><span class="section-heading">T.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0227-txiddigest">8</a>.</p>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0227-txiddigest">8</a>.</p>
                 </section>
             </section>
         </section>
         <section id="signature-digest-and-authorizing-data-commitment"><h2><span class="section-heading">Signature Digest and Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest-and-authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0227-sigdigest">9</a> <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-authcommitment">10</a>.</p>
+            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-sigdigest">9</a> <a id="footnote-reference-57" class="footnote_reference" href="#zip-0227-authcommitment">10</a>.</p>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
@@ -552,7 +561,7 @@ T.4d.ii: valueBurn    (field encoding bytes)</pre>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-57" class="footnote_reference" href="#zip-0317b">14</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-58" class="footnote_reference" href="#zip-0317b">14</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and ZSA notes. As we specify above, there are three main reasons we can do this:</p>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -37,7 +37,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </ul>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">5</a>. The ZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">5</a>, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226). While the proposed ZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.</p>
+            <p>This ZIP (ZIP 226) proposes the Orchard Zcash Shielded Assets (OrchardZSA) protocol, in conjunction with ZIP 227 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0227">5</a>. The OrchardZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">5</a>, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226). While the proposed OrchardZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>None of the currently deployed Zcash transfer protocols support Custom Assets. Enabling multi-asset support on the Zcash chain will open the door for a host of applications, and enhance the ecosystem with application developers and Asset custody institutions for issuance and bridging purposes. This ZIP builds on the issuance mechanism introduced in ZIP 227 <a id="footnote-reference-8" class="footnote_reference" href="#zip-0227">5</a>.</p>
@@ -47,7 +47,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <span class="math">\(\mathsf{AssetId}\!\)</span>
             . This Asset Identifier maps to an Asset Base
                 <span class="math">\(\mathsf{AssetBase}\)</span>
-             that is stored in Orchard-based ZSA notes. These terms are formally defined in ZIP 227 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">5</a>.</p>
+             that is stored in OrchardZSA notes. These terms are formally defined in ZIP 227 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">5</a>.</p>
             <p>The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description <a id="footnote-reference-10" class="footnote_reference" href="#protocol-actions">16</a> <a id="footnote-reference-11" class="footnote_reference" href="#protocol-actionencodingandconsensus">29</a> is preserved across Assets (see the Orchard Binding Signature <a id="footnote-reference-12" class="footnote_reference" href="#protocol-orchardbalance">19</a>), and by extension the balance of an Orchard transaction. That is, the sum of all the
                 <span class="math">\(\mathsf{value^{net}}\)</span>
              from each Action Description, computed as
@@ -95,12 +95,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <section id="note-structure-commitment"><h3><span class="section-heading">Note Structure &amp; Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#note-structure-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>Let
                     <span class="math">\(\mathsf{Note^{OrchardZSA}}\)</span>
-                 be the type of a ZSA note, i.e.
+                 be the type of a OrchardZSA note, i.e.
                     <span class="math">\(\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}^*\!\)</span>
                 .</p>
-                <p>An Orchard ZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">15</a> by additionally including the Asset Base,
+                <p>An OrchardZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">15</a> by additionally including the Asset Base,
                     <span class="math">\(\mathsf{AssetBase}\!\)</span>
-                . So a ZSA note is a tuple
+                . So an OrchardZSA note is a tuple
                     <span class="math">\((\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!\)</span>
                 , where</p>
                 <ul>
@@ -147,21 +147,21 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{I2LEBSP}\)</span>
                  is as defined in §5.1 <a id="footnote-reference-30" class="footnote_reference" href="#protocol-endian">22</a> of the Zcash protocol specification.</p>
                 <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-31" class="footnote_reference" href="#protocol-commitmentsandnullifiers">20</a>.</p>
-                <p>The ZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-32" class="footnote_reference" href="#protocol-notept">28</a>. It consists of</p>
+                <p>The OrchardZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-32" class="footnote_reference" href="#protocol-notept">28</a>. It consists of</p>
                 <div class="math">\((\mathsf{leadByte} : \mathbb{B}^{\mathbb{Y}}, \mathsf{d} : \mathbb{B}^{[\ell_{\mathsf{d}}]}, \mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}, \mathsf{rseed} : \mathbb{B}^{\mathbb{Y}[32]}, \mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}, \mathsf{memo} : \mathbb{B}^{\mathbb{Y}[512]})\)</div>
                 <section id="rationale-for-note-commitment"><h4><span class="section-heading">Rationale for Note Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-note-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In the ZSA protocol, the instance of the note commitment scheme,
+                    <p>In the OrchardZSA protocol, the instance of the note commitment scheme,
                         <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\!\)</span>
                     , differs from the Orchard note commitment
                         <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm}}\)</span>
                      in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretesinsemillacommit">26</a> allows us to add the Asset Base as a final recursive step.</p>
-                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-34" class="footnote_reference" href="#protocol-concretesinsemillahash">24</a>. ZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
+                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-34" class="footnote_reference" href="#protocol-concretesinsemillahash">24</a>. OrchardZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
                     <div class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase}) \in \mathsf{NoteCommit^{Orchard}}.\!\mathsf{Output}\)</div>
-                    <p>This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and ZSA notes.</p>
+                    <p>This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and OrchardZSA notes.</p>
                 </section>
             </section>
             <section id="value-commitment"><h3><span class="section-heading">Value Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#value-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In the case of the Orchard-based ZSA protocol, the value of different Asset Identifiers in a given transaction will be committed using a <strong>different value base point</strong>. The value commitment becomes:</p>
+                <p>In the case of the OrchardZSA protocol, the value of different Asset Identifiers in a given transaction will be committed using a <strong>different value base point</strong>. The value commitment becomes:</p>
                 <div class="math">\(\mathsf{cv^{net}} := \mathsf{ValueCommit^{OrchardZSA}_{rcv}}(\mathsf{AssetBase_{AssetId}}, \mathsf{v^{net}_{AssetId}}) = [\mathsf{v^{net}_{AssetId}}]\,\mathsf{AssetBase_{AssetId}} + [\mathsf{rcv}]\,\mathcal{R}^{\mathsf{Orchard}}\)</div>
                 <p>where
                     <span class="math">\(\mathsf{v^{net}_{AssetId}} = \mathsf{v^{old}_{AssetId}} - \mathsf{v^{new}_{AssetId}}\)</span>
@@ -196,7 +196,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
             <section id="burn-mechanism"><h3><span class="section-heading">Burn Mechanism</span><span class="section-anchor"> <a rel="bookmark" href="#burn-mechanism"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The burn mechanism is a transparent extension to the transfer protocol that enables a specific amount of any Custom Asset to be "destroyed" by the holder. The burn mechanism does NOT send Assets to a non-spendable address, it simply reduces the total number of units of a given Custom Asset in circulation. It is enforced at the consensus level, by using an extension of the value balance mechanism used for ZEC Assets. Burning makes it globally provable that a given amount of a Custom Asset has been destroyed. Note that the OrchardZSA Protocol does not allow for the burning of ZEC (or TAZ).</p>
-                <p>In the <a href="#orchard-zsa-transaction-structure">Orchard-ZSA Transaction Structure</a>, there is now an
+                <p>In the <a href="#orchardzsa-transaction-structure">OrchardZSA Transaction Structure</a>, there is now an
                     <span class="math">\(\mathsf{assetBurn}\)</span>
                  set. For every Custom Asset (represented by its
                     <span class="math">\(\mathsf{AssetBase}\!\)</span>
@@ -323,15 +323,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 .</p>
                 <section id="rationale-for-split-notes"><h4><span class="section-heading">Rationale for Split Notes</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-split-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orcharddummynotes">18</a> to the Actions that have not been assigned input notes.</p>
-                    <p>The Orchard technique requires modification for the ZSA protocol with multiple Asset Identifiers, as the output note of the split Actions <em>cannot</em> contain <em>just any</em> Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.</p>
-                    <p>Therefore, for Custom Assets we enforce that <em>every</em> input note to an ZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the
+                    <p>The Orchard technique requires modification for the OrchardZSA protocol with multiple Asset Identifiers, as the output note of the split Actions <em>cannot</em> contain <em>just any</em> Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.</p>
+                    <p>Therefore, for Custom Assets we enforce that <em>every</em> input note to an OrchardZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the
                         <span class="math">\(\mathsf{split\_flag}\)</span>
                      boolean). This ensures that the value base points of all output notes of a transfer are actual outputs of a GroupHash, as they originate in the Issuance protocol which is publicly verified.</p>
                     <p>Note that the Orchard dummy note functionality remains in use for ZEC notes, and the Split Input technique is used in order to support Custom Assets.</p>
                 </section>
             </section>
             <section id="circuit-statement"><h3><span class="section-heading">Circuit Statement</span><span class="section-anchor"> <a rel="bookmark" href="#circuit-statement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Every <em>ZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">21</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
+                <p>Every <em>OrchardZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">21</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
                 <p>All modifications in the Circuit are detailed in <a id="footnote-reference-45" class="footnote_reference" href="#circuit-modifications">32</a>.</p>
                 <section id="asset-base-equality"><h4><span class="section-heading">Asset Base Equality</span><span class="section-anchor"> <a rel="bookmark" href="#asset-base-equality"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>The following constraints must be added to ensure that the input and output note are of the same
@@ -463,15 +463,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                 </section>
                 <section id="backwards-compatibility-with-zec-notes"><h4><span class="section-heading">Backwards Compatibility with ZEC Notes</span><span class="section-anchor"> <a rel="bookmark" href="#backwards-compatibility-with-zec-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">17</a>. If the note is a ZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
+                    <p>The input note in the old note commitment integrity check must either include an Asset Base (OrchardZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">17</a>. If the note is an OrchardZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
                 </section>
             </section>
         </section>
-        <section id="orchard-zsa-transaction-structure"><h2><span class="section-heading">Orchard-ZSA Transaction Structure</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-transaction-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+        <section id="orchardzsa-transaction-structure"><h2><span class="section-heading">OrchardZSA Transaction Structure</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-transaction-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-49" class="footnote_reference" href="#zip-0230">11</a>.</p>
         </section>
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">12</a> is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the ZSA protocol.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">13</a> is modified by the OrchardZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the OrchardZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values:</p>
                 <pre>T.1: header_digest       (32-byte hash output)
@@ -479,18 +479,18 @@ T.2: transparent_digest  (32-byte hash output)
 T.3: sapling_digest      (32-byte hash output)
 T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
 T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0244">12</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0244">13</a>.</p>
                 <section id="t-4-orchard-digest"><h4><span class="section-heading">T.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>When Orchard Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values:</p>
+                    <p>When OrchardZSA Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values:</p>
                     <pre>T.4a: orchard_action_groups_digest   (32-byte hash output)          [ADDED FOR ZSA]
 T.4b: orchard_zsa_burn_digest        (32-byte hash output)          [ADDED FOR ZSA]
 T.4c: valueBalanceOrchard            (64-bit signed little-endian)</pre>
-                    <p>The personalization field of this hash is the same as in ZIP 244 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0244">12</a></p>
+                    <p>The personalization field of this hash is the same as in ZIP 244 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0244">13</a></p>
                     <pre>"ZTxIdOrchardHash"</pre>
-                    <p>In the case that the transaction has no Orchard Action Groups, <code>orchard_digest</code> is</p>
+                    <p>In the case that the transaction has no OrchardZSA Action Groups, <code>orchard_digest</code> is</p>
                     <pre>BLAKE2b-256("ZTxIdOrchardHash", [])</pre>
                     <section id="t-4a-orchard-action-groups-digest"><h5><span class="section-heading">T.4a: orchard_action_groups_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-action-groups-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the subset of Orchard Action Groups information for all Orchard Action Groups belonging to the transaction. For each Action Group, the following elements are included in the hash:</p>
+                        <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action Groups information for all OrchardZSA Action Groups belonging to the transaction. For each Action Group, the following elements are included in the hash:</p>
                         <pre>T.4a.i  : orchard_actions_compact_digest      (32-byte hash output)
 T.4a.ii : orchard_actions_memos_digest        (32-byte hash output)
 T.4a.iii: orchard_actions_noncompact_digest   (32-byte hash output)
@@ -500,7 +500,7 @@ T.4a.vi : nAGExpiryHeight                     (4 bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcActGHash"</pre>
                         <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">14</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.i.1 : nullifier            (field encoding bytes)
 T.4a.i.2 : cmx                  (field encoding bytes)
 T.4a.i.3 : ephemeralKey         (field encoding bytes)
@@ -509,13 +509,13 @@ T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR
                             <pre>"ZTxIdOrcActCHash"</pre>
                         </section>
                         <section id="t-4a-ii-orchard-actions-memos-digest"><h6><span class="section-heading">T.4a.ii: orchard_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-ii-orchard-actions-memos-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all OrchardZSA Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]</pre>
                             <p>The personalization field of this hash remains identical to ZIP 244:</p>
                             <pre>"ZTxIdOrcActMHash"</pre>
                         </section>
                         <section id="t-4a-iii-orchard-actions-noncompact-digest"><h6><span class="section-heading">T.4a.iii: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iii-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">13</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">14</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.iii.1 : cv                    (field encoding bytes)
 T.4a.iii.2 : rk                    (field encoding bytes)
 T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
@@ -554,30 +554,30 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
-                <li>After the protocol upgrade, the Orchard shielded pool will be shared by the Orchard protocol and the Orchard-ZSA protocol.</li>
-                <li>Deploying the Orchard-ZSA protocol does not necessitate disabling the Orchard protocol. Both can co-exist and be addressed via different transaction versions (V5 for Orchard and V6 for Orchard-ZSA). Due to this, Orchard note commitments can be distinguished from Orchard-ZSA note commitments. This holds whether or not the two protocols are active simultaneously.</li>
-                <li>Orchard-ZSA note commitments for the native asset (ZEC) are indistinguishable from Orchard-ZSA note commitments for non-native Assets.</li>
+                <li>After the protocol upgrade, the Orchard shielded pool will be shared by the Orchard protocol and the OrchardZSA protocol.</li>
+                <li>Deploying the OrchardZSA protocol does not necessitate disabling the Orchard protocol. Both can co-exist and be addressed via different transaction versions (V5 for Orchard and V6 for OrchardZSA). Due to this, Orchard note commitments can be distinguished from OrchardZSA note commitments. This holds whether or not the two protocols are active simultaneously.</li>
+                <li>OrchardZSA note commitments for the native asset (ZEC) are indistinguishable from OrchardZSA note commitments for non-native Assets.</li>
                 <li>When including new Assets we would like to maintain the amount and identifiers of Assets private, which is achieved with the design.</li>
                 <li>We prevent a potential malleability attack on the Asset Identifier by ensuring the output notes receive an Asset Base that exists on the global state.</li>
             </ul>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade <a id="footnote-reference-58" class="footnote_reference" href="#zip-0317b">14</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 230 <a id="footnote-reference-58" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">12</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and ZSA notes. As we specify above, there are three main reasons we can do this:</p>
+                <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and OrchardZSA notes. As we specify above, there are three main reasons we can do this:</p>
                 <ul>
                     <li>Note commitments for ZEC notes will remain the same, while note commitments for Custom Assets will be computed taking into account the
                         <span class="math">\(\mathsf{AssetBase}\)</span>
                      value as well.</li>
-                    <li>The existing Orchard shielded pool will continue to be used for the new ZSA notes post the upgrade.</li>
+                    <li>The existing Orchard shielded pool will continue to be used for the new OrchardZSA notes post the upgrade.</li>
                     <li>The value commitment is abstracted to allow for the value base-point as a variable private input to the proof.</li>
-                    <li>The ZEC-based Actions will still include dummy input notes, whereas the ZSA-based Actions will include split input notes and will not include dummy input notes.</li>
+                    <li>The ZEC-based Actions will still include dummy input notes, whereas the OrchardZSA Actions will include split input notes and will not include dummy input notes.</li>
                 </ul>
             </section>
             <section id="deployment"><h3><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The Zcash Shielded Assets protocol will be deployed in a subsequent Network Upgrade.</p>
+                <p>The Zcash Shielded Assets protocol is scheduled to be deployed in Network Upgrade 7 (NU7).</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -682,10 +682,18 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0244" class="footnote">
+            <table id="zip-0230-orchardzsa-fee-calculation" class="footnote">
                 <tbody>
                     <tr>
                         <th>12</th>
+                        <td><a href="zip-0230.html#orchardzsa-fee-calculation">ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0244" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>13</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -693,16 +701,8 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="zip-0307" class="footnote">
                 <tbody>
                     <tr>
-                        <th>13</th>
-                        <td><a href="zip-0307">ZIP 307: Light Client Protocol for Payment Detection</a></td>
-                    </tr>
-                </tbody>
-            </table>
-            <table id="zip-0317b" class="footnote">
-                <tbody>
-                    <tr>
                         <th>14</th>
-                        <td><a href="https://github.com/zcash/zips/pull/667">ZIP 317: Proportional Transfer Fee Mechanism - Pull Request #667 for ZSA Protocol ZIPs</a></td>
+                        <td><a href="zip-0307">ZIP 307: Light Client Protocol for Payment Detection</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -846,7 +846,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>32</th>
-                        <td><a href="https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing">Modifications to the Orchard circuit for the ZSA Protocol</a></td>
+                        <td><a href="https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing">Modifications to the Orchard circuit for the OrchardZSA Protocol</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -101,7 +101,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <p>An Orchard ZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">15</a> by additionally including the Asset Base,
                     <span class="math">\(\mathsf{AssetBase}\!\)</span>
                 . So a ZSA note is a tuple
-                    <span class="math">\((\mathsf{g_d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!\)</span>
+                    <span class="math">\((\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!\)</span>
                 , where</p>
                 <ul>
                     <li>
@@ -496,7 +496,7 @@ T.4a.ii : orchard_actions_memos_digest        (32-byte hash output)
 T.4a.iii: orchard_actions_noncompact_digest   (32-byte hash output)
 T.4a.iv : flagsOrchard                        (1 byte)
 T.4a.v  : anchorOrchard                       (32 bytes)
-T.4a.vi : timeLimit                           (4 bytes)</pre>
+T.4a.vi : nAGExpiryHeight                     (4 bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcActGHash"</pre>
                         <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -43,7 +43,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </ul>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This ZIP (ZIP 227) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 226 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0226">10</a>. This protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of Custom Assets on the Zcash chain. The creation of such Assets is defined in this ZIP (ZIP 227), while the transfer and burn of such Assets is defined in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">10</a>. This ZIP must only be implemented in conjunction with ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">10</a>. The proposed issuance mechanism is only valid for the Orchard-ZSA transfer protocol, because it produces notes that can only be transferred under ZSA.</p>
+            <p>This ZIP (ZIP 227) proposes the Orchard Zcash Shielded Assets (OrchardZSA) protocol, in conjunction with ZIP 226 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0226">10</a>. This protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of Custom Assets on the Zcash chain. The creation of such Assets is defined in this ZIP (ZIP 227), while the transfer and burn of such Assets is defined in ZIP 226 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0226">10</a>. This ZIP must only be implemented in conjunction with ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">10</a>. The proposed issuance mechanism is only valid for the OrchardZSA transfer protocol, because it produces notes that can only be transferred via this protocol.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This ZIP introduces the issuance mechanism for Custom Assets on the Zcash chain. While originally part of a single ZSA ZIP, the issuance mechanism turned out to be substantial enough to stand on its own and justify the creation of this supporting ZIP for ZIP 226 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0226">10</a>.</p>
@@ -73,7 +73,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </ul>
         </section>
         <section id="specification-issuance-keys-and-issuance-authorization-signature-scheme"><h2><span class="section-heading">Specification: Issuance Keys and Issuance Authorization Signature Scheme</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-keys-and-issuance-authorization-signature-scheme"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The Orchard-ZSA Protocol adds the following keys to the key components <a id="footnote-reference-8" class="footnote_reference" href="#protocol-addressesandkeys">21</a> <a id="footnote-reference-9" class="footnote_reference" href="#protocol-orchardkeycomponents">22</a>:</p>
+            <p>The OrchardZSA Protocol adds the following keys to the key components <a id="footnote-reference-8" class="footnote_reference" href="#protocol-addressesandkeys">21</a> <a id="footnote-reference-9" class="footnote_reference" href="#protocol-orchardkeycomponents">22</a>:</p>
             <ol type="1">
                 <li>The issuance authorizing key, denoted as
                     <span class="math">\(\mathsf{isk}\!\)</span>
@@ -85,7 +85,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>The relations between these keys are shown in the following diagram:</p>
             <figure class="align-center" align="center">
                 <img width="450" src="assets/images/zip-0227-key-components-zsa.png" alt="" />
-                <figcaption>Diagram of Issuance Key Components for the Orchard-ZSA Protocol</figcaption>
+                <figcaption>Diagram of Issuance Key Components for the OrchardZSA Protocol</figcaption>
             </figure>
             <section id="issuance-authorization-signature-scheme"><h3><span class="section-heading">Issuance Authorization Signature Scheme</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-authorization-signature-scheme"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>We instantiate the issuance authorization signature scheme
@@ -275,7 +275,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
              is the issuance key and
                 <span class="math">\(\mathsf{asset\_desc}\)</span>
              is a byte string.</p>
-            <p>A given Asset Identifier is used across all Zcash protocols that support ZSAs -- that is, the Orchard-ZSA protocol and potentially future Zcash shielded protocols. For this Asset Identifier, we derive an Asset Digest,
+            <p>A given Asset Identifier is used across all Zcash protocols that support ZSAs -- that is, the OrchardZSA protocol and potentially future Zcash shielded protocols. For this Asset Identifier, we derive an Asset Digest,
                 <span class="math">\(\mathsf{AssetDigest}\!\)</span>
             , which is simply is a
                 <span class="math">\(\textsf{BLAKE2b-512}\)</span>
@@ -303,7 +303,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>Define
                 <span class="math">\(\mathsf{AssetBase_{AssetId}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}})\)</span>
             </p>
-            <p>In the case of the Orchard-ZSA protocol, we define
+            <p>In the case of the OrchardZSA protocol, we define
                 <span class="math">\(\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})\)</span>
              where
                 <span class="math">\(\mathsf{GroupHash}^\mathbb{P}\)</span>
@@ -311,7 +311,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>The relations between the Asset Identifier, Asset Digest, and Asset Base are shown in the following diagram:</p>
             <figure class="align-center" align="center">
                 <img width="600" src="assets/images/zip-0227-asset-identifier-relation.png" alt="" />
-                <figcaption>Diagram relating the Asset Identifier, Asset Digest, and Asset Base in the ZSA Protocol</figcaption>
+                <figcaption>Diagram relating the Asset Identifier, Asset Digest, and Asset Base in the OrchardZSA Protocol</figcaption>
             </figure>
             <p><strong>Note:</strong> To keep notations light and concise, we may omit
                 <span class="math">\(\mathsf{AssetId}\)</span>
@@ -435,7 +435,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(i\)</span>
                     :
                         <ul>
-                            <li>generate a ZSA output note that includes the Asset Base. For an Orchard-ZSA note this is
+                            <li>generate a ZSA output note that includes the Asset Base. For an OrchardZSA note this is
                                 <span class="math">\(\mathsf{note}_i = (\mathsf{d}_i, \mathsf{pk}_{\mathsf{d}_i}, \mathsf{v}_i, \text{ρ}_i, \mathsf{rseed}_i, \mathsf{AssetBase}, \mathsf{rcm}_i)\!\)</span>
                             .</li>
                         </ul>
@@ -581,7 +581,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="txid-digest-issuance"><h2><span class="section-heading">TxId Digest - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the Orchard-ZSA protocol can be found in ZIP 226 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0226-txiddigest">12</a>. As in ZIP 244 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0244">15</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
+            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0226-txiddigest">12</a>. As in ZIP 244 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0244">16</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
             <p>A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below:</p>
             <pre>issuance_digest
 ├── issue_actions_digest
@@ -651,8 +651,8 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0244-sigdigest">16</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
-            <p>The overall structure of the hash is as follows. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
+            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0244-sigdigest">17</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
+            <p>The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
             <pre>signature_digest
 ├── header_digest
 ├── transparent_sig_digest
@@ -666,14 +666,14 @@ S.2: transparent_sig_digest (32-byte hash output)
 S.3: sapling_digest         (32-byte hash output)
 S.4: orchard_digest         (32-byte hash output)
 S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0244">15</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0244">16</a>.</p>
                 <section id="s-5-issuance-digest"><h4><span class="section-heading">S.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>Identical to that specified for the transaction identifier.</p>
                 </section>
             </section>
         </section>
         <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0244-authcommitment">17</a> which commits to the authorizing data of a transaction is modified by the Orchard-ZSA protocol to have the following structure. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0244-authcommitment">18</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the following structure. We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
             <pre>auth_digest
 ├── transparent_scripts_digest
 ├── sapling_auth_digest
@@ -728,7 +728,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                  in order to properly keep track of the total supply for different Asset Identifiers. This is useful for wallets and other applications that need to keep track of the total supply of Assets.</p>
             </section>
             <section id="fee-structures"><h3><span class="section-heading">Fee Structures</span><span class="section-anchor"> <a rel="bookmark" href="#fee-structures"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317 <a id="footnote-reference-33" class="footnote_reference" href="#zip-0317b">18</a>.</p>
+                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 <a id="footnote-reference-33" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">15</a>.</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -858,10 +858,18 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0244" class="footnote">
+            <table id="zip-0230-orchardzsa-fee-calculation" class="footnote">
                 <tbody>
                     <tr>
                         <th>15</th>
+                        <td><a href="zip-0230.html#orchardzsa-fee-calculation">ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0244" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>16</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -869,7 +877,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244-sigdigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>17</th>
                         <td><a href="zip-0244.html#signature-digest">ZIP 244: Transaction Identifier Non-Malleability: Signature Digest</a></td>
                     </tr>
                 </tbody>
@@ -877,16 +885,8 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244-authcommitment" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
-                        <td><a href="zip-0244.html#authorizing-data-commitment">ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment</a></td>
-                    </tr>
-                </tbody>
-            </table>
-            <table id="zip-0317b" class="footnote">
-                <tbody>
-                    <tr>
                         <th>18</th>
-                        <td><a href="https://github.com/zcash/zips/pull/667">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
+                        <td><a href="zip-0244.html#authorizing-data-commitment">ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -25,7 +25,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://github.com/zcash/zips/issues/686</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
-            <p>The terms "Zcash Shielded Asset", "ZSA" and "Asset" in this document are to be interpreted as described in ZIP 226 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0226">8</a>.</p>
+            <p>The terms "Zcash Shielded Asset", "OrchardZSA", "ZSA" and "Asset" in this document are to be interpreted as described in ZIP 226 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0226">8</a>.</p>
             <p>The term "Issuance" and "Issuance Action" in this document are to be interpreted as described in ZIP 227 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0227">9</a>.</p>
             <p>We define the following additional terms:</p>
             <ul>
@@ -34,16 +34,16 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             <p>The character § is used when referring to sections of the Zcash Protocol Specification <a id="footnote-reference-4" class="footnote_reference" href="#protocol">2</a>.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This proposal defines a new Zcash peer-to-peer transaction format, which includes data that supports the Orchard-ZSA protocol and all operations related to Zcash Shielded Assets (ZSAs). The new format adds and describes new fields containing ZSA-specific elements. Like the existing v5 transaction format, it keeps well-bounded regions of the serialized form to serve each pool of funds.</p>
+            <p>This proposal defines a new Zcash peer-to-peer transaction format, which includes data that supports the OrchardZSA protocol and all operations related to Zcash Shielded Assets (ZSAs). The new format adds and describes new fields containing ZSA-specific elements. Like the existing v5 transaction format, it keeps well-bounded regions of the serialized form to serve each pool of funds.</p>
             <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0244">11</a>.</p>
             <p>This ZIP additionally defines the fee mechanism associated with the Orchard Zcash Shielded Assets (OrchardZSA) protocol as described in ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">8</a> and ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">9</a>. The fee mechanism is defined in terms of modifications to the Proportionak Transfer Fee Mechanism <a id="footnote-reference-8" class="footnote_reference" href="#zip-0317">12</a>.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The Orchard-ZSA protocol requires serialized data elements that are distinct from any previous Zcash transaction. Since ZIP 244 was activated in NU5, the v5 and later serialized transaction formats are not consensus-critical. Thus, this ZIP defines format that can easily accommodate future extensions, where elements or a given pool are kept separate.</p>
+            <p>The OrchardZSA protocol requires serialized data elements that are distinct from any previous Zcash transaction. Since ZIP 244 was activated in NU5, the v5 and later serialized transaction formats are not consensus-critical. Thus, this ZIP defines format that can easily accommodate future extensions, where elements or a given pool are kept separate.</p>
             <p>The upgrade to the OrchardZSA protocol will also need to define a fee structure consistent with the objectives of ZIP 317 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0317">12</a>. This involves adaptation for the transfer protocol <a id="footnote-reference-10" class="footnote_reference" href="#zip-0226">8</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-11" class="footnote_reference" href="#zip-0227">9</a> such as fees for asset issuance. Specifically, the OrchardZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers. In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-12" class="footnote_reference" href="#zip-0227">9</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
         </section>
         <section id="requirements"><h2><span class="section-heading">Requirements</span><span class="section-anchor"> <a rel="bookmark" href="#requirements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The new format must fully support the Orchard-ZSA protocol.</p>
+            <p>The new format must fully support the OrchardZSA protocol.</p>
             <p>The new format should lend itself to future extension or pruning to add or remove value pools.</p>
             <p>The computation of the non-malleable transaction identifier hash must include all newly incorporated elements except those that attest to transaction validity.</p>
             <p>The computation of the commitment to authorizing data for a transaction must include all newly incorporated elements that attest to transaction validity.</p>
@@ -210,7 +210,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                             <td>A Sapling binding signature on the SIGHASH transaction hash.</td>
                         </tr>
                         <tr>
-                            <td colspan="4"><strong>Orchard-ZSA Transaction Fields</strong></td>
+                            <td colspan="4"><strong>OrchardZSA Transaction Fields</strong></td>
                         </tr>
                         <tr>
                             <td><code>varies</code></td>
@@ -240,16 +240,16 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                             <td><code>40 * nAssetBurn</code></td>
                             <td><code>vAssetBurn</code></td>
                             <td><code>AssetBurn[nAssetBurn]</code></td>
-                            <td>A sequence of Asset Burn descriptions, encoded per <a href="#orchard-zsa-asset-burn-description">Orchard-ZSA Asset Burn Description</a>.</td>
+                            <td>A sequence of Asset Burn descriptions, encoded per <a href="#orchardzsa-asset-burn-description">OrchardZSA Asset Burn Description</a>.</td>
                         </tr>
                         <tr>
                             <td><code>64</code></td>
                             <td><code>bindingSigOrchard</code></td>
                             <td><code>byte[64]</code></td>
-                            <td>An Orchard-ZSA binding signature on the SIGHASH transaction hash.</td>
+                            <td>An OrchardZSA binding signature on the SIGHASH transaction hash.</td>
                         </tr>
                         <tr>
-                            <td colspan="4"><strong>Orchard-ZSA Issuance Fields</strong></td>
+                            <td colspan="4"><strong>OrchardZSA Issuance Fields</strong></td>
                         </tr>
                         <tr>
                             <td><code>varies</code></td>
@@ -407,8 +407,8 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         <tr>
                             <td><code>852 * nActionsOrchard</code></td>
                             <td><code>vActionsOrchard</code></td>
-                            <td><code>OrchardZsaAction[nActionsOrchard]</code></td>
-                            <td>A sequence of ZSA Swap Action descriptions in the Action Group.</td>
+                            <td><code>OrchardZSAAction[nActionsOrchard]</code></td>
+                            <td>A sequence of OrchardZSA Action descriptions in the Action Group.</td>
                         </tr>
                         <tr>
                             <td><code>1</code></td>
@@ -448,15 +448,15 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encoding of <code>OrchardZsaAction</code> is described below.</p>
+                <p>The encoding of <code>OrchardZSAAction</code> is described below.</p>
                 <ul>
-                    <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
+                    <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZSAAction</code> at the same index.</li>
                 </ul>
                 <section id="rationale-for-nagexpiryheight"><h4><span class="section-heading">Rationale for nAGExpiryHeight</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-nagexpiryheight"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>We introduce the <code>nAGExpiryHeight</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-20" class="footnote_reference" href="#zip-0228">10</a>. For the OrchardZSA protocol, which does not make use of an additional expiry height for transactions, we set the value of <code>nAGExpiryHeight</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no expiry, analogous to the convention adopted for <code>nExpiryHeight</code> in ZIP 203 [#zip-0203].</p>
+                    <p>We introduce the <code>nAGExpiryHeight</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs, as proposed in ZIP 228 <a id="footnote-reference-20" class="footnote_reference" href="#zip-0228">10</a>. For the OrchardZSA protocol, which does not make use of an additional expiry height for transactions, we set the value of <code>nAGExpiryHeight</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no expiry, analogous to the convention adopted for <code>nExpiryHeight</code> in ZIP 203 [#zip-0203].</p>
                 </section>
             </section>
-            <section id="orchard-zsa-action-description-orchardzsaaction"><h3><span class="section-heading">Orchard-ZSA Action Description (<code>OrchardZsaAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-action-description-orchardzsaaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+            <section id="orchardzsa-action-description-orchardzsaaction"><h3><span class="section-heading">OrchardZSA Action Description (<code>OrchardZSAAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-action-description-orchardzsaaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <table>
                     <thead>
                         <tr>
@@ -515,8 +515,8 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 </table>
                 <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-21" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
             </section>
-            <section id="orchard-zsa-asset-burn-description"><h3><span class="section-heading">Orchard-ZSA Asset Burn Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-asset-burn-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>An Orchard-ZSA Asset Burn description is encoded in a transaction as an instance of an <code>AssetBurn</code> type:</p>
+            <section id="orchardzsa-asset-burn-description"><h3><span class="section-heading">OrchardZSA Asset Burn Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-asset-burn-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>An OrchardZSA Asset Burn description is encoded in a transaction as an instance of an <code>AssetBurn</code> type:</p>
                 <table>
                     <thead>
                         <tr>
@@ -531,7 +531,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                             <td>32</td>
                             <td><code>AssetBase</code></td>
                             <td><code>byte[32]</code></td>
-                            <td>For the Orchard-based ZSA protocol, this is the encoding of the Asset Base
+                            <td>For the OrchardZSA protocol, this is the encoding of the Asset Base
                                 <span class="math">\(\mathsf{AssetBase^{Orchard}}\!\)</span>
                             .</td>
                         </tr>
@@ -702,7 +702,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     </tr>
                     <tr>
                         <td>
-                            <span class="math">\(nTotalOutputsZsaIssuance\)</span>
+                            <span class="math">\(nTotalOutputsZSAIssuance\)</span>
                         </td>
                         <td>number</td>
                         <td>the total number of OrchardZSA issuance outputs (added across issuance actions)</td>
@@ -726,7 +726,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
              (with the updated computation of
                 <span class="math">\(logical\_actions\)</span>
              as described above) is:</p>
-            <div class="math">\(zsa\_logical\_actions  = logical\_actions \;+ nTotalOutputsZsaIssuance\)</div>
+            <div class="math">\(zsa\_logical\_actions  = logical\_actions \;+ nTotalOutputsZSAIssuance\)</div>
             <p>The formula for the computation of the
                 <span class="math">\(zsa\_conventional\_fee\)</span>
              is:</p>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -216,7 +216,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                             <td><code>varies</code></td>
                             <td><code>nActionGroupsOrchard</code></td>
                             <td><code>compactSize</code></td>
-                            <td>The number of Action Group descriptions in <code>vActionGroupsOrchard</code>. This has a value of either <code>0</code> or <code>1</code>.</td>
+                            <td>The number of Action Group descriptions in <code>vActionGroupsOrchard</code>. This MUST have a value of either <code>0</code> or <code>1</code>.</td>
                         </tr>
                         <tr>
                             <td><code>varies</code></td>
@@ -388,72 +388,42 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             </section>
             <section id="orchardzsa-action-group-description"><h3><span class="section-heading">OrchardZSA Action Group Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-action-group-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The OrchardZSA Action Group Description is encoded in a transaction as an instance of an <code>ActionGroupDescription</code> type:</p>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Bytes</th>
-                            <th>Name</th>
-                            <th>Data Type</th>
-                            <th>Description</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><code>varies</code></td>
-                            <td><code>nActionsOrchard</code></td>
-                            <td><code>compactSize</code></td>
-                            <td>The number of Action descriptions in <code>vActionsOrchard</code>.</td>
-                        </tr>
-                        <tr>
-                            <td><code>852 * nActionsOrchard</code></td>
-                            <td><code>vActionsOrchard</code></td>
-                            <td><code>OrchardZsaAction[nActionsOrchard]</code></td>
-                            <td>A sequence of ZSA Swap Action descriptions in the Action Group.</td>
-                        </tr>
-                        <tr>
-                            <td><code>1</code></td>
-                            <td><code>flagsOrchard</code></td>
-                            <td><code>byte</code></td>
-                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-17" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
-                        </tr>
-                        <tr>
-                            <td><code>32</code></td>
-                            <td><code>anchorOrchard</code></td>
-                            <td><code>byte[32]</code></td>
-                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-18" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
-                        </tr>
-                        <tr>
-                            <td><code>varies</code></td>
-                            <td><code>sizeProofsOrchard</code></td>
-                            <td><code>compactSize</code></td>
-                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-19" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
-                        </tr>
-                        <tr>
-                            <td><code>sizeProofsOrchard</code></td>
-                            <td><code>proofsOrchard</code></td>
-                            <td><code>byte[sizeProofsOrchard]</code></td>
-                            <td>The aggregated zk-SNARK proof for all Actions in the Action Group.</td>
-                        </tr>
-                        <tr>
-                            <td><code>4</code></td>
-                            <td><code>timeLimit</code></td>
-                            <td><code>uint32</code></td>
-                            <td>The block number (in the future) after which the Actions of the Action Group become invalid and should be rejected by consensus. This is set to be a value of <code>0</code>.</td>
-                        </tr>
-                        <tr>
-                            <td><code>64 * nActionsOrchard</code></td>
-                            <td><code>vSpendAuthSigsOrchard</code></td>
-                            <td><code>byte[64 * nActionsOrchard]</code></td>
-                            <td>Authorizing signatures for each Action of the Action Group in a transaction.</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div>
+                    <h1>System Message: ERROR/3 (zips/zip-0230.rst line 279)</h1>
+                    <p>Malformed table.</p>
+                    <pre>+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+| Bytes                              | Name                     | Data Type                                        | Description                                                         |
++====================================+==========================+==================================================+=====================================================================+
+|``varies``                          |``nActionsOrchard``       |``compactSize``                                   |The number of Action descriptions in ``vActionsOrchard``.            |
+|                                    |                          |                                                  |This MUST have a value strictly greater than ``0``.                  |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``852 * nActionsOrchard``           |``vActionsOrchard``       |``OrchardZsaAction[nActionsOrchard]``             |A sequence of ZSA Swap Action descriptions in the Action Group.      |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``1``                               |``flagsOrchard``          |``byte``                                          |As defined in Section 7.1 of the Protocol                            |
+|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``32``                              |``anchorOrchard``         |``byte[32]``                                      |As defined in Section 7.1 of the Protocol                            |
+|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``varies``                          |``sizeProofsOrchard``     |``compactSize``                                   |As defined in Section 7.1 of the Protocol                            |
+|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``sizeProofsOrchard``               |``proofsOrchard``         |``byte[sizeProofsOrchard]``                       |The aggregated zk-SNARK proof for all Actions in the Action Group.   |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``4``                               |``timeLimit``             |``uint32``                                        |The block number (in the future) after which the Actions of the      |
+|                                    |                          |                                                  |Action Group become invalid and should be rejected by consensus.     |
+|                                    |                          |                                                  |This MUST have a value of ``0``.                                  |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64 * nActionsOrchard]``                    |Authorizing signatures for each Action of the Action Group in a      |
+|                                    |                          |                                                  |transaction.                                                         |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+</pre>
+                </div>
                 <p>The encoding of <code>OrchardZsaAction</code> is described below.</p>
                 <ul>
                     <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
                 </ul>
                 <section id="rationale-for-timelimit"><h4><span class="section-heading">Rationale for timeLimit</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-timelimit"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>We introduce the <code>timeLimit</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-20" class="problematic" href="#system-message-2">[#zip-0228]_</a>. For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of <code>timeLimit</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no specified time limit.</p>
+                    <p>We introduce the <code>timeLimit</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-17" class="problematic" href="#system-message-2">[#zip-0228]_</a>. For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of <code>timeLimit</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no specified time limit.</p>
                 </section>
             </section>
             <section id="orchard-zsa-action-description-orchardzsaaction"><h3><span class="section-heading">Orchard-ZSA Action Description (<code>OrchardZsaAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-action-description-orchardzsaaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -513,7 +483,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-21" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
+                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-18" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
             </section>
             <section id="orchard-zsa-asset-burn-description"><h3><span class="section-heading">Orchard-ZSA Asset Burn Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-asset-burn-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An Orchard-ZSA Asset Burn description is encoded in a transaction as an instance of an <code>AssetBurn</code> type:</p>
@@ -543,7 +513,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0226">7</a>.</p>
+                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0226">7</a>.</p>
             </section>
             <section id="issuance-action-description-issueaction"><h3><span class="section-heading">Issuance Action Description (<code>IssueAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description-issueaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
@@ -662,7 +632,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             </section>
         </section>
         <section id="orchardzsa-fee-calculation"><h2><span class="section-heading">OrchardZSA Fee Calculation</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0317-fee-calc">11</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
+            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-20" class="footnote_reference" href="#zip-0317-fee-calc">11</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
             <table>
                 <thead>
                     <tr>
@@ -716,7 +686,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     </tr>
                 </tbody>
             </table>
-            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-24" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0317-fee-calc">11</a>. Note that
+            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-21" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0317-fee-calc">11</a>. Note that
                 <span class="math">\(nOrchardActions\)</span>
             , that is used in the computation of
                 <span class="math">\(logical\_actions\)</span>
@@ -841,11 +811,11 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
     <section class="system-messages">
         <h1>Docutils System Messages</h1>
         <div id="system-message-1">
-            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 315)</h1>
+            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 316)</h1>
             <p>Too many autonumbered footnote references: only 0 corresponding footnotes available.</p>
         </div>
         <div id="system-message-2">
-            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 315) <a href="#footnote-reference-20">footnote-reference-20</a></h1>
+            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 316) <a href="#footnote-reference-17">footnote-reference-17</a></h1>
             <p>Unknown target name: "zip-0228".</p>
         </div>
     </section>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -443,8 +443,8 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         <tr>
                             <td><code>64 * nActionsOrchard</code></td>
                             <td><code>vSpendAuthSigsOrchard</code></td>
-                            <td><code>byte[64][nActionsOrchard]</code></td>
-                            <td>Authorizing signatures for the inclusion of each Action of the Action Group in a transaction.</td>
+                            <td><code>byte[64 * nActionsOrchard]</code></td>
+                            <td>Authorizing signatures for each Action of the Action Group in a transaction.</td>
                         </tr>
                     </tbody>
                 </table>
@@ -452,6 +452,9 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <ul>
                     <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
                 </ul>
+                <section id="rationale-for-timelimit"><h4><span class="section-heading">Rationale for timeLimit</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-timelimit"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>We introduce the <code>timeLimit</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-20" class="problematic" href="#system-message-2">[#zip-0228]_</a>. For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of <code>timeLimit</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no specified time limit.</p>
+                </section>
             </section>
             <section id="orchard-zsa-action-description-orchardzsaaction"><h3><span class="section-heading">Orchard-ZSA Action Description (<code>OrchardZsaAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-action-description-orchardzsaaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <table>
@@ -510,7 +513,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-20" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
+                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-21" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
             </section>
             <section id="orchard-zsa-asset-burn-description"><h3><span class="section-heading">Orchard-ZSA Asset Burn Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-asset-burn-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An Orchard-ZSA Asset Burn description is encoded in a transaction as an instance of an <code>AssetBurn</code> type:</p>
@@ -540,7 +543,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0226">7</a>.</p>
+                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0226">7</a>.</p>
             </section>
             <section id="issuance-action-description-issueaction"><h3><span class="section-heading">Issuance Action Description (<code>IssueAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description-issueaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
@@ -659,7 +662,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             </section>
         </section>
         <section id="orchardzsa-fee-calculation"><h2><span class="section-heading">OrchardZSA Fee Calculation</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0317-fee-calc">11</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
+            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0317-fee-calc">11</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
             <table>
                 <thead>
                     <tr>
@@ -713,7 +716,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     </tr>
                 </tbody>
             </table>
-            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-23" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0317-fee-calc">11</a>. Note that
+            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-24" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0317-fee-calc">11</a>. Note that
                 <span class="math">\(nOrchardActions\)</span>
             , that is used in the computation of
                 <span class="math">\(logical\_actions\)</span>
@@ -834,6 +837,17 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 </tbody>
             </table>
         </section>
+    </section>
+    <section class="system-messages">
+        <h1>Docutils System Messages</h1>
+        <div id="system-message-1">
+            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 315)</h1>
+            <p>Too many autonumbered footnote references: only 0 corresponding footnotes available.</p>
+        </div>
+        <div id="system-message-2">
+            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 315) <a href="#footnote-reference-20">footnote-reference-20</a></h1>
+            <p>Unknown target name: "zip-0228".</p>
+        </div>
     </section>
 </body>
 </html>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -25,8 +25,8 @@ License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://github.com/zcash/zips/issues/686</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
-            <p>The terms "Zcash Shielded Asset", "ZSA" and "Asset" in this document are to be interpreted as described in ZIP 226 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0226">7</a>.</p>
-            <p>The term "Issuance" and "Issuance Action" in this document are to be interpreted as described in ZIP 227 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0227">8</a>.</p>
+            <p>The terms "Zcash Shielded Asset", "ZSA" and "Asset" in this document are to be interpreted as described in ZIP 226 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0226">8</a>.</p>
+            <p>The term "Issuance" and "Issuance Action" in this document are to be interpreted as described in ZIP 227 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0227">9</a>.</p>
             <p>We define the following additional terms:</p>
             <ul>
                 <li>Issuance Fee: This is the specific fixed fee that has to be paid to the network for every given issuance action.</li>
@@ -35,19 +35,19 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This proposal defines a new Zcash peer-to-peer transaction format, which includes data that supports the Orchard-ZSA protocol and all operations related to Zcash Shielded Assets (ZSAs). The new format adds and describes new fields containing ZSA-specific elements. Like the existing v5 transaction format, it keeps well-bounded regions of the serialized form to serve each pool of funds.</p>
-            <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0244">10</a>.</p>
-            <p>This ZIP additionally defines the fee mechanism associated with the Orchard Zcash Shielded Assets (OrchardZSA) protocol as described in ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">7</a> and ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">8</a>. The fee mechanism is defined in terms of modifications to the Proportionak Transfer Fee Mechanism <a id="footnote-reference-8" class="footnote_reference" href="#zip-0317">11</a>.</p>
+            <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0244">11</a>.</p>
+            <p>This ZIP additionally defines the fee mechanism associated with the Orchard Zcash Shielded Assets (OrchardZSA) protocol as described in ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">8</a> and ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">9</a>. The fee mechanism is defined in terms of modifications to the Proportionak Transfer Fee Mechanism <a id="footnote-reference-8" class="footnote_reference" href="#zip-0317">12</a>.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The Orchard-ZSA protocol requires serialized data elements that are distinct from any previous Zcash transaction. Since ZIP 244 was activated in NU5, the v5 and later serialized transaction formats are not consensus-critical. Thus, this ZIP defines format that can easily accommodate future extensions, where elements or a given pool are kept separate.</p>
-            <p>The upgrade to the OrchardZSA protocol will also need to define a fee structure consistent with the objectives of ZIP 317 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0317">11</a>. This involves adaptation for the transfer protocol <a id="footnote-reference-10" class="footnote_reference" href="#zip-0226">7</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-11" class="footnote_reference" href="#zip-0227">8</a> such as fees for asset issuance. Specifically, the OrchardZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers. In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-12" class="footnote_reference" href="#zip-0227">8</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
+            <p>The upgrade to the OrchardZSA protocol will also need to define a fee structure consistent with the objectives of ZIP 317 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0317">12</a>. This involves adaptation for the transfer protocol <a id="footnote-reference-10" class="footnote_reference" href="#zip-0226">8</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-11" class="footnote_reference" href="#zip-0227">9</a> such as fees for asset issuance. Specifically, the OrchardZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers. In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-12" class="footnote_reference" href="#zip-0227">9</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
         </section>
         <section id="requirements"><h2><span class="section-heading">Requirements</span><span class="section-anchor"> <a rel="bookmark" href="#requirements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The new format must fully support the Orchard-ZSA protocol.</p>
             <p>The new format should lend itself to future extension or pruning to add or remove value pools.</p>
             <p>The computation of the non-malleable transaction identifier hash must include all newly incorporated elements except those that attest to transaction validity.</p>
             <p>The computation of the commitment to authorizing data for a transaction must include all newly incorporated elements that attest to transaction validity.</p>
-            <p>In addition to the requirements of ZIP 317 <a id="footnote-reference-13" class="footnote_reference" href="#zip-0317">11</a>, the fee mechanism for the OrchardZSA protocol should satisfy the following requirements:</p>
+            <p>In addition to the requirements of ZIP 317 <a id="footnote-reference-13" class="footnote_reference" href="#zip-0317">12</a>, the fee mechanism for the OrchardZSA protocol should satisfy the following requirements:</p>
             <ul>
                 <li>The conventional fee should not leak private information used in constructing the transaction; that is, it should be computable from only the public data of the transaction.</li>
                 <li>Users should be discouraged from issuing new “garbage” custom Assets. The fee should reflect the cost of adding new data to the global state.</li>
@@ -273,7 +273,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                             <td><code>64</code></td>
                             <td><code>issueAuthSig</code></td>
                             <td><code>byte[64]</code></td>
-                            <td>The signature of the transaction SIGHASH, signed by the issuer, validated as in Issuance Authorization Signature Scheme <a id="footnote-reference-14" class="footnote_reference" href="#zip-0227">8</a>.</td>
+                            <td>The signature of the transaction SIGHASH, signed by the issuer, validated as in Issuance Authorization Signature Scheme <a id="footnote-reference-14" class="footnote_reference" href="#zip-0227">9</a>.</td>
                         </tr>
                     </tbody>
                 </table>
@@ -436,9 +436,9 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                         <tr>
                             <td><code>4</code></td>
-                            <td><code>timeLimit</code></td>
+                            <td><code>nAGExpiryHeight</code></td>
                             <td><code>uint32</code></td>
-                            <td>The block number (in the future) after which the Actions of the Action Group become invalid and should be rejected by consensus. This MUST have a value of <code>0</code>.</td>
+                            <td>A block height (in the future) after which the Actions of the Action Group become invalid and should be rejected by consensus. This MUST have a value of <code>0</code>.</td>
                         </tr>
                         <tr>
                             <td><code>64 * nActionsOrchard</code></td>
@@ -452,8 +452,8 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <ul>
                     <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
                 </ul>
-                <section id="rationale-for-timelimit"><h4><span class="section-heading">Rationale for timeLimit</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-timelimit"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>We introduce the <code>timeLimit</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-20" class="footnote_reference" href="#zip-0228">9</a>. For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of <code>timeLimit</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no specified time limit.</p>
+                <section id="rationale-for-nagexpiryheight"><h4><span class="section-heading">Rationale for nAGExpiryHeight</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-nagexpiryheight"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>We introduce the <code>nAGExpiryHeight</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-20" class="footnote_reference" href="#zip-0228">10</a>. For the OrchardZSA protocol, which does not make use of an additional expiry height for transactions, we set the value of <code>nAGExpiryHeight</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no expiry, analogous to the convention adopted for <code>nExpiryHeight</code> in ZIP 203 [#zip-0203].</p>
                 </section>
             </section>
             <section id="orchard-zsa-action-description-orchardzsaaction"><h3><span class="section-heading">Orchard-ZSA Action Description (<code>OrchardZsaAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-action-description-orchardzsaaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -543,7 +543,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0226">7</a>.</p>
+                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0226">8</a>.</p>
             </section>
             <section id="issuance-action-description-issueaction"><h3><span class="section-heading">Issuance Action Description (<code>IssueAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description-issueaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
@@ -662,7 +662,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             </section>
         </section>
         <section id="orchardzsa-fee-calculation"><h2><span class="section-heading">OrchardZSA Fee Calculation</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0317-fee-calc">12</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
+            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0317-fee-calc">13</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
             <table>
                 <thead>
                     <tr>
@@ -716,7 +716,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     </tr>
                 </tbody>
             </table>
-            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-24" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0317-fee-calc">12</a>. Note that
+            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-24" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0317-fee-calc">13</a>. Note that
                 <span class="math">\(nOrchardActions\)</span>
             , that is used in the computation of
                 <span class="math">\(logical\_actions\)</span>
@@ -796,10 +796,18 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0226" class="footnote">
+            <table id="zip-0203" class="footnote">
                 <tbody>
                     <tr>
                         <th>7</th>
+                        <td><a href="zip-0203.html">ZIP 203: Transaction Expiry</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0226" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>8</th>
                         <td><a href="zip-0226.html">ZIP 226: Transfer and Burn of Zcash Shielded Assets</a></td>
                     </tr>
                 </tbody>
@@ -807,7 +815,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             <table id="zip-0227" class="footnote">
                 <tbody>
                     <tr>
-                        <th>8</th>
+                        <th>9</th>
                         <td><a href="zip-0227.html">ZIP 227: Issuance of Zcash Shielded Assets</a></td>
                     </tr>
                 </tbody>
@@ -815,7 +823,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             <table id="zip-0228" class="footnote">
                 <tbody>
                     <tr>
-                        <th>9</th>
+                        <th>10</th>
                         <td><a href="zip-0228.html">ZIP 228: Asset Swaps for Zcash Shielded Assets</a></td>
                     </tr>
                 </tbody>
@@ -823,7 +831,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>10</th>
+                        <th>11</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -831,7 +839,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             <table id="zip-0317" class="footnote">
                 <tbody>
                     <tr>
-                        <th>11</th>
+                        <th>12</th>
                         <td><a href="zip-0317.html">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
                     </tr>
                 </tbody>
@@ -839,7 +847,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             <table id="zip-0317-fee-calc" class="footnote">
                 <tbody>
                     <tr>
-                        <th>12</th>
+                        <th>13</th>
                         <td><a href="zip-0317.html#fee-calculation">ZIP 317: Proportional Transfer Fee Mechanism, Fee calculation</a></td>
                     </tr>
                 </tbody>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -35,19 +35,19 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This proposal defines a new Zcash peer-to-peer transaction format, which includes data that supports the Orchard-ZSA protocol and all operations related to Zcash Shielded Assets (ZSAs). The new format adds and describes new fields containing ZSA-specific elements. Like the existing v5 transaction format, it keeps well-bounded regions of the serialized form to serve each pool of funds.</p>
-            <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0244">9</a>.</p>
-            <p>This ZIP additionally defines the fee mechanism associated with the Orchard Zcash Shielded Assets (OrchardZSA) protocol as described in ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">7</a> and ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">8</a>. The fee mechanism is defined in terms of modifications to the Proportionak Transfer Fee Mechanism <a id="footnote-reference-8" class="footnote_reference" href="#zip-0317">10</a>.</p>
+            <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0244">10</a>.</p>
+            <p>This ZIP additionally defines the fee mechanism associated with the Orchard Zcash Shielded Assets (OrchardZSA) protocol as described in ZIP 226 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0226">7</a> and ZIP 227 <a id="footnote-reference-7" class="footnote_reference" href="#zip-0227">8</a>. The fee mechanism is defined in terms of modifications to the Proportionak Transfer Fee Mechanism <a id="footnote-reference-8" class="footnote_reference" href="#zip-0317">11</a>.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The Orchard-ZSA protocol requires serialized data elements that are distinct from any previous Zcash transaction. Since ZIP 244 was activated in NU5, the v5 and later serialized transaction formats are not consensus-critical. Thus, this ZIP defines format that can easily accommodate future extensions, where elements or a given pool are kept separate.</p>
-            <p>The upgrade to the OrchardZSA protocol will also need to define a fee structure consistent with the objectives of ZIP 317 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0317">10</a>. This involves adaptation for the transfer protocol <a id="footnote-reference-10" class="footnote_reference" href="#zip-0226">7</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-11" class="footnote_reference" href="#zip-0227">8</a> such as fees for asset issuance. Specifically, the OrchardZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers. In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-12" class="footnote_reference" href="#zip-0227">8</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
+            <p>The upgrade to the OrchardZSA protocol will also need to define a fee structure consistent with the objectives of ZIP 317 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0317">11</a>. This involves adaptation for the transfer protocol <a id="footnote-reference-10" class="footnote_reference" href="#zip-0226">7</a>, as well as additional considerations for the issuance protocol <a id="footnote-reference-11" class="footnote_reference" href="#zip-0227">8</a> such as fees for asset issuance. Specifically, the OrchardZSA Transfer and Burn mechanism should follow the same fee mechanism in order to not discriminate between transfer bundle types. When it comes to Issuance of ZSA, however, there should be a disincentive that will stop users from flooding the chain with useless asset identifiers. In the case of Issuance, the computational power needed to verify the bundle is not large. The transaction size, however, can be an issue as the number of output notes can be large. Furthermore, as defined in ZIP 227 <a id="footnote-reference-12" class="footnote_reference" href="#zip-0227">8</a>, there is an additional data structure in the global state that needs to be maintained as part of the consensus. This motivates further the addition of an Issuance-specific fee.</p>
         </section>
         <section id="requirements"><h2><span class="section-heading">Requirements</span><span class="section-anchor"> <a rel="bookmark" href="#requirements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The new format must fully support the Orchard-ZSA protocol.</p>
             <p>The new format should lend itself to future extension or pruning to add or remove value pools.</p>
             <p>The computation of the non-malleable transaction identifier hash must include all newly incorporated elements except those that attest to transaction validity.</p>
             <p>The computation of the commitment to authorizing data for a transaction must include all newly incorporated elements that attest to transaction validity.</p>
-            <p>In addition to the requirements of ZIP 317 <a id="footnote-reference-13" class="footnote_reference" href="#zip-0317">10</a>, the fee mechanism for the OrchardZSA protocol should satisfy the following requirements:</p>
+            <p>In addition to the requirements of ZIP 317 <a id="footnote-reference-13" class="footnote_reference" href="#zip-0317">11</a>, the fee mechanism for the OrchardZSA protocol should satisfy the following requirements:</p>
             <ul>
                 <li>The conventional fee should not leak private information used in constructing the transaction; that is, it should be computable from only the public data of the transaction.</li>
                 <li>Users should be discouraged from issuing new “garbage” custom Assets. The fee should reflect the cost of adding new data to the global state.</li>
@@ -388,42 +388,72 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             </section>
             <section id="orchardzsa-action-group-description"><h3><span class="section-heading">OrchardZSA Action Group Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-action-group-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The OrchardZSA Action Group Description is encoded in a transaction as an instance of an <code>ActionGroupDescription</code> type:</p>
-                <div>
-                    <h1>System Message: ERROR/3 (zips/zip-0230.rst line 279)</h1>
-                    <p>Malformed table.</p>
-                    <pre>+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-| Bytes                              | Name                     | Data Type                                        | Description                                                         |
-+====================================+==========================+==================================================+=====================================================================+
-|``varies``                          |``nActionsOrchard``       |``compactSize``                                   |The number of Action descriptions in ``vActionsOrchard``.            |
-|                                    |                          |                                                  |This MUST have a value strictly greater than ``0``.                  |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``852 * nActionsOrchard``           |``vActionsOrchard``       |``OrchardZsaAction[nActionsOrchard]``             |A sequence of ZSA Swap Action descriptions in the Action Group.      |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``1``                               |``flagsOrchard``          |``byte``                                          |As defined in Section 7.1 of the Protocol                            |
-|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``32``                              |``anchorOrchard``         |``byte[32]``                                      |As defined in Section 7.1 of the Protocol                            |
-|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``varies``                          |``sizeProofsOrchard``     |``compactSize``                                   |As defined in Section 7.1 of the Protocol                            |
-|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``sizeProofsOrchard``               |``proofsOrchard``         |``byte[sizeProofsOrchard]``                       |The aggregated zk-SNARK proof for all Actions in the Action Group.   |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``4``                               |``timeLimit``             |``uint32``                                        |The block number (in the future) after which the Actions of the      |
-|                                    |                          |                                                  |Action Group become invalid and should be rejected by consensus.     |
-|                                    |                          |                                                  |This MUST have a value of ``0``.                                  |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64 * nActionsOrchard]``                    |Authorizing signatures for each Action of the Action Group in a      |
-|                                    |                          |                                                  |transaction.                                                         |
-+------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+</pre>
-                </div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nActionsOrchard</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of Action descriptions in <code>vActionsOrchard</code>. This MUST have a value strictly greater than <code>0</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>852 * nActionsOrchard</code></td>
+                            <td><code>vActionsOrchard</code></td>
+                            <td><code>OrchardZsaAction[nActionsOrchard]</code></td>
+                            <td>A sequence of ZSA Swap Action descriptions in the Action Group.</td>
+                        </tr>
+                        <tr>
+                            <td><code>1</code></td>
+                            <td><code>flagsOrchard</code></td>
+                            <td><code>byte</code></td>
+                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-17" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>anchorOrchard</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-18" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>sizeProofsOrchard</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-19" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>sizeProofsOrchard</code></td>
+                            <td><code>proofsOrchard</code></td>
+                            <td><code>byte[sizeProofsOrchard]</code></td>
+                            <td>The aggregated zk-SNARK proof for all Actions in the Action Group.</td>
+                        </tr>
+                        <tr>
+                            <td><code>4</code></td>
+                            <td><code>timeLimit</code></td>
+                            <td><code>uint32</code></td>
+                            <td>The block number (in the future) after which the Actions of the Action Group become invalid and should be rejected by consensus. This MUST have a value of <code>0</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>64 * nActionsOrchard</code></td>
+                            <td><code>vSpendAuthSigsOrchard</code></td>
+                            <td><code>byte[64 * nActionsOrchard]</code></td>
+                            <td>Authorizing signatures for each Action of the Action Group in a transaction.</td>
+                        </tr>
+                    </tbody>
+                </table>
                 <p>The encoding of <code>OrchardZsaAction</code> is described below.</p>
                 <ul>
                     <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
                 </ul>
                 <section id="rationale-for-timelimit"><h4><span class="section-heading">Rationale for timeLimit</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-timelimit"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>We introduce the <code>timeLimit</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-17" class="problematic" href="#system-message-2">[#zip-0228]_</a>. For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of <code>timeLimit</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no specified time limit.</p>
+                    <p>We introduce the <code>timeLimit</code> field in this transaction format in order to be forward compatible with Swaps over ZSAs <a id="footnote-reference-20" class="footnote_reference" href="#zip-0228">9</a>. For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of <code>timeLimit</code> to be <code>0</code> by consensus. This serves as a default value to represent the situation where there is no specified time limit.</p>
                 </section>
             </section>
             <section id="orchard-zsa-action-description-orchardzsaaction"><h3><span class="section-heading">Orchard-ZSA Action Description (<code>OrchardZsaAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-action-description-orchardzsaaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -483,7 +513,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-18" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
+                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-21" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
             </section>
             <section id="orchard-zsa-asset-burn-description"><h3><span class="section-heading">Orchard-ZSA Asset Burn Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-asset-burn-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An Orchard-ZSA Asset Burn description is encoded in a transaction as an instance of an <code>AssetBurn</code> type:</p>
@@ -513,7 +543,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0226">7</a>.</p>
+                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0226">7</a>.</p>
             </section>
             <section id="issuance-action-description-issueaction"><h3><span class="section-heading">Issuance Action Description (<code>IssueAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description-issueaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
@@ -632,7 +662,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             </section>
         </section>
         <section id="orchardzsa-fee-calculation"><h2><span class="section-heading">OrchardZSA Fee Calculation</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-20" class="footnote_reference" href="#zip-0317-fee-calc">11</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
+            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0317-fee-calc">12</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
             <table>
                 <thead>
                     <tr>
@@ -686,7 +716,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     </tr>
                 </tbody>
             </table>
-            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-21" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0317-fee-calc">11</a>. Note that
+            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-24" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0317-fee-calc">12</a>. Note that
                 <span class="math">\(nOrchardActions\)</span>
             , that is used in the computation of
                 <span class="math">\(logical\_actions\)</span>
@@ -770,7 +800,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <tbody>
                     <tr>
                         <th>7</th>
-                        <td><a href="https://qed-it.github.io/zips/zip-0226">ZIP 226: Transfer and Burn of Zcash Shielded Assets</a></td>
+                        <td><a href="zip-0226.html">ZIP 226: Transfer and Burn of Zcash Shielded Assets</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -778,46 +808,43 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 <tbody>
                     <tr>
                         <th>8</th>
-                        <td><a href="https://qed-it.github.io/zips/zip-0227">ZIP 227: Issuance of Zcash Shielded Assets</a></td>
+                        <td><a href="zip-0227.html">ZIP 227: Issuance of Zcash Shielded Assets</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0228" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>9</th>
+                        <td><a href="zip-0228.html">ZIP 228: Asset Swaps for Zcash Shielded Assets</a></td>
                     </tr>
                 </tbody>
             </table>
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>9</th>
-                        <td><a href="zip-0244">ZIP 244: Transaction Identifier Non-Malleability</a></td>
+                        <th>10</th>
+                        <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
             </table>
             <table id="zip-0317" class="footnote">
                 <tbody>
                     <tr>
-                        <th>10</th>
-                        <td><a href="zip-0317">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
+                        <th>11</th>
+                        <td><a href="zip-0317.html">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
                     </tr>
                 </tbody>
             </table>
             <table id="zip-0317-fee-calc" class="footnote">
                 <tbody>
                     <tr>
-                        <th>11</th>
-                        <td><a href="zip-0317#fee-calculation">ZIP 317: Proportional Transfer Fee Mechanism, Fee calculation</a></td>
+                        <th>12</th>
+                        <td><a href="zip-0317.html#fee-calculation">ZIP 317: Proportional Transfer Fee Mechanism, Fee calculation</a></td>
                     </tr>
                 </tbody>
             </table>
         </section>
-    </section>
-    <section class="system-messages">
-        <h1>Docutils System Messages</h1>
-        <div id="system-message-1">
-            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 316)</h1>
-            <p>Too many autonumbered footnote references: only 0 corresponding footnotes available.</p>
-        </div>
-        <div id="system-message-2">
-            <h1>System Message: ERROR/3 (zips/zip-0230.rst line 316) <a href="#footnote-reference-17">footnote-reference-17</a></h1>
-            <p>Unknown target name: "zip-0228".</p>
-        </div>
     </section>
 </body>
 </html>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -438,7 +438,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                             <td><code>4</code></td>
                             <td><code>timeLimit</code></td>
                             <td><code>uint32</code></td>
-                            <td>This is set to be a value of <code>0</code>.</td>
+                            <td>The block number (in the future) after which the Actions of the Action Group become invalid and should be rejected by consensus. This is set to be a value of <code>0</code>.</td>
                         </tr>
                         <tr>
                             <td><code>64 * nActionsOrchard</code></td>

--- a/rendered/zip-0230.html
+++ b/rendered/zip-0230.html
@@ -214,67 +214,21 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                         <tr>
                             <td><code>varies</code></td>
-                            <td><code>nActionsOrchard</code></td>
+                            <td><code>nActionGroupsOrchard</code></td>
                             <td><code>compactSize</code></td>
-                            <td>The number of Orchard-ZSA Action descriptions in <code>vActionsOrchard</code>.</td>
+                            <td>The number of Action Group descriptions in <code>vActionGroupsOrchard</code>. This has a value of either <code>0</code> or <code>1</code>.</td>
                         </tr>
                         <tr>
-                            <td><code>852 * nActionsOrchard</code></td>
-                            <td><code>vActionsOrchard</code></td>
-                            <td><code>OrchardZsaAction[nActionsOrchard]</code></td>
-                            <td>A sequence of Orchard-ZSA Action descriptions, encoded per the <cite>Orchard-ZSA Action Description Encoding</cite>.</td>
-                        </tr>
-                        <tr>
-                            <td><code>1</code></td>
-                            <td><code>flagsOrchard</code></td>
-                            <td><code>byte</code></td>
-                            <td>
-                                <dl>
-                                    <dt>An 8-bit value representing a set of flags. Ordered from LSB to MSB:</dt>
-                                    <dd>
-                                        <ul>
-                                            <li><code>enableSpendsOrchard</code></li>
-                                            <li><code>enableOutputsOrchard</code></li>
-                                            <li><code>enableZSAs</code></li>
-                                            <li>The remaining bits are set to
-                                                <span class="math">\(0\!\)</span>
-                                            .</li>
-                                        </ul>
-                                    </dd>
-                                </dl>
-                            </td>
+                            <td><code>varies</code></td>
+                            <td><code>vActionGroupsOrchard</code></td>
+                            <td><code>ActionGroupDescription[nActionGroupsOrchard]</code></td>
+                            <td>A sequence of Action Group descriptions, encoded as per the <a href="#orchardzsa-action-group-description">OrchardZSA Action Group Description</a>.</td>
                         </tr>
                         <tr>
                             <td><code>8</code></td>
                             <td><code>valueBalanceOrchard</code></td>
                             <td><code>int64</code></td>
                             <td>The net value of Orchard spends minus outputs.</td>
-                        </tr>
-                        <tr>
-                            <td><code>32</code></td>
-                            <td><code>anchorOrchard</code></td>
-                            <td><code>byte[32]</code></td>
-                            <td>A root of the Orchard note commitment tree at some block height in the past.</td>
-                        </tr>
-                        <tr>
-                            <td><code>varies</code></td>
-                            <td><code>sizeProofsOrchardZSA</code></td>
-                            <td><code>compactSize</code></td>
-                            <td>Length in bytes of <code>proofsOrchardZSA</code>. Value is <strong>(TO UPDATE)</strong>
-                                <span class="math">\(2720 + 2272 \cdot \mathtt{nActionsOrchard}\!\)</span>
-                            .</td>
-                        </tr>
-                        <tr>
-                            <td><code>sizeProofsOrchardZSA</code></td>
-                            <td><code>proofsOrchardZSA</code></td>
-                            <td><code>byte[sizeProofsOrchardZSA]</code></td>
-                            <td>Encoding of aggregated zk-SNARK proofs for Orchard-ZSA Actions.</td>
-                        </tr>
-                        <tr>
-                            <td><code>64 * nActionsOrchard</code></td>
-                            <td><code>vSpendAuthSigsOrchard</code></td>
-                            <td><code>byte[64 * nActionsOrchard]</code></td>
-                            <td>Authorizing signatures for each Orchard-ZSA Action.</td>
                         </tr>
                         <tr>
                             <td><code>varies</code></td>
@@ -336,14 +290,13 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     .</li>
                     <li>The elements of <code>vSpendProofsSapling</code> and <code>vSpendAuthSigsSapling</code> have a 1:1 correspondence to the elements of <code>vSpendsSapling</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>SpendDescriptionV6</code> at the same index.</li>
                     <li>The elements of <code>vOutputProofsSapling</code> have a 1:1 correspondence to the elements of <code>vOutputsSapling</code> and MUST be ordered such that the proof at a given index corresponds to the <code>OutputDescriptionV6</code> at the same index.</li>
-                    <li>The fields <code>flagsOrchard</code>, <code>valueBalanceOrchard</code>, <code>anchorOrchard</code>, <code>sizeProofsOrchardZSA</code>, <code>proofsOrchardZSA</code>, and <code>bindingSigOrchard</code> are present if and only if
-                        <span class="math">\(\mathtt{nActionsOrchard} &gt; 0\!\)</span>
+                    <li>The fields <code>valueBalanceOrchard</code> and <code>bindingSigOrchard</code> are present if and only if
+                        <span class="math">\(\mathtt{nActionGroupsOrchard} &gt; 0\!\)</span>
                     . If <code>valueBalanceOrchard</code> is not present, then
                         <span class="math">\(\mathsf{v^{balanceOrchard}}\)</span>
                      is defined to be
                         <span class="math">\(0\!\)</span>
                     .</li>
-                    <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
                     <li>The fields <code>ik</code> and <code>issueAuthSig</code> are present if and only if
                         <span class="math">\(\mathtt{nIssueActions} &gt; 0\!\)</span>
                     .</li>
@@ -351,7 +304,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         <span class="math">\(0\!\)</span>
                     .</li>
                 </ul>
-                <p>The encodings of <code>tx_in</code>, and <code>tx_out</code> are as in a version 4 transaction (i.e. unchanged from Canopy). The encodings of <code>SpendDescriptionV6</code>, <code>OutputDescriptionV6</code> , <code>OrchardZsaAction</code>, <code>AssetBurn</code> and <code>IssueAction</code> are described below. The encoding of Sapling Spends and Outputs has changed relative to prior versions in order to better separate data that describe the effects of the transaction from the proofs of and commitments to those effects, and for symmetry with this separation in the Orchard-related parts of the transaction format.</p>
+                <p>The encodings of <code>tx_in</code>, and <code>tx_out</code> are as in a version 4 transaction (i.e. unchanged from Canopy). The encodings of <code>SpendDescriptionV6</code>, <code>OutputDescriptionV6</code> , <code>ActionGroupDescription</code>, <code>AssetBurn</code> and <code>IssueAction</code> are described below. The encoding of Sapling Spends and Outputs has changed relative to prior versions in order to better separate data that describe the effects of the transaction from the proofs of and commitments to those effects, and for symmetry with this separation in the Orchard-related parts of the transaction format.</p>
             </section>
             <section id="sapling-spend-description-spenddescriptionv6"><h3><span class="section-heading">Sapling Spend Description (<code>SpendDescriptionV6</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#sapling-spend-description-spenddescriptionv6"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <table>
@@ -433,6 +386,73 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                 </table>
                 <p>The encodings of each of these elements are defined in §7.4 ‘Output Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-16" class="footnote_reference" href="#protocol-outputdesc">4</a>.</p>
             </section>
+            <section id="orchardzsa-action-group-description"><h3><span class="section-heading">OrchardZSA Action Group Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-action-group-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The OrchardZSA Action Group Description is encoded in a transaction as an instance of an <code>ActionGroupDescription</code> type:</p>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Bytes</th>
+                            <th>Name</th>
+                            <th>Data Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>nActionsOrchard</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>The number of Action descriptions in <code>vActionsOrchard</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>852 * nActionsOrchard</code></td>
+                            <td><code>vActionsOrchard</code></td>
+                            <td><code>OrchardZsaAction[nActionsOrchard]</code></td>
+                            <td>A sequence of ZSA Swap Action descriptions in the Action Group.</td>
+                        </tr>
+                        <tr>
+                            <td><code>1</code></td>
+                            <td><code>flagsOrchard</code></td>
+                            <td><code>byte</code></td>
+                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-17" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>32</code></td>
+                            <td><code>anchorOrchard</code></td>
+                            <td><code>byte[32]</code></td>
+                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-18" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>varies</code></td>
+                            <td><code>sizeProofsOrchard</code></td>
+                            <td><code>compactSize</code></td>
+                            <td>As defined in Section 7.1 of the Protocol Specification <a id="footnote-reference-19" class="footnote_reference" href="#protocol-txnencoding">6</a>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>sizeProofsOrchard</code></td>
+                            <td><code>proofsOrchard</code></td>
+                            <td><code>byte[sizeProofsOrchard]</code></td>
+                            <td>The aggregated zk-SNARK proof for all Actions in the Action Group.</td>
+                        </tr>
+                        <tr>
+                            <td><code>4</code></td>
+                            <td><code>timeLimit</code></td>
+                            <td><code>uint32</code></td>
+                            <td>This is set to be a value of <code>0</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>64 * nActionsOrchard</code></td>
+                            <td><code>vSpendAuthSigsOrchard</code></td>
+                            <td><code>byte[64][nActionsOrchard]</code></td>
+                            <td>Authorizing signatures for the inclusion of each Action of the Action Group in a transaction.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>The encoding of <code>OrchardZsaAction</code> is described below.</p>
+                <ul>
+                    <li>The proofs aggregated in <code>proofsOrchardZSA</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardZsaAction</code> at the same index.</li>
+                </ul>
+            </section>
             <section id="orchard-zsa-action-description-orchardzsaaction"><h3><span class="section-heading">Orchard-ZSA Action Description (<code>OrchardZsaAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-action-description-orchardzsaaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <table>
                     <thead>
@@ -474,7 +494,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                             <td><code>32</code></td>
                             <td><code>ephemeralKey</code></td>
                             <td><code>byte[32]</code></td>
-                            <td>An encoding of an ephemeral Pallas public key</td>
+                            <td>An encoding of an ephemeral Pallas public key.</td>
                         </tr>
                         <tr>
                             <td><code>612</code></td>
@@ -490,7 +510,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-17" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
+                <p>The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding and Consensus’ of the Zcash Protocol Specification <a id="footnote-reference-20" class="footnote_reference" href="#protocol-actiondesc">5</a>.</p>
             </section>
             <section id="orchard-zsa-asset-burn-description"><h3><span class="section-heading">Orchard-ZSA Asset Burn Description</span><span class="section-anchor"> <a rel="bookmark" href="#orchard-zsa-asset-burn-description"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An Orchard-ZSA Asset Burn description is encoded in a transaction as an instance of an <code>AssetBurn</code> type:</p>
@@ -520,7 +540,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                         </tr>
                     </tbody>
                 </table>
-                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-18" class="footnote_reference" href="#zip-0226">7</a>.</p>
+                <p>The encodings of each of these elements are defined in ZIP 226 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0226">7</a>.</p>
             </section>
             <section id="issuance-action-description-issueaction"><h3><span class="section-heading">Issuance Action Description (<code>IssueAction</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action-description-issueaction"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
@@ -639,7 +659,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
             </section>
         </section>
         <section id="orchardzsa-fee-calculation"><h2><span class="section-heading">OrchardZSA Fee Calculation</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-19" class="footnote_reference" href="#zip-0317-fee-calc">11</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
+            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0317-fee-calc">11</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
             <table>
                 <thead>
                     <tr>
@@ -693,7 +713,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/686">https://g
                     </tr>
                 </tbody>
             </table>
-            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-20" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0317-fee-calc">11</a>. Note that
+            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-23" class="footnote_reference" href="#protocol-txnencoding">6</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0317-fee-calc">11</a>. Note that
                 <span class="math">\(nOrchardActions\)</span>
             , that is used in the computation of
                 <span class="math">\(logical\_actions\)</span>

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -37,8 +37,8 @@ We define the following additional terms:
 Abstract
 ========
 
-This ZIP (ZIP 226) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The ZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
-While the proposed ZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.
+This ZIP (ZIP 226) proposes the Orchard Zcash Shielded Assets (OrchardZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The OrchardZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
+While the proposed OrchardZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.
 
 Motivation
 ==========
@@ -49,7 +49,7 @@ This ZIP builds on the issuance mechanism introduced in ZIP 227 [#zip-0227]_.
 Overview
 ========
 In order to be able to represent different Assets, we need to define a data field that uniquely represents the Asset in question, which we call the Asset Identifier :math:`\mathsf{AssetId}\!`.
-This Asset Identifier maps to an Asset Base :math:`\mathsf{AssetBase}` that is stored in Orchard-based ZSA notes.
+This Asset Identifier maps to an Asset Base :math:`\mathsf{AssetBase}` that is stored in OrchardZSA notes.
 These terms are formally defined in ZIP 227 [#zip-0227]_.
 
 The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description [#protocol-actions]_ [#protocol-actionencodingandconsensus]_ is preserved across Assets (see the Orchard Binding Signature [#protocol-orchardbalance]_), and by extension the balance of an Orchard transaction. That is, the sum of all the :math:`\mathsf{value^{net}}` from each Action Description, computed as :math:`\mathsf{value^{old}} - \mathsf{value^{new}}\!`, must be balanced **only with respect to the same Asset Identifier**. This is especially important since we will allow different Action Descriptions to transfer notes of different Asset Identifiers, where the overall balance is checked without revealing which (or how many distinct) Assets are being transferred.
@@ -86,10 +86,10 @@ In future network and protocol upgrades, the same Asset description string can b
 Note Structure & Commitment
 ---------------------------
 
-Let :math:`\mathsf{Note^{OrchardZSA}}` be the type of a ZSA note, i.e.
+Let :math:`\mathsf{Note^{OrchardZSA}}` be the type of a OrchardZSA note, i.e.
 :math:`\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}^*\!`.
 
-An Orchard ZSA note differs from an Orchard note [#protocol-notes]_ by additionally including the Asset Base, :math:`\mathsf{AssetBase}\!`. So a ZSA note is a tuple :math:`(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!`,
+An OrchardZSA note differs from an Orchard note [#protocol-notes]_ by additionally including the Asset Base, :math:`\mathsf{AssetBase}\!`. So an OrchardZSA note is a tuple :math:`(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!`,
 where
 
 - :math:`\mathsf{AssetBase} : \mathbb{P}^*` is the unique element of the Pallas group [#protocol-pallasandvesta]_ that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 [#zip-0227]_, a valid group element that is not the identity and is not :math:`\bot\!`. The byte representation of the Asset Base is defined as :math:`\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})\!`.
@@ -123,7 +123,7 @@ Note that :math:`\mathsf{repr}_{\mathbb{P}}` and :math:`\mathsf{GroupHash}^{\mat
 
 The nullifier is generated in the same manner as in the Orchard protocol [#protocol-commitmentsandnullifiers]_.
 
-The ZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext [#protocol-notept]_.
+The OrchardZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext [#protocol-notept]_.
 It consists of
 
 .. math:: (\mathsf{leadByte} : \mathbb{B}^{\mathbb{Y}}, \mathsf{d} : \mathbb{B}^{[\ell_{\mathsf{d}}]}, \mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}, \mathsf{rseed} : \mathbb{B}^{\mathbb{Y}[32]}, \mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}, \mathsf{memo} : \mathbb{B}^{\mathbb{Y}[512]})
@@ -131,20 +131,20 @@ It consists of
 Rationale for Note Commitment
 `````````````````````````````
 
-In the ZSA protocol, the instance of the note commitment scheme, :math:`\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\!`, differs from the Orchard note commitment :math:`\mathsf{NoteCommit^{Orchard}_{rcm}}` in that for Custom Assets, the Asset Base will be added as an input to the commitment computation.
+In the OrchardZSA protocol, the instance of the note commitment scheme, :math:`\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\!`, differs from the Orchard note commitment :math:`\mathsf{NoteCommit^{Orchard}_{rcm}}` in that for Custom Assets, the Asset Base will be added as an input to the commitment computation.
 In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input.
 As we will see, the nested structure of the Sinsemilla-based commitment [#protocol-concretesinsemillacommit]_ allows us to add the Asset Base as a final recursive step.
 
-The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function [#protocol-concretesinsemillahash]_. ZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:
+The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function [#protocol-concretesinsemillahash]_. OrchardZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:
 
 .. math:: \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase}) \in \mathsf{NoteCommit^{Orchard}}.\!\mathsf{Output}
 
-This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and ZSA notes.
+This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and OrchardZSA notes.
 
 Value Commitment
 ----------------
 
-In the case of the Orchard-based ZSA protocol, the value of different Asset Identifiers in a given transaction will be committed using a **different value base point**. The value commitment becomes:
+In the case of the OrchardZSA protocol, the value of different Asset Identifiers in a given transaction will be committed using a **different value base point**. The value commitment becomes:
 
 .. math:: \mathsf{cv^{net}} := \mathsf{ValueCommit^{OrchardZSA}_{rcv}}(\mathsf{AssetBase_{AssetId}}, \mathsf{v^{net}_{AssetId}}) = [\mathsf{v^{net}_{AssetId}}]\,\mathsf{AssetBase_{AssetId}} + [\mathsf{rcv}]\,\mathcal{R}^{\mathsf{Orchard}}
 
@@ -174,7 +174,7 @@ It is enforced at the consensus level, by using an extension of the value balanc
 Burning makes it globally provable that a given amount of a Custom Asset has been destroyed.
 Note that the OrchardZSA Protocol does not allow for the burning of ZEC (or TAZ).
 
-In the `Orchard-ZSA Transaction Structure`_, there is now an :math:`\mathsf{assetBurn}` set. 
+In the `OrchardZSA Transaction Structure`_, there is now an :math:`\mathsf{assetBurn}` set. 
 For every Custom Asset (represented by its :math:`\mathsf{AssetBase}\!`) that is burnt in the transaction, the sender adds to :math:`\mathsf{assetBurn}` the tuple :math:`(\mathsf{AssetBase}, \mathsf{v})`, where :math:`\mathsf{v}` is the amount of the Custom Asset the sender wants to burn. 
 We denote by :math:`L` the cardinality of the :math:`\mathsf{assetBurn}` set in a transaction.
 
@@ -259,9 +259,9 @@ Rationale for Split Notes
 
 In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives *dummy spend notes* [#protocol-orcharddummynotes]_ to the Actions that have not been assigned input notes.
 
-The Orchard technique requires modification for the ZSA protocol with multiple Asset Identifiers, as the output note of the split Actions *cannot* contain *just any* Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.
+The Orchard technique requires modification for the OrchardZSA protocol with multiple Asset Identifiers, as the output note of the split Actions *cannot* contain *just any* Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.
 
-Therefore, for Custom Assets we enforce that *every* input note to an ZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the :math:`\mathsf{split\_flag}` boolean).
+Therefore, for Custom Assets we enforce that *every* input note to an OrchardZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the :math:`\mathsf{split\_flag}` boolean).
 This ensures that the value base points of all output notes of a transfer are actual outputs of a GroupHash, as they originate in the Issuance protocol which is publicly verified.
 
 Note that the Orchard dummy note functionality remains in use for ZEC notes, and the Split Input technique is used in order to support Custom Assets.
@@ -270,7 +270,7 @@ Note that the Orchard dummy note functionality remains in use for ZEC notes, and
 Circuit Statement
 -----------------
 
-Every *ZSA Action statement* is closely similar to the Orchard Action statement [#protocol-actionstatement]_, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.
+Every *OrchardZSA Action statement* is closely similar to the Orchard Action statement [#protocol-actionstatement]_, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.
 
 All modifications in the Circuit are detailed in [#circuit-modifications]_.
 
@@ -318,10 +318,10 @@ Senders must not be able to change the Asset Base for the output note in a Split
 Backwards Compatibility with ZEC Notes
 ``````````````````````````````````````
 
-The input note in the old note commitment integrity check must either include an Asset Base (ZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion [#protocol-abstractcommit]_. If the note is a ZSA note, the note commitment is computed as defined in the `Note Structure & Commitment`_ section.
+The input note in the old note commitment integrity check must either include an Asset Base (OrchardZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion [#protocol-abstractcommit]_. If the note is an OrchardZSA note, the note commitment is computed as defined in the `Note Structure & Commitment`_ section.
 
-Orchard-ZSA Transaction Structure
-=================================
+OrchardZSA Transaction Structure
+================================
 
 The transaction format for v6 transactions is described in ZIP 230 [#zip-0230]_.
 
@@ -329,8 +329,8 @@ The transaction format for v6 transactions is described in ZIP 230 [#zip-0230]_.
 TxId Digest
 ===========
 
-The transaction digest algorithm defined in ZIP 244 [#zip-0244]_ is modified by the ZSA protocol to add a new branch for issuance information, along with modifications within the ``orchard_digest`` to account for the inclusion of the Asset Base.
-The details of these changes are described in this section, and highlighted using the ``[UPDATED FOR ZSA]`` or ``[ADDED FOR ZSA]`` text label. We omit the details of the sections that do not change for the ZSA protocol.
+The transaction digest algorithm defined in ZIP 244 [#zip-0244]_ is modified by the OrchardZSA protocol to add a new branch for issuance information, along with modifications within the ``orchard_digest`` to account for the inclusion of the Asset Base.
+The details of these changes are described in this section, and highlighted using the ``[UPDATED FOR ZSA]`` or ``[ADDED FOR ZSA]`` text label. We omit the details of the sections that do not change for the OrchardZSA protocol.
 
 txid_digest
 -----------
@@ -346,7 +346,7 @@ The personalization field remains the same as in ZIP 244 [#zip-0244]_.
 
 T.4: orchard_digest
 ```````````````````
-When Orchard Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values::
+When OrchardZSA Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values::
 
     T.4a: orchard_action_groups_digest   (32-byte hash output)          [ADDED FOR ZSA]
     T.4b: orchard_zsa_burn_digest        (32-byte hash output)          [ADDED FOR ZSA]
@@ -356,14 +356,14 @@ The personalization field of this hash is the same as in ZIP 244 [#zip-0244]_ ::
 
     "ZTxIdOrchardHash"
 
-In the case that the transaction has no Orchard Action Groups, ``orchard_digest`` is ::
+In the case that the transaction has no OrchardZSA Action Groups, ``orchard_digest`` is ::
 
     BLAKE2b-256("ZTxIdOrchardHash", [])
 
 T.4a: orchard_action_groups_digest
 ''''''''''''''''''''''''''''''''''
 
-A BLAKE2b-256 hash of the subset of Orchard Action Groups information for all Orchard Action Groups belonging to the transaction.
+A BLAKE2b-256 hash of the subset of OrchardZSA Action Groups information for all OrchardZSA Action Groups belonging to the transaction.
 For each Action Group, the following elements are included in the hash::
 
     T.4a.i  : orchard_actions_compact_digest      (32-byte hash output)
@@ -381,8 +381,8 @@ The personalization field of this hash is set to::
 T.4a.i: orchard_actions_compact_digest
 ......................................
 
-A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in
-an updated version of the ZIP-307 [#zip-0307]_ ``CompactBlock`` format for all Orchard
+A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in
+an updated version of the ZIP-307 [#zip-0307]_ ``CompactBlock`` format for all OrchardZSA
 Actions belonging to the transaction. For each Action, the following elements are included
 in the hash::
 
@@ -399,7 +399,7 @@ The personalization field of this hash is the same as in ZIP 244::
 T.4a.ii: orchard_actions_memos_digest
 .....................................
 
-A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all Orchard
+A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all OrchardZSA
 Actions belonging to the transaction. For each Action, the following elements are included
 in the hash::
 
@@ -413,9 +413,9 @@ The personalization field of this hash remains identical to ZIP 244::
 T.4a.iii: orchard_actions_noncompact_digest
 ...........................................
 
-A BLAKE2b-256 hash of the remaining subset of Orchard Action information **not** intended
+A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information **not** intended
 for inclusion in an updated version of the the ZIP 307 [#zip-0307]_ ``CompactBlock``
-format, for all Orchard Actions belonging to the transaction. For each Action,
+format, for all OrchardZSA Actions belonging to the transaction. For each Action,
 the following elements are included in the hash::
 
    T.4a.iii.1 : cv                    (field encoding bytes)
@@ -469,9 +469,9 @@ The details of the changes to these algorithms are in ZIP 227 [#zip-0227-sigdige
 Security and Privacy Considerations
 ===================================
 
-- After the protocol upgrade, the Orchard shielded pool will be shared by the Orchard protocol and the Orchard-ZSA protocol.
-- Deploying the Orchard-ZSA protocol does not necessitate disabling the Orchard protocol. Both can co-exist and be addressed via different transaction versions (V5 for Orchard and V6 for Orchard-ZSA). Due to this, Orchard note commitments can be distinguished from Orchard-ZSA note commitments. This holds whether or not the two protocols are active simultaneously.
-- Orchard-ZSA note commitments for the native asset (ZEC) are indistinguishable from Orchard-ZSA note commitments for non-native Assets.
+- After the protocol upgrade, the Orchard shielded pool will be shared by the Orchard protocol and the OrchardZSA protocol.
+- Deploying the OrchardZSA protocol does not necessitate disabling the Orchard protocol. Both can co-exist and be addressed via different transaction versions (V5 for Orchard and V6 for OrchardZSA). Due to this, Orchard note commitments can be distinguished from OrchardZSA note commitments. This holds whether or not the two protocols are active simultaneously.
+- OrchardZSA note commitments for the native asset (ZEC) are indistinguishable from OrchardZSA note commitments for non-native Assets.
 - When including new Assets we would like to maintain the amount and identifiers of Assets private, which is achieved with the design.
 - We prevent a potential malleability attack on the Asset Identifier by ensuring the output notes receive an Asset Base that exists on the global state.
 
@@ -481,21 +481,21 @@ Other Considerations
 Transaction Fees
 ----------------
 
-The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the ZSA protocol upgrade [#zip-0317b]_.
+The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 230 [#zip-0230-orchardzsa-fee-calculation]_.
 
 Backward Compatibility
 ----------------------
 
-In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and ZSA notes. As we specify above, there are three main reasons we can do this:
+In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and OrchardZSA notes. As we specify above, there are three main reasons we can do this:
 
 - Note commitments for ZEC notes will remain the same, while note commitments for Custom Assets will be computed taking into account the :math:`\mathsf{AssetBase}` value as well.
-- The existing Orchard shielded pool will continue to be used for the new ZSA notes post the upgrade.
+- The existing Orchard shielded pool will continue to be used for the new OrchardZSA notes post the upgrade.
 - The value commitment is abstracted to allow for the value base-point as a variable private input to the proof.
-- The ZEC-based Actions will still include dummy input notes, whereas the ZSA-based Actions will include split input notes and will not include dummy input notes.
+- The ZEC-based Actions will still include dummy input notes, whereas the OrchardZSA Actions will include split input notes and will not include dummy input notes.
 
 Deployment
 -----------
-The Zcash Shielded Assets protocol will be deployed in a subsequent Network Upgrade.
+The Zcash Shielded Assets protocol is scheduled to be deployed in Network Upgrade 7 (NU7).
 
 Test Vectors
 ============
@@ -524,9 +524,9 @@ References
 .. [#zip-0227-sigdigest] `ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest <zip-0227.html#signature-digest>`_
 .. [#zip-0227-authcommitment] `ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment <zip-0227.html#authorizing-data-commitment>`_
 .. [#zip-0230] `ZIP 230: Version 6 Transaction Format <zip-0230.html>`_
+.. [#zip-0230-orchardzsa-fee-calculation] `ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation <zip-0230.html#orchardzsa-fee-calculation>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_
-.. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism - Pull Request #667 for ZSA Protocol ZIPs <https://github.com/zcash/zips/pull/667>`_
 .. [#protocol-notes] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
 .. [#protocol-actions] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.7: Action Transfers and their Descriptions <protocol/protocol.pdf#actions>`_
 .. [#protocol-abstractcommit] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.1.8: Commitment <protocol/protocol.pdf#abstractcommit>`_
@@ -544,4 +544,4 @@ References
 .. [#protocol-actionencodingandconsensus] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.5: Action Description Encoding and Consensus  <protocol/protocol.pdf#actionencodingandconsensus>`_
 .. [#initial-zsa-issue] `User-Defined Assets and Wrapped Assets <https://github.com/str4d/zips/blob/zip-udas/drafts/zip-user-defined-assets.rst>`_
 .. [#generalized-value-commitments] `Comment on Generalized Value Commitments <https://github.com/zcash/zcash/issues/2277#issuecomment-321106819>`_
-.. [#circuit-modifications] `Modifications to the Orchard circuit for the ZSA Protocol <https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing>`_
+.. [#circuit-modifications] `Modifications to the Orchard circuit for the OrchardZSA Protocol <https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing>`_

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -334,7 +334,7 @@ The details of these changes are described in this section, and highlighted usin
 
 txid_digest
 -----------
-A BLAKE2b-256 hash of the following values ::
+A BLAKE2b-256 hash of the following values::
 
    T.1: header_digest       (32-byte hash output)
    T.2: transparent_digest  (32-byte hash output)
@@ -346,74 +346,91 @@ The personalization field remains the same as in ZIP 244 [#zip-0244]_.
 
 T.4: orchard_digest
 ```````````````````
-When Orchard Actions are present in the transaction, this digest is a BLAKE2b-256 hash of the following values ::
+When Orchard Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values::
 
-   T.4a: orchard_actions_compact_digest      (32-byte hash output)          [UPDATED FOR ZSA]
-   T.4b: orchard_actions_memos_digest        (32-byte hash output)          [UPDATED FOR ZSA]
-   T.4c: orchard_actions_noncompact_digest   (32-byte hash output)          [UPDATED FOR ZSA]
-   T.4d: orchard_zsa_burn_digest             (32-byte hash output)          [ADDED FOR ZSA]
-   T.4e: flagsOrchard                        (1 byte)
-   T.4f: valueBalanceOrchard                 (64-bit signed little-endian)
-   T.4g: anchorOrchard                       (32 bytes)
+    T.4a: orchard_action_groups_digest   (32-byte hash output)          [ADDED FOR ZSA]
+    T.4b: orchard_zsa_burn_digest        (32-byte hash output)          [ADDED FOR ZSA]
+    T.4c: valueBalanceOrchard            (64-bit signed little-endian)
 
-T.4a: orchard_actions_compact_digest
-''''''''''''''''''''''''''''''''''''
+The personalization field of this hash is the same as in ZIP 244 [#zip-0244]_ ::
+
+    "ZTxIdOrchardHash"
+
+In the case that the transaction has no Orchard Action Groups, ``orchard_digest`` is ::
+
+    BLAKE2b-256("ZTxIdOrchardHash", [])
+
+T.4a: orchard_action_groups_digest
+''''''''''''''''''''''''''''''''''
+
+A BLAKE2b-256 hash of the subset of Orchard Action Groups information for all Orchard Action Groups belonging to the transaction.
+For each Action Group, the following elements are included in the hash::
+
+    T.4a.i  : orchard_actions_compact_digest      (32-byte hash output)
+    T.4a.ii : orchard_actions_memos_digest        (32-byte hash output)
+    T.4a.iii: orchard_actions_noncompact_digest   (32-byte hash output)
+    T.4a.iv : flagsOrchard                        (1 byte)
+    T.4a.v  : anchorOrchard                       (32 bytes)
+    T.4a.vi : timeLimit                           (4 bytes)
+
+T.4a.i: orchard_actions_compact_digest
+......................................
 
 A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in
 an updated version of the ZIP-307 [#zip-0307]_ ``CompactBlock`` format for all Orchard
 Actions belonging to the transaction. For each Action, the following elements are included
 in the hash::
 
-   T.4a.i  : nullifier            (field encoding bytes)
-   T.4a.ii : cmx                  (field encoding bytes)
-   T.4a.iii: ephemeralKey         (field encoding bytes)
-   T.4a.iv : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR ZSA]
+   T.4a.i.1 : nullifier            (field encoding bytes)
+   T.4a.i.2 : cmx                  (field encoding bytes)
+   T.4a.i.3 : ephemeralKey         (field encoding bytes)
+   T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR ZSA]
 
 The personalization field of this hash is the same as in ZIP 244::
 
   "ZTxIdOrcActCHash"
 
 
-T.4b: orchard_actions_memos_digest
-''''''''''''''''''''''''''''''''''
+T.4a.ii: orchard_actions_memos_digest
+.....................................
 
 A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all Orchard
 Actions belonging to the transaction. For each Action, the following elements are included
 in the hash::
 
-    T.4b.i: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]
+    T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]
 
 The personalization field of this hash remains identical to ZIP 244::
 
   "ZTxIdOrcActMHash"
 
 
-T.4c: orchard_actions_noncompact_digest
-'''''''''''''''''''''''''''''''''''''''
+T.4a.iii: orchard_actions_noncompact_digest
+...........................................
 
 A BLAKE2b-256 hash of the remaining subset of Orchard Action information **not** intended
 for inclusion in an updated version of the the ZIP 307 [#zip-0307]_ ``CompactBlock``
 format, for all Orchard Actions belonging to the transaction. For each Action,
 the following elements are included in the hash::
 
-   T.4d.i  : cv                    (field encoding bytes)
-   T.4d.ii : rk                    (field encoding bytes)
-   T.4d.iii: encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
-   T.4d.iv : outCiphertext         (field encoding bytes)
+   T.4a.iii.1 : cv                    (field encoding bytes)
+   T.4a.iii.2 : rk                    (field encoding bytes)
+   T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
+   T.4a.iii.4 : outCiphertext         (field encoding bytes)
 
 The personalization field of this hash is defined identically to ZIP 244::
 
     "ZTxIdOrcActNHash"
 
 
-T.4d: orchard_zsa_burn_digest
+T.4b: orchard_zsa_burn_digest
 '''''''''''''''''''''''''''''
 
 A BLAKE2b-256 hash of the data from the burn fields of the transaction. For each tuple in 
 the :math:`\mathsf{assetBurn}` set, the following elements are included in the hash::
 
-    T.4d.i : assetBase    (field encoding bytes)
-    T.4d.ii: valueBurn    (field encoding bytes)
+    T.4b.i : assetBase    (field encoding bytes)
+    T.4b.ii: valueBurn    (field encoding bytes)
 
 The personalization field of this hash is set to::
 
@@ -424,12 +441,12 @@ In case the transaction does not perform the burning of any Assets (i.e. the
 
     BLAKE2b-256("ZTxIdOrcBurnHash", [])
 
-T.4d.i: assetBase
+T.4b.i: assetBase
 .................
 The Asset Base being burnt encoded as the 32-byte representation of a point on the 
 Pallas curve.
 
-T.4d.ii: valueBurn
+T.4b.ii: valueBurn
 ..................
 Value of the Asset Base being burnt encoded as little-endian 8-byte representation 
 of 64-bit unsigned integer (e.g. u64 in Rust) raw value.

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -373,6 +373,11 @@ For each Action Group, the following elements are included in the hash::
     T.4a.v  : anchorOrchard                       (32 bytes)
     T.4a.vi : timeLimit                           (4 bytes)
 
+The personalization field of this hash is set to::
+
+    "ZTxIdOrcActGHash"
+
+
 T.4a.i: orchard_actions_compact_digest
 ......................................
 

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -89,7 +89,7 @@ Note Structure & Commitment
 Let :math:`\mathsf{Note^{OrchardZSA}}` be the type of a ZSA note, i.e.
 :math:`\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}^*\!`.
 
-An Orchard ZSA note differs from an Orchard note [#protocol-notes]_ by additionally including the Asset Base, :math:`\mathsf{AssetBase}\!`. So a ZSA note is a tuple :math:`(\mathsf{g_d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!`,
+An Orchard ZSA note differs from an Orchard note [#protocol-notes]_ by additionally including the Asset Base, :math:`\mathsf{AssetBase}\!`. So a ZSA note is a tuple :math:`(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!`,
 where
 
 - :math:`\mathsf{AssetBase} : \mathbb{P}^*` is the unique element of the Pallas group [#protocol-pallasandvesta]_ that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 [#zip-0227]_, a valid group element that is not the identity and is not :math:`\bot\!`. The byte representation of the Asset Base is defined as :math:`\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})\!`.
@@ -371,7 +371,7 @@ For each Action Group, the following elements are included in the hash::
     T.4a.iii: orchard_actions_noncompact_digest   (32-byte hash output)
     T.4a.iv : flagsOrchard                        (1 byte)
     T.4a.v  : anchorOrchard                       (32 bytes)
-    T.4a.vi : timeLimit                           (4 bytes)
+    T.4a.vi : nAGExpiryHeight                     (4 bytes)
 
 The personalization field of this hash is set to::
 

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -44,7 +44,7 @@ We define the following additional terms:
 Abstract
 ========
 
-This ZIP (ZIP 227) proposes the Zcash Shielded Assets (ZSA) protocol, in conjunction with ZIP 226 [#zip-0226]_. This protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of Custom Assets on the Zcash chain. The creation of such Assets is defined in this ZIP (ZIP 227), while the transfer and burn of such Assets is defined in ZIP 226 [#zip-0226]_. This ZIP must only be implemented in conjunction with ZIP 226 [#zip-0226]_. The proposed issuance mechanism is only valid for the Orchard-ZSA transfer protocol, because it produces notes that can only be transferred under ZSA.
+This ZIP (ZIP 227) proposes the Orchard Zcash Shielded Assets (OrchardZSA) protocol, in conjunction with ZIP 226 [#zip-0226]_. This protocol is an extension of the Orchard protocol that enables the creation, transfer and burn of Custom Assets on the Zcash chain. The creation of such Assets is defined in this ZIP (ZIP 227), while the transfer and burn of such Assets is defined in ZIP 226 [#zip-0226]_. This ZIP must only be implemented in conjunction with ZIP 226 [#zip-0226]_. The proposed issuance mechanism is only valid for the OrchardZSA transfer protocol, because it produces notes that can only be transferred via this protocol.
 
 Motivation
 ==========
@@ -81,7 +81,7 @@ Requirements
 Specification: Issuance Keys and Issuance Authorization Signature Scheme
 ========================================================================
 
-The Orchard-ZSA Protocol adds the following keys to the key components [#protocol-addressesandkeys]_ [#protocol-orchardkeycomponents]_:
+The OrchardZSA Protocol adds the following keys to the key components [#protocol-addressesandkeys]_ [#protocol-orchardkeycomponents]_:
 
 1. The issuance authorizing key, denoted as :math:`\mathsf{isk}\!`, is the key used to authorize the issuance of Asset Identifiers by a given issuer, and is only used by that issuer.
 
@@ -94,7 +94,7 @@ The relations between these keys are shown in the following diagram:
     :align: center
     :figclass: align-center
 
-    Diagram of Issuance Key Components for the Orchard-ZSA Protocol
+    Diagram of Issuance Key Components for the OrchardZSA Protocol
 
 
 Issuance Authorization Signature Scheme
@@ -187,7 +187,7 @@ Specification: Asset Identifier
 
 For every new Asset, there MUST be a new and unique Asset Identifier, denoted :math:`\mathsf{AssetId}\!`. We define this to be a globally unique pair :math:`\mathsf{AssetId} := (\mathsf{ik}, \mathsf{asset\_desc})\!`, where :math:`\mathsf{ik}` is the issuance key and :math:`\mathsf{asset\_desc}` is a byte string.
 
-A given Asset Identifier is used across all Zcash protocols that support ZSAs -- that is, the Orchard-ZSA protocol and potentially future Zcash shielded protocols. For this Asset Identifier, we derive an Asset Digest, :math:`\mathsf{AssetDigest}\!`, which is simply is a :math:`\textsf{BLAKE2b-512}` hash of the Asset Identifier.
+A given Asset Identifier is used across all Zcash protocols that support ZSAs -- that is, the OrchardZSA protocol and potentially future Zcash shielded protocols. For this Asset Identifier, we derive an Asset Digest, :math:`\mathsf{AssetDigest}\!`, which is simply is a :math:`\textsf{BLAKE2b-512}` hash of the Asset Identifier.
 From the Asset Digest, we derive a specific Asset Base within each shielded protocol using the applicable hash-to-curve algorithm. This Asset Base is included in shielded notes.
 
 Let
@@ -203,7 +203,7 @@ where
 
 Define :math:`\mathsf{AssetBase_{AssetId}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}})`
 
-In the case of the Orchard-ZSA protocol, we define :math:`\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})`
+In the case of the OrchardZSA protocol, we define :math:`\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})`
 where :math:`\mathsf{GroupHash}^\mathbb{P}` is defined as in [#protocol-concretegrouphashpallasandvesta]_.
 
 The relations between the Asset Identifier, Asset Digest, and Asset Base are shown in the following diagram:
@@ -213,7 +213,7 @@ The relations between the Asset Identifier, Asset Digest, and Asset Base are sho
     :align: center
     :figclass: align-center
 
-    Diagram relating the Asset Identifier, Asset Digest, and Asset Base in the ZSA Protocol
+    Diagram relating the Asset Identifier, Asset Digest, and Asset Base in the OrchardZSA Protocol
 
 
 **Note:** To keep notations light and concise, we may omit :math:`\mathsf{AssetId}` (resp. :math:`\mathsf{Protocol}\!`) in the subscript (resp. superscript) when the Asset Identifier (resp. Protocol) is clear from the context.
@@ -294,7 +294,7 @@ For all actions ``IssueAction``:
 - set the :math:`\mathsf{finalize}` boolean as desired (if more issuance actions are to be created for this :math:`\mathsf{AssetBase}\!`, set :math:`\mathsf{finalize} = 0\!`, otherwise set :math:`\mathsf{finalize} = 1\!`).
 - for each recipient :math:`i`:
 
-    - generate a ZSA output note that includes the Asset Base. For an Orchard-ZSA note this is :math:`\mathsf{note}_i = (\mathsf{d}_i, \mathsf{pk}_{\mathsf{d}_i}, \mathsf{v}_i, \text{ρ}_i, \mathsf{rseed}_i, \mathsf{AssetBase}, \mathsf{rcm}_i)\!`.
+    - generate a ZSA output note that includes the Asset Base. For an OrchardZSA note this is :math:`\mathsf{note}_i = (\mathsf{d}_i, \mathsf{pk}_{\mathsf{d}_i}, \mathsf{v}_i, \text{ρ}_i, \mathsf{rseed}_i, \mathsf{AssetBase}, \mathsf{rcm}_i)\!`.
 
 - encode the ``IssueAction`` into the vector ``vIssueActions`` of the bundle.
 
@@ -378,7 +378,7 @@ TxId Digest - Issuance
 ======================
 
 This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data.
-Details of the overall changes to the transaction digest due to the Orchard-ZSA protocol can be found in ZIP 226 [#zip-0226-txiddigest]_.
+Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 [#zip-0226-txiddigest]_.
 As in ZIP 244 [#zip-0244]_, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.
 
 A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below::
@@ -479,7 +479,7 @@ Signature Digest
 The per-input transaction digest algorithm to generate the signature digest in ZIP 244 [#zip-0244-sigdigest]_ is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action.
 For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.
 
-The overall structure of the hash is as follows. We highlight the changes for the Orchard-ZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol::
+The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
 
     signature_digest
     ├── header_digest
@@ -507,8 +507,8 @@ Identical to that specified for the transaction identifier.
 Authorizing Data Commitment
 ===========================
 
-The transaction digest algorithm defined in ZIP 244 [#zip-0244-authcommitment]_ which commits to the authorizing data of a transaction is modified by the Orchard-ZSA protocol to have the following structure.
-We highlight the changes for the Orchard-ZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol::
+The transaction digest algorithm defined in ZIP 244 [#zip-0244-authcommitment]_ which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the following structure.
+We highlight the changes for the OrchardZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
 
     auth_digest
     ├── transparent_scripts_digest
@@ -574,7 +574,7 @@ Although not enforced in the global state, it is RECOMMENDED that Zcash full val
 Fee Structures
 --------------
 
-The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317 [#zip-0317b]_.
+The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 [#zip-0230-orchardzsa-fee-calculation]_.
 
 
 Test Vectors
@@ -611,10 +611,10 @@ References
 .. [#zip-0226-txiddigest] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - TxId Digest <zip-0226.html#txid-digest>`_
 .. [#zip-0230-issuance-action-description] `ZIP 230: Version 6 Transaction Format: Issuance Action Description (IssueAction) <zip-0230.html#issuance-action-description-issueaction>`_
 .. [#zip-0230-transaction-format] `ZIP 230: Version 6 Transaction Format: Transaction Format <zip-0230.html#transaction-format>`_
+.. [#zip-0230-orchardzsa-fee-calculation] `ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation <zip-0230.html#orchardzsa-fee-calculation>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0244-sigdigest] `ZIP 244: Transaction Identifier Non-Malleability: Signature Digest <zip-0244.html#signature-digest>`_
 .. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_
-.. [#zip-0317b] `ZIP 317: Proportional Transfer Fee Mechanism <https://github.com/zcash/zips/pull/667>`_
 .. [#bip-0340] `BIP 340: Schnorr Signatures for secp256k1 <https://github.com/bitcoin/bips/blob/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb/bip-0340.mediawiki>`_
 .. [#protocol-notation] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 2: Notation <protocol/protocol.pdf#notation>`_
 .. [#protocol-addressesandkeys] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.1: Payment Addresses and Keys <protocol/protocol.pdf#addressesandkeys>`_

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -294,7 +294,9 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``sizeProofsOrchard``               |``proofsOrchard``         |``byte[sizeProofsOrchard]``                       |The aggregated zk-SNARK proof for all Actions in the Action Group.   |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``4``                               |``timeLimit``             |``uint32``                                        |This is set to be a value of ``0``.                                  |  
+|``4``                               |``timeLimit``             |``uint32``                                        |The block number (in the future) after which the Actions of the      |
+|                                    |                          |                                                  |Action Group become invalid and should be rejected by consensus.     |
+|                                    |                          |                                                  |This is set to be a value of ``0``.                                  |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64][nActionsOrchard]``                     |Authorizing signatures for the inclusion of each Action of the       |  
 |                                    |                          |                                                  |Action Group in a transaction.                                       |

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -24,7 +24,7 @@ Terminology
 The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as
 described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
-The terms "Zcash Shielded Asset", "ZSA" and "Asset" in this document are to be interpreted as described in ZIP 226 [#zip-0226]_.
+The terms "Zcash Shielded Asset", "OrchardZSA", "ZSA" and "Asset" in this document are to be interpreted as described in ZIP 226 [#zip-0226]_.
 
 The term "Issuance" and "Issuance Action" in this document are to be interpreted as described in ZIP 227 [#zip-0227]_.
 
@@ -40,7 +40,7 @@ Abstract
 ========
 
 This proposal defines a new Zcash peer-to-peer transaction format, which includes
-data that supports the Orchard-ZSA protocol and all operations related to Zcash
+data that supports the OrchardZSA protocol and all operations related to Zcash
 Shielded Assets (ZSAs). The new format adds and describes new fields containing
 ZSA-specific elements. Like the existing v5 transaction format, it keeps well-bounded
 regions of the serialized form to serve each pool of funds.
@@ -57,7 +57,7 @@ The fee mechanism is defined in terms of modifications to the Proportionak Trans
 Motivation
 ==========
 
-The Orchard-ZSA protocol requires serialized data elements that are distinct from
+The OrchardZSA protocol requires serialized data elements that are distinct from
 any previous Zcash transaction. Since ZIP 244 was activated in NU5, the
 v5 and later serialized transaction formats are not consensus-critical.
 Thus, this ZIP defines format that can easily accommodate future extensions,
@@ -76,7 +76,7 @@ This motivates further the addition of an Issuance-specific fee.
 Requirements
 ============
 
-The new format must fully support the Orchard-ZSA protocol.
+The new format must fully support the OrchardZSA protocol.
 
 The new format should lend itself to future extension or pruning to add or remove
 value pools.
@@ -169,7 +169,7 @@ Transaction Format
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
 |``64``                              |``bindingSigSapling``     |``byte[64]``                                      |A Sapling binding signature on the SIGHASH transaction hash.               |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
-| **Orchard-ZSA Transaction Fields**                                                                                                                                                           |
+| **OrchardZSA Transaction Fields**                                                                                                                                                            |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
 |``varies``                          |``nActionGroupsOrchard``  |``compactSize``                                   |The number of Action Group descriptions in ``vActionGroupsOrchard``.       |  
 |                                    |                          |                                                  |This MUST have a value of either ``0`` or ``1``.                           |  
@@ -182,11 +182,11 @@ Transaction Format
 | ``varies``                         | ``nAssetBurn``           | ``compactSize``                                  | The number of Assets burnt.                                               |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
 | ``40 * nAssetBurn``                | ``vAssetBurn``           | ``AssetBurn[nAssetBurn]``                        | A sequence of Asset Burn descriptions,                                    |
-|                                    |                          |                                                  | encoded per `Orchard-ZSA Asset Burn Description`_.                        |
+|                                    |                          |                                                  | encoded per `OrchardZSA Asset Burn Description`_.                         |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
-|``64``                              |``bindingSigOrchard``     |``byte[64]``                                      |An Orchard-ZSA binding signature on the SIGHASH transaction hash.          |
+|``64``                              |``bindingSigOrchard``     |``byte[64]``                                      |An OrchardZSA binding signature on the SIGHASH transaction hash.           |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
-| **Orchard-ZSA Issuance Fields**                                                                                                                                                              |
+| **OrchardZSA Issuance Fields**                                                                                                                                                               |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
 |``varies``                          |``nIssueActions``         |``compactSize``                                   |The number of issuance actions in the bundle.                              |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
@@ -282,7 +282,7 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 |``varies``                          |``nActionsOrchard``       |``compactSize``                                   |The number of Action descriptions in ``vActionsOrchard``.            |  
 |                                    |                          |                                                  |This MUST have a value strictly greater than ``0``.                  |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``852 * nActionsOrchard``           |``vActionsOrchard``       |``OrchardZsaAction[nActionsOrchard]``             |A sequence of ZSA Swap Action descriptions in the Action Group.      |  
+|``852 * nActionsOrchard``           |``vActionsOrchard``       |``OrchardZSAAction[nActionsOrchard]``             |A sequence of OrchardZSA Action descriptions in the Action Group.    |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``1``                               |``flagsOrchard``          |``byte``                                          |As defined in Section 7.1 of the Protocol                            |  
 |                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |  
@@ -303,22 +303,22 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 |                                    |                          |                                                  |transaction.                                                         |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 
-The encoding of ``OrchardZsaAction`` is described below.
+The encoding of ``OrchardZSAAction`` is described below.
 
 * The proofs aggregated in ``proofsOrchardZSA``, and the elements of
   ``vSpendAuthSigsOrchard``, each have a 1:1 correspondence to the elements of
   ``vActionsOrchard`` and MUST be ordered such that the proof or signature at a given
-  index corresponds to the ``OrchardZsaAction`` at the same index.
+  index corresponds to the ``OrchardZSAAction`` at the same index.
 
 Rationale for nAGExpiryHeight
 `````````````````````````````
 
-We introduce the ``nAGExpiryHeight`` field in this transaction format in order to be forward compatible with Swaps over ZSAs [#zip-0228]_.
+We introduce the ``nAGExpiryHeight`` field in this transaction format in order to be forward compatible with Swaps over ZSAs, as proposed in ZIP 228 [#zip-0228]_.
 For the OrchardZSA protocol, which does not make use of an additional expiry height for transactions, we set the value of ``nAGExpiryHeight`` to be ``0`` by consensus.
 This serves as a default value to represent the situation where there is no expiry, analogous to the convention adopted for ``nExpiryHeight`` in ZIP 203 [#zip-0203].
 
-Orchard-ZSA Action Description (``OrchardZsaAction``)
------------------------------------------------------
+OrchardZSA Action Description (``OrchardZSAAction``)
+----------------------------------------------------
 
 +-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
 | Bytes                       | Name                     | Data Type                            | Description                                                |
@@ -346,15 +346,15 @@ Orchard-ZSA Action Description (``OrchardZsaAction``)
 The encodings of each of these elements are defined in §7.5 ‘Action Description Encoding
 and Consensus’ of the Zcash Protocol Specification [#protocol-actiondesc]_.
 
-Orchard-ZSA Asset Burn Description
+OrchardZSA Asset Burn Description
 ----------------------------------
 
-An Orchard-ZSA Asset Burn description is encoded in a transaction as an instance of an ``AssetBurn`` type:
+An OrchardZSA Asset Burn description is encoded in a transaction as an instance of an ``AssetBurn`` type:
 
 +-------+---------------+-----------------------------+--------------------------------------------------------------------------------------------------------------------+
 | Bytes | Name          | Data Type                   | Description                                                                                                        |
 +=======+===============+=============================+====================================================================================================================+
-| 32    | ``AssetBase`` | ``byte[32]``                | For the Orchard-based ZSA protocol, this is the encoding of the Asset Base :math:`\mathsf{AssetBase^{Orchard}}\!`. |
+| 32    | ``AssetBase`` | ``byte[32]``                | For the OrchardZSA protocol, this is the encoding of the Asset Base :math:`\mathsf{AssetBase^{Orchard}}\!`.        |
 +-------+---------------+-----------------------------+--------------------------------------------------------------------------------------------------------------------+
 | 8     | ``valueBurn`` | ``uint64``                  | The amount being burnt. The value is checked by consensus to be non-zero.                                          |
 +-------+---------------+-----------------------------+--------------------------------------------------------------------------------------------------------------------+
@@ -435,7 +435,7 @@ calculated in zatoshis. Additional definitions that are used in the formula for 
 Input                            Units  Description
 ================================ ====== ====================================================================================================================
 :math:`nOrchardActions`          number the number of OrchardZSA transfer actions (including ZEC actions)
-:math:`nTotalOutputsZsaIssuance` number the total number of OrchardZSA issuance outputs (added across issuance actions)
+:math:`nTotalOutputsZSAIssuance` number the total number of OrchardZSA issuance outputs (added across issuance actions)
 :math:`nCreateActions`           number the number of OrchardZSA issuance actions that issue a Custom Asset that is not present in the Global Issuance State
 ================================ ====== ====================================================================================================================
 
@@ -446,7 +446,7 @@ Note that :math:`nOrchardActions`, that is used in the computation of :math:`log
 The formula for the computation of the :math:`zsa\_logical\_actions` (with the updated computation of :math:`logical\_actions` as described above) is:
 
 .. math::
-     zsa\_logical\_actions  = logical\_actions \;+ nTotalOutputsZsaIssuance
+     zsa\_logical\_actions  = logical\_actions \;+ nTotalOutputsZSAIssuance
 
 The formula for the computation of the :math:`zsa\_conventional\_fee` is:
 

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -113,107 +113,91 @@ The Zcash transaction format for transaction version 6 is as follows:
 Transaction Format
 ------------------
 
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-| Bytes                              | Name                     | Data Type                              | Description                                                               |
-+====================================+==========================+========================================+===========================================================================+
-| **Common Transaction Fields**                                                                                                                                                      |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``4``                               |``header``                |``uint32``                              |Contains:                                                                  |
-|                                    |                          |                                        |  * ``fOverwintered`` flag (bit 31, always set)                            |
-|                                    |                          |                                        |  * ``version`` (bits 30 .. 0) – transaction version.                      |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``4``                               |``nVersionGroupId``       |``uint32``                              |Version group ID (nonzero).                                                |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``4``                               |``nConsensusBranchId``    |``uint32``                              |Consensus branch ID (nonzero).                                             |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``4``                               |``lock_time``             |``uint32``                              |Unix-epoch UTC time or block height, encoded as in Bitcoin.                |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``4``                               |``nExpiryHeight``         |``uint32``                              |A block height in the range {1 .. 499999999} after which                   |
-|                                    |                          |                                        |the transaction will expire, or 0 to disable expiry.                       |
-|                                    |                          |                                        |[ZIP-203]                                                                  |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``8``                               |``fee``                   |``int64``                               |The fee to be paid by this transaction, in zatoshis.                       |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-| **Transparent Transaction Fields**                                                                                                                                                 |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``tx_in_count``           |``compactSize``                         |Number of transparent inputs in ``tx_in``.                                 |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``tx_in``                 |``tx_in``                               |Transparent inputs, encoded as in Bitcoin.                                 |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``tx_out_count``          |``compactSize``                         |Number of transparent outputs in ``tx_out``.                               |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``tx_out``                |``tx_out``                              |Transparent outputs, encoded as in Bitcoin.                                |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-| **Sapling Transaction Fields**                                                                                                                                                     |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``nSpendsSapling``        |``compactSize``                         |Number of Sapling Spend descriptions in ``vSpendsSapling``.                |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``96 * nSpendsSapling``             |``vSpendsSapling``        |``SpendDescriptionV6[nSpendsSapling]``  |A sequence of Sapling Spend descriptions, encoded per                      |
-|                                    |                          |                                        |protocol §7.3 ‘Spend Description Encoding and Consensus’.                  |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``nOutputsSapling``       |``compactSize``                         |Number of Sapling Output Decriptions in ``vOutputsSapling``.               |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``756 * nOutputsSapling``           |``vOutputsSapling``       |``OutputDescriptionV6[nOutputsSapling]``|A sequence of Sapling Output descriptions, encoded per                     |
-|                                    |                          |                                        |protocol §7.4 ‘Output Description Encoding and Consensus’.                 |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``8``                               |``valueBalanceSapling``   |``int64``                               |The net value of Sapling Spends minus Outputs                              |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``32``                              |``anchorSapling``         |``byte[32]``                            |A root of the Sapling note commitment tree                                 |
-|                                    |                          |                                        |at some block height in the past.                                          |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``192 * nSpendsSapling``            |``vSpendProofsSapling``   |``byte[192 * nSpendsSapling]``          |Encodings of the zk-SNARK proofs for each Sapling Spend.                   |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``64 * nSpendsSapling``             |``vSpendAuthSigsSapling`` |``byte[64 * nSpendsSapling]``           |Authorizing signatures for each Sapling Spend.                             |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``192 * nOutputsSapling``           |``vOutputProofsSapling``  |``byte[192 * nOutputsSapling]``         |Encodings of the zk-SNARK proofs for each Sapling Output.                  |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``64``                              |``bindingSigSapling``     |``byte[64]``                            |A Sapling binding signature on the SIGHASH transaction hash.               |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-| **Orchard-ZSA Transaction Fields**                                                                                                                                                 |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``nActionsOrchard``       |``compactSize``                         |The number of Orchard-ZSA Action descriptions in                           |
-|                                    |                          |                                        |``vActionsOrchard``.                                                       |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``852 * nActionsOrchard``           |``vActionsOrchard``       |``OrchardZsaAction[nActionsOrchard]``   |A sequence of Orchard-ZSA Action descriptions, encoded per                 |
-|                                    |                          |                                        |the `Orchard-ZSA Action Description Encoding`.                             |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``1``                               |``flagsOrchard``          |``byte``                                |An 8-bit value representing a set of flags. Ordered from LSB to MSB:       |
-|                                    |                          |                                        | * ``enableSpendsOrchard``                                                 |
-|                                    |                          |                                        | * ``enableOutputsOrchard``                                                |
-|                                    |                          |                                        | * ``enableZSAs``                                                          |
-|                                    |                          |                                        | * The remaining bits are set to :math:`0\!`.                              |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``8``                               |``valueBalanceOrchard``   |``int64``                               |The net value of Orchard spends minus outputs.                             |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``32``                              |``anchorOrchard``         |``byte[32]``                            |A root of the Orchard note commitment tree at some block                   |
-|                                    |                          |                                        |height in the past.                                                        |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``sizeProofsOrchardZSA``  |``compactSize``                         |Length in bytes of ``proofsOrchardZSA``. Value is **(TO UPDATE)**          |
-|                                    |                          |                                        |:math:`2720 + 2272 \cdot \mathtt{nActionsOrchard}\!`.                      |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``sizeProofsOrchardZSA``            |``proofsOrchardZSA``      |``byte[sizeProofsOrchardZSA]``          |Encoding of aggregated zk-SNARK proofs for Orchard-ZSA Actions.            |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64 * nActionsOrchard]``          |Authorizing signatures for each Orchard-ZSA Action.                        |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-| ``varies``                         | ``nAssetBurn``           | ``compactSize``                        | The number of Assets burnt.                                               |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-| ``40 * nAssetBurn``                | ``vAssetBurn``           | ``AssetBurn[nAssetBurn]``              | A sequence of Asset Burn descriptions,                                    |
-|                                    |                          |                                        | encoded per `Orchard-ZSA Asset Burn Description`_.                        |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``64``                              |``bindingSigOrchard``     |``byte[64]``                            |An Orchard-ZSA binding signature on the SIGHASH transaction hash.          |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-| **Orchard-ZSA Issuance Fields**                                                                                                                                                    |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``varies``                          |``nIssueActions``         |``compactSize``                         |The number of issuance actions in the bundle.                              |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``IssueActionSize * nIssueActions`` |``vIssueActions``         |``IssueAction[nIssueActions]``          |A sequence of issuance action descriptions, where IssueActionSize is       |
-|                                    |                          |                                        |the size, in bytes, of an IssueAction description.                         |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``32``                              |``ik``                    |``byte[32]``                            |The issuance validating key of the issuer, used to validate the signature. |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
-|``64``                              |``issueAuthSig``          |``byte[64]``                            |The signature of the transaction SIGHASH, signed by the issuer,            |
-|                                    |                          |                                        |validated as in Issuance Authorization Signature Scheme [#zip-0227]_.      |
-+------------------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------------+
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+| Bytes                              | Name                     | Data Type                                        | Description                                                               |
++====================================+==========================+==================================================+===========================================================================+
+| **Common Transaction Fields**                                                                                                                                                                |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``header``                |``uint32``                                        |Contains:                                                                  |
+|                                    |                          |                                                  |  * ``fOverwintered`` flag (bit 31, always set)                            |
+|                                    |                          |                                                  |  * ``version`` (bits 30 .. 0) – transaction version.                      |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``nVersionGroupId``       |``uint32``                                        |Version group ID (nonzero).                                                |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``nConsensusBranchId``    |``uint32``                                        |Consensus branch ID (nonzero).                                             |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``lock_time``             |``uint32``                                        |Unix-epoch UTC time or block height, encoded as in Bitcoin.                |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``4``                               |``nExpiryHeight``         |``uint32``                                        |A block height in the range {1 .. 499999999} after which                   |
+|                                    |                          |                                                  |the transaction will expire, or 0 to disable expiry.                       |
+|                                    |                          |                                                  |[ZIP-203]                                                                  |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``8``                               |``fee``                   |``int64``                                         |The fee to be paid by this transaction, in zatoshis.                       |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+| **Transparent Transaction Fields**                                                                                                                                                           |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_in_count``           |``compactSize``                                   |Number of transparent inputs in ``tx_in``.                                 |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_in``                 |``tx_in``                                         |Transparent inputs, encoded as in Bitcoin.                                 |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_out_count``          |``compactSize``                                   |Number of transparent outputs in ``tx_out``.                               |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``tx_out``                |``tx_out``                                        |Transparent outputs, encoded as in Bitcoin.                                |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+| **Sapling Transaction Fields**                                                                                                                                                               |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nSpendsSapling``        |``compactSize``                                   |Number of Sapling Spend descriptions in ``vSpendsSapling``.                |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``96 * nSpendsSapling``             |``vSpendsSapling``        |``SpendDescriptionV6[nSpendsSapling]``            |A sequence of Sapling Spend descriptions, encoded per                      |
+|                                    |                          |                                                  |protocol §7.3 ‘Spend Description Encoding and Consensus’.                  |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nOutputsSapling``       |``compactSize``                                   |Number of Sapling Output Decriptions in ``vOutputsSapling``.               |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``756 * nOutputsSapling``           |``vOutputsSapling``       |``OutputDescriptionV6[nOutputsSapling]``          |A sequence of Sapling Output descriptions, encoded per                     |
+|                                    |                          |                                                  |protocol §7.4 ‘Output Description Encoding and Consensus’.                 |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``8``                               |``valueBalanceSapling``   |``int64``                                         |The net value of Sapling Spends minus Outputs                              |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``32``                              |``anchorSapling``         |``byte[32]``                                      |A root of the Sapling note commitment tree                                 |
+|                                    |                          |                                                  |at some block height in the past.                                          |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``192 * nSpendsSapling``            |``vSpendProofsSapling``   |``byte[192 * nSpendsSapling]``                    |Encodings of the zk-SNARK proofs for each Sapling Spend.                   |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``64 * nSpendsSapling``             |``vSpendAuthSigsSapling`` |``byte[64 * nSpendsSapling]``                     |Authorizing signatures for each Sapling Spend.                             |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``192 * nOutputsSapling``           |``vOutputProofsSapling``  |``byte[192 * nOutputsSapling]``                   |Encodings of the zk-SNARK proofs for each Sapling Output.                  |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``64``                              |``bindingSigSapling``     |``byte[64]``                                      |A Sapling binding signature on the SIGHASH transaction hash.               |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+| **Orchard-ZSA Transaction Fields**                                                                                                                                                           |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nActionGroupsOrchard``  |``compactSize``                                   |The number of Action Group descriptions in ``vActionGroupsOrchard``.       |  
+|                                    |                          |                                                  |This has a value of either ``0`` or ``1``.                                 |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``vActionGroupsOrchard``  |``ActionGroupDescription[nActionGroupsOrchard]``  |A sequence of Action Group descriptions, encoded as per the                |  
+|                                    |                          |                                                  |`OrchardZSA Action Group Description`_.                                    |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``8``                               |``valueBalanceOrchard``   |``int64``                                         |The net value of Orchard spends minus outputs.                             |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+| ``varies``                         | ``nAssetBurn``           | ``compactSize``                                  | The number of Assets burnt.                                               |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+| ``40 * nAssetBurn``                | ``vAssetBurn``           | ``AssetBurn[nAssetBurn]``                        | A sequence of Asset Burn descriptions,                                    |
+|                                    |                          |                                                  | encoded per `Orchard-ZSA Asset Burn Description`_.                        |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``64``                              |``bindingSigOrchard``     |``byte[64]``                                      |An Orchard-ZSA binding signature on the SIGHASH transaction hash.          |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+| **Orchard-ZSA Issuance Fields**                                                                                                                                                              |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``varies``                          |``nIssueActions``         |``compactSize``                                   |The number of issuance actions in the bundle.                              |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``IssueActionSize * nIssueActions`` |``vIssueActions``         |``IssueAction[nIssueActions]``                    |A sequence of issuance action descriptions, where IssueActionSize is       |
+|                                    |                          |                                                  |the size, in bytes, of an IssueAction description.                         |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``32``                              |``ik``                    |``byte[32]``                                      |The issuance validating key of the issuer, used to validate the signature. |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
+|``64``                              |``issueAuthSig``          |``byte[64]``                                      |The signature of the transaction SIGHASH, signed by the issuer,            |
+|                                    |                          |                                                  |validated as in Issuance Authorization Signature Scheme [#zip-0227]_.      |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
 
 
 * The fields ``valueBalanceSapling`` and ``bindingSigSapling`` are present if and only if
@@ -231,15 +215,9 @@ Transaction Format
   ``vOutputsSapling`` and MUST be ordered such that the proof at a given index corresponds
   to the ``OutputDescriptionV6`` at the same index.
 
-* The fields ``flagsOrchard``, ``valueBalanceOrchard``, ``anchorOrchard``,
-  ``sizeProofsOrchardZSA``, ``proofsOrchardZSA``, and ``bindingSigOrchard`` are present if and
-  only if :math:`\mathtt{nActionsOrchard} > 0\!`. If ``valueBalanceOrchard`` is not present,
+* The fields ``valueBalanceOrchard`` and ``bindingSigOrchard`` are present if and
+  only if :math:`\mathtt{nActionGroupsOrchard} > 0\!`. If ``valueBalanceOrchard`` is not present,
   then :math:`\mathsf{v^{balanceOrchard}}` is defined to be :math:`0\!`.
-
-* The proofs aggregated in ``proofsOrchardZSA``, and the elements of
-  ``vSpendAuthSigsOrchard``, each have a 1:1 correspondence to the elements of
-  ``vActionsOrchard`` and MUST be ordered such that the proof or signature at a given
-  index corresponds to the ``OrchardZsaAction`` at the same index.
 
 * The fields ``ik`` and ``issueAuthSig`` are present if and only if :math:`\mathtt{nIssueActions} > 0\!`.
 
@@ -247,10 +225,11 @@ Transaction Format
 
 The encodings of ``tx_in``, and ``tx_out`` are as in a version 4 transaction (i.e.
 unchanged from Canopy). The encodings of ``SpendDescriptionV6``, ``OutputDescriptionV6``
-, ``OrchardZsaAction``, ``AssetBurn`` and ``IssueAction`` are described below. The encoding of Sapling Spends and Outputs has
-changed relative to prior versions in order to better separate data that describe the
-effects of the transaction from the proofs of and commitments to those effects, and for
-symmetry with this separation in the Orchard-related parts of the transaction format.
+, ``ActionGroupDescription``, ``AssetBurn`` and ``IssueAction`` are described below. 
+The encoding of Sapling Spends and Outputs has changed relative to prior versions in order 
+to better separate data that describe the effects of the transaction from the proofs of and 
+commitments to those effects, and for symmetry with this separation in the Orchard-related parts 
+of the transaction format.
 
 Sapling Spend Description (``SpendDescriptionV6``)
 --------------------------------------------------
@@ -292,6 +271,43 @@ Sapling Output Description (``OutputDescriptionV6``)
 The encodings of each of these elements are defined in §7.4 ‘Output Description Encoding
 and Consensus’ of the Zcash Protocol Specification [#protocol-outputdesc]_.
 
+OrchardZSA Action Group Description 
+-----------------------------------
+
+The OrchardZSA Action Group Description is encoded in a transaction as an instance of an ``ActionGroupDescription`` type:
+
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+| Bytes                              | Name                     | Data Type                                        | Description                                                         |
++====================================+==========================+==================================================+=====================================================================+
+|``varies``                          |``nActionsOrchard``       |``compactSize``                                   |The number of Action descriptions in ``vActionsOrchard``.            |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``852 * nActionsOrchard``           |``vActionsOrchard``       |``OrchardZsaAction[nActionsOrchard]``             |A sequence of ZSA Swap Action descriptions in the Action Group.      |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``1``                               |``flagsOrchard``          |``byte``                                          |As defined in Section 7.1 of the Protocol                            |  
+|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``32``                              |``anchorOrchard``         |``byte[32]``                                      |As defined in Section 7.1 of the Protocol                            |  
+|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``varies``                          |``sizeProofsOrchard``     |``compactSize``                                   |As defined in Section 7.1 of the Protocol                            |  
+|                                    |                          |                                                  |Specification [#protocol-txnencoding]_.                              |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``sizeProofsOrchard``               |``proofsOrchard``         |``byte[sizeProofsOrchard]``                       |The aggregated zk-SNARK proof for all Actions in the Action Group.   |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``4``                               |``timeLimit``             |``uint32``                                        |This is set to be a value of ``0``.                                  |  
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+|``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64][nActionsOrchard]``                     |Authorizing signatures for the inclusion of each Action of the       |  
+|                                    |                          |                                                  |Action Group in a transaction.                                       |
++------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
+
+The encoding of ``OrchardZsaAction`` is described below.
+
+* The proofs aggregated in ``proofsOrchardZSA``, and the elements of
+  ``vSpendAuthSigsOrchard``, each have a 1:1 correspondence to the elements of
+  ``vActionsOrchard`` and MUST be ordered such that the proof or signature at a given
+  index corresponds to the ``OrchardZsaAction`` at the same index.
+
+
 Orchard-ZSA Action Description (``OrchardZsaAction``)
 -----------------------------------------------------
 
@@ -309,7 +325,7 @@ Orchard-ZSA Action Description (``OrchardZsaAction``)
 |``32``                       |``cmx``                   |``byte[32]``                          |The :math:`x\!`-coordinate of the note commitment for the   |
 |                             |                          |                                      |output note.                                                |
 +-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
-|``32``                       |``ephemeralKey``          |``byte[32]``                          |An encoding of an ephemeral Pallas public key               |
+|``32``                       |``ephemeralKey``          |``byte[32]``                          |An encoding of an ephemeral Pallas public key.              |
 +-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+
 |``612``                      |``encCiphertext``         |``byte[580]``                         |The encrypted contents of the note plaintext.               |
 +-----------------------------+--------------------------+--------------------------------------+------------------------------------------------------------+

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -298,8 +298,8 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 |                                    |                          |                                                  |Action Group become invalid and should be rejected by consensus.     |
 |                                    |                          |                                                  |This is set to be a value of ``0``.                                  |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64][nActionsOrchard]``                     |Authorizing signatures for the inclusion of each Action of the       |  
-|                                    |                          |                                                  |Action Group in a transaction.                                       |
+|``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64 * nActionsOrchard]``                    |Authorizing signatures for each Action of the Action Group in a      |  
+|                                    |                          |                                                  |transaction.                                                         |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 
 The encoding of ``OrchardZsaAction`` is described below.
@@ -309,6 +309,12 @@ The encoding of ``OrchardZsaAction`` is described below.
   ``vActionsOrchard`` and MUST be ordered such that the proof or signature at a given
   index corresponds to the ``OrchardZsaAction`` at the same index.
 
+Rationale for timeLimit
+```````````````````````
+
+We introduce the ``timeLimit`` field in this transaction format in order to be forward compatible with Swaps over ZSAs [#zip-0228]_.
+For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of ``timeLimit`` to be ``0`` by consensus.
+This serves as a default value to represent the situation where there is no specified time limit.
 
 Orchard-ZSA Action Description (``OrchardZsaAction``)
 -----------------------------------------------------

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -295,7 +295,7 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``sizeProofsOrchard``               |``proofsOrchard``         |``byte[sizeProofsOrchard]``                       |The aggregated zk-SNARK proof for all Actions in the Action Group.   |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
-|``4``                               |``timeLimit``             |``uint32``                                        |The block number (in the future) after which the Actions of the      |
+|``4``                               |``nAGExpiryHeight``       |``uint32``                                        |A block height (in the future) after which the Actions of the        |
 |                                    |                          |                                                  |Action Group become invalid and should be rejected by consensus.     |
 |                                    |                          |                                                  |This MUST have a value of ``0``.                                     |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
@@ -310,12 +310,12 @@ The encoding of ``OrchardZsaAction`` is described below.
   ``vActionsOrchard`` and MUST be ordered such that the proof or signature at a given
   index corresponds to the ``OrchardZsaAction`` at the same index.
 
-Rationale for timeLimit
-```````````````````````
+Rationale for nAGExpiryHeight
+`````````````````````````````
 
-We introduce the ``timeLimit`` field in this transaction format in order to be forward compatible with Swaps over ZSAs [#zip-0228]_.
-For the OrchardZSA protocol, which does not make use of a time limit for transactions, we set the value of ``timeLimit`` to be ``0`` by consensus.
-This serves as a default value to represent the situation where there is no specified time limit.
+We introduce the ``nAGExpiryHeight`` field in this transaction format in order to be forward compatible with Swaps over ZSAs [#zip-0228]_.
+For the OrchardZSA protocol, which does not make use of an additional expiry height for transactions, we set the value of ``nAGExpiryHeight`` to be ``0`` by consensus.
+This serves as a default value to represent the situation where there is no expiry, analogous to the convention adopted for ``nExpiryHeight`` in ZIP 203 [#zip-0203].
 
 Orchard-ZSA Action Description (``OrchardZsaAction``)
 -----------------------------------------------------
@@ -497,6 +497,7 @@ References
 .. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_
 .. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.6: Action Descriptions <protocol/protocol.pdf#actiondesc>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2022.3.8. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
+.. [#zip-0203] `ZIP 203: Transaction Expiry <zip-0203.html>`_
 .. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zip-0226.html>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.html>`_
 .. [#zip-0228] `ZIP 228: Asset Swaps for Zcash Shielded Assets <zip-0228.html>`_

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -297,7 +297,7 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``4``                               |``timeLimit``             |``uint32``                                        |The block number (in the future) after which the Actions of the      |
 |                                    |                          |                                                  |Action Group become invalid and should be rejected by consensus.     |
-|                                    |                          |                                                  |This MUST have a value of ``0``.                                  |  
+|                                    |                          |                                                  |This MUST have a value of ``0``.                                     |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64 * nActionsOrchard]``                    |Authorizing signatures for each Action of the Action Group in a      |  
 |                                    |                          |                                                  |transaction.                                                         |
@@ -497,8 +497,9 @@ References
 .. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_
 .. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.6: Action Descriptions <protocol/protocol.pdf#actiondesc>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2022.3.8. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
-.. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <https://qed-it.github.io/zips/zip-0226>`_
-.. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <https://qed-it.github.io/zips/zip-0227>`_
-.. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.rst>`_
-.. [#zip-0317] `ZIP 317: Proportional Transfer Fee Mechanism <zip-0317.rst>`_
-.. [#zip-0317-fee-calc] `ZIP 317: Proportional Transfer Fee Mechanism, Fee calculation <zip-0317.rst#fee-calculation>`_
+.. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zip-0226.html>`_
+.. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.html>`_
+.. [#zip-0228] `ZIP 228: Asset Swaps for Zcash Shielded Assets <zip-0228.html>`_
+.. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
+.. [#zip-0317] `ZIP 317: Proportional Transfer Fee Mechanism <zip-0317.html>`_
+.. [#zip-0317-fee-calc] `ZIP 317: Proportional Transfer Fee Mechanism, Fee calculation <zip-0317.html#fee-calculation>`_

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -172,7 +172,7 @@ Transaction Format
 | **Orchard-ZSA Transaction Fields**                                                                                                                                                           |
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
 |``varies``                          |``nActionGroupsOrchard``  |``compactSize``                                   |The number of Action Group descriptions in ``vActionGroupsOrchard``.       |  
-|                                    |                          |                                                  |This has a value of either ``0`` or ``1``.                                 |  
+|                                    |                          |                                                  |This MUST have a value of either ``0`` or ``1``.                           |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------------+
 |``varies``                          |``vActionGroupsOrchard``  |``ActionGroupDescription[nActionGroupsOrchard]``  |A sequence of Action Group descriptions, encoded as per the                |  
 |                                    |                          |                                                  |`OrchardZSA Action Group Description`_.                                    |  
@@ -280,6 +280,7 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 | Bytes                              | Name                     | Data Type                                        | Description                                                         |
 +====================================+==========================+==================================================+=====================================================================+
 |``varies``                          |``nActionsOrchard``       |``compactSize``                                   |The number of Action descriptions in ``vActionsOrchard``.            |  
+|                                    |                          |                                                  |This MUST have a value strictly greater than ``0``.                  |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``852 * nActionsOrchard``           |``vActionsOrchard``       |``OrchardZsaAction[nActionsOrchard]``             |A sequence of ZSA Swap Action descriptions in the Action Group.      |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
@@ -296,7 +297,7 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``4``                               |``timeLimit``             |``uint32``                                        |The block number (in the future) after which the Actions of the      |
 |                                    |                          |                                                  |Action Group become invalid and should be rejected by consensus.     |
-|                                    |                          |                                                  |This is set to be a value of ``0``.                                  |  
+|                                    |                          |                                                  |This MUST have a value of ``0``.                                  |  
 +------------------------------------+--------------------------+--------------------------------------------------+---------------------------------------------------------------------+
 |``64 * nActionsOrchard``            |``vSpendAuthSigsOrchard`` |``byte[64 * nActionsOrchard]``                    |Authorizing signatures for each Action of the Action Group in a      |  
 |                                    |                          |                                                  |transaction.                                                         |


### PR DESCRIPTION
This PR changes the encoding of the transaction format to add Action Groups to TxV6.
The motivation is to avoid the need of a further transaction format upgrade while introducing Asset Swaps for ZSAs in a subsequent upgrade.