### PR TITLE
Removal of redundant encoding definitions in ZIP 227

### DIFF
--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -73,7 +73,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </ul>
         </section>
         <section id="specification-issuance-keys-and-issuance-authorization-signature-scheme"><h2><span class="section-heading">Specification: Issuance Keys and Issuance Authorization Signature Scheme</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issuance-keys-and-issuance-authorization-signature-scheme"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The Orchard-ZSA Protocol adds the following keys to the key components <a id="footnote-reference-8" class="footnote_reference" href="#protocol-addressesandkeys">19</a> <a id="footnote-reference-9" class="footnote_reference" href="#protocol-orchardkeycomponents">20</a>:</p>
+            <p>The Orchard-ZSA Protocol adds the following keys to the key components <a id="footnote-reference-8" class="footnote_reference" href="#protocol-addressesandkeys">21</a> <a id="footnote-reference-9" class="footnote_reference" href="#protocol-orchardkeycomponents">22</a>:</p>
             <ol type="1">
                 <li>The issuance authorizing key, denoted as
                     <span class="math">\(\mathsf{isk}\!\)</span>
@@ -90,7 +90,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <section id="issuance-authorization-signature-scheme"><h3><span class="section-heading">Issuance Authorization Signature Scheme</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-authorization-signature-scheme"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>We instantiate the issuance authorization signature scheme
                     <span class="math">\(\mathsf{IssueAuthSig}\)</span>
-                 as a BIP-340 Schnorr signature over the secp256k1 curve. The signing and validation algorithms, signature encoding, and public key encoding MUST follow BIP 340 <a id="footnote-reference-10" class="footnote_reference" href="#bip-0340">17</a>.</p>
+                 as a BIP-340 Schnorr signature over the secp256k1 curve. The signing and validation algorithms, signature encoding, and public key encoding MUST follow BIP 340 <a id="footnote-reference-10" class="footnote_reference" href="#bip-0340">19</a>.</p>
                 <p>Batch verification MAY be used. Precomputation MAY be used if and only if it produces equivalent results; for example, for a given verification key
                     <span class="math">\(pk\)</span>
                  and
@@ -120,7 +120,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(k\)</span>
                  bytes, and
                     <span class="math">\(\mathbb{B}^{\mathbb{Y}^{[\mathbb{N}]}}\)</span>
-                 denotes the type of byte sequences of arbitrary length, as defined in the Zcash protocol specification <a id="footnote-reference-11" class="footnote_reference" href="#protocol-notation">18</a>.</p>
+                 denotes the type of byte sequences of arbitrary length, as defined in the Zcash protocol specification <a id="footnote-reference-11" class="footnote_reference" href="#protocol-notation">20</a>.</p>
                 <p>The issuance authorizing key generation algorithm and the issuance validating key derivation algorithm are defined in the <a href="#issuance-key-derivation">Issuance Key Derivation</a> section, while the corresponding signing and validation algorithms are defined in the <a href="#issuance-authorization-signing-and-validation">Issuance Authorization Signing and Validation</a> section.</p>
             </section>
             <section id="issuance-key-derivation"><h3><span class="section-heading">Issuance Key Derivation</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-key-derivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -200,7 +200,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                     <p>where the
                         <span class="math">\(\textit{PubKey}\)</span>
-                     algorithm is defined in BIP 340 <a id="footnote-reference-16" class="footnote_reference" href="#bip-0340">17</a>. Note that the byte representation of
+                     algorithm is defined in BIP 340 <a id="footnote-reference-16" class="footnote_reference" href="#bip-0340">19</a>. Note that the byte representation of
                         <span class="math">\(\mathsf{ik}\)</span>
                      is in big-endian order as defined in BIP 340.</p>
                     <p>It is possible for the
@@ -238,7 +238,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{Sign}\)</span>
                  algorithm is defined in BIP 340 and
                     <span class="math">\(a\)</span>
-                 denotes the auxiliary data used in BIP 340 <a id="footnote-reference-18" class="footnote_reference" href="#bip-0340">17</a>. Note that
+                 denotes the auxiliary data used in BIP 340 <a id="footnote-reference-18" class="footnote_reference" href="#bip-0340">19</a>. Note that
                     <span class="math">\(\mathsf{IssueAuthSig}.\!\mathsf{Sign}\)</span>
                  could return
                     <span class="math">\(\bot\)</span>
@@ -262,7 +262,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </ul>
                 <p>where the
                     <span class="math">\(\mathsf{Verify}\)</span>
-                 algorithm is defined in BIP 340 <a id="footnote-reference-19" class="footnote_reference" href="#bip-0340">17</a>.</p>
+                 algorithm is defined in BIP 340 <a id="footnote-reference-19" class="footnote_reference" href="#bip-0340">19</a>.</p>
             </section>
         </section>
         <section id="specification-asset-identifier"><h2><span class="section-heading">Specification: Asset Identifier</span><span class="section-anchor"> <a rel="bookmark" href="#specification-asset-identifier"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -307,7 +307,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <span class="math">\(\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})\)</span>
              where
                 <span class="math">\(\mathsf{GroupHash}^\mathbb{P}\)</span>
-             is defined as in <a id="footnote-reference-20" class="footnote_reference" href="#protocol-concretegrouphashpallasandvesta">21</a>.</p>
+             is defined as in <a id="footnote-reference-20" class="footnote_reference" href="#protocol-concretegrouphashpallasandvesta">23</a>.</p>
             <p>The relations between the Asset Identifier, Asset Digest, and Asset Base are shown in the following diagram:</p>
             <figure class="align-center" align="center">
                 <img width="600" src="assets/images/zip-0227-asset-identifier-relation.png" alt="" />
@@ -373,7 +373,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(0\)</span>
                      and
                         <span class="math">\(512\!\)</span>
-                    , stored in two bytes.</li>
+                    .</li>
                     <li><code>asset_desc</code>: the Asset description, a byte string of up to 512 bytes as defined in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
                     <li><code>vNotes</code>: an array of <code>Note</code> containing the unencrypted output notes of the recipients of the Asset.</li>
                     <li><code>flagsIssuance</code>: a byte that stores the
@@ -383,66 +383,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <p>The
                     <span class="math">\(\mathsf{finalize}\)</span>
                  boolean is set by the Issuer to signal that there will be no further issuance of the specific Custom Asset. As we will see in <a href="#specification-consensus-rule-changes">Specification: Consensus Rule Changes</a>, transactions that attempt to issue further amounts of a Custom Asset that has previously been finalized will be rejected.</p>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Bytes</th>
-                            <th>Name</th>
-                            <th>Data Type</th>
-                            <th>Description</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><code>2</code></td>
-                            <td><code>assetDescSize</code></td>
-                            <td><code>byte</code></td>
-                            <td>The length of the <code>asset_desc</code> string in bytes.</td>
-                        </tr>
-                        <tr>
-                            <td><code>assetDescSize</code></td>
-                            <td><code>asset_desc</code></td>
-                            <td><code>byte[assetDescSize]</code></td>
-                            <td>A byte sequence of length <code>assetDescSize</code> bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.</td>
-                        </tr>
-                        <tr>
-                            <td><code>varies</code></td>
-                            <td><code>nNotes</code></td>
-                            <td><code>compactSize</code></td>
-                            <td>The number of notes in the issuance action.</td>
-                        </tr>
-                        <tr>
-                            <td><code>noteSize * nNotes</code></td>
-                            <td><code>vNotes</code></td>
-                            <td><code>Note[nNotes]</code></td>
-                            <td>A sequence of note descriptions within the issuance action, where <code>noteSize</code> is the size, in bytes, of a Note.</td>
-                        </tr>
-                        <tr>
-                            <td><code>1</code></td>
-                            <td><code>flagsIssuance</code></td>
-                            <td><code>byte</code></td>
-                            <td>
-                                <dl>
-                                    <dt>An 8-bit value representing a set of flags. Ordered from LSB to MSB:</dt>
-                                    <dd>
-                                        <ul>
-                                            <li>
-                                                <span class="math">\(\mathsf{finalize}\)</span>
-                                            </li>
-                                            <li>The remaining bits are set to
-                                                <span class="math">\(0\!\)</span>
-                                            .</li>
-                                        </ul>
-                                    </dd>
-                                </dl>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0230-issuance-action-description">13</a>.</p>
                 <p>We note that the output note commitment of the recipient's notes are not included in the actual transaction, but when added to the global state of the chain, they will be added to the note commitment tree as a shielded note. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
             </section>
             <section id="issuance-bundle"><h3><span class="section-heading">Issuance Bundle</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-bundle"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>An issuance bundle, <code>IssueBundle</code>, is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:</p>
+                <p>An issuance bundle is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:</p>
                 <ul>
                     <li>
                         <span class="math">\(\mathsf{ik}\)</span>
@@ -456,43 +401,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{isk}\!\)</span>
                     , that validates the issuance.</li>
                 </ul>
-                <p>The issuance bundle is then added within the transaction format as a new bundle. That is, issuance requires the addition of the following information to the transaction format <a id="footnote-reference-22" class="footnote_reference" href="#protocol-txnencoding">23</a>.</p>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Bytes</th>
-                            <th>Name</th>
-                            <th>Data Type</th>
-                            <th>Description</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><code>varies</code></td>
-                            <td><code>nIssueActions</code></td>
-                            <td><code>compactSize</code></td>
-                            <td>The number of issuance actions in the bundle.</td>
-                        </tr>
-                        <tr>
-                            <td><code>IssueActionSize * nIssueActions</code></td>
-                            <td><code>vIssueActions</code></td>
-                            <td><code>IssueAction[nIssueActions]</code></td>
-                            <td>A sequence of issuance action descriptions, where IssueActionSize is the size, in bytes, of an IssueAction description.</td>
-                        </tr>
-                        <tr>
-                            <td><code>32</code></td>
-                            <td><code>ik</code></td>
-                            <td><code>byte[32]</code></td>
-                            <td>The issuance validating key of the issuer, used to validate the signature.</td>
-                        </tr>
-                        <tr>
-                            <td><code>64</code></td>
-                            <td><code>issueAuthSig</code></td>
-                            <td><code>byte[64]</code></td>
-                            <td>The signature of the transaction SIGHASH, signed by the issuer, validated as in <a href="#issuance-authorization-signature-scheme">Issuance Authorization Signature Scheme</a>.</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <p>The issuance bundle is added within the transaction format as a new bundle. The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0230-transaction-format">14</a>.</p>
             </section>
             <section id="issuance-protocol"><h3><span class="section-heading">Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The issuer program performs the following operations:</p>
@@ -593,7 +502,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <ul>
                         <li>compute the note commitment as
                             <span class="math">\(\mathsf{cm} = \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\)</span>
-                         as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-23" class="footnote_reference" href="#zip-0226-notestructure">11</a>.</li>
+                         as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0226-notestructure">11</a>.</li>
                         <li>Add
                             <span class="math">\(\mathsf{cm}\)</span>
                          to the Merkle tree of note commitments.</li>
@@ -639,7 +548,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <ul>
                     <li>By using the
                         <span class="math">\(\mathsf{finalize}\)</span>
-                     boolean and the burning mechanism defined in <a id="footnote-reference-24" class="footnote_reference" href="#zip-0226">10</a>, issuers can control the supply production of any Asset associated to their issuer keys. For example,
+                     boolean and the burning mechanism defined in <a id="footnote-reference-25" class="footnote_reference" href="#zip-0226">10</a>, issuers can control the supply production of any Asset associated to their issuer keys. For example,
                         <ul>
                             <li>by setting
                                 <span class="math">\(\mathsf{finalize} = 1\)</span>
@@ -672,7 +581,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="txid-digest-issuance"><h2><span class="section-heading">TxId Digest - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the Orchard-ZSA protocol can be found in ZIP 226 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0226-txiddigest">12</a>. As in ZIP 244 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0244">13</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
+            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the Orchard-ZSA protocol can be found in ZIP 226 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0226-txiddigest">12</a>. As in ZIP 244 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0244">15</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
             <p>A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below:</p>
             <pre>issuance_digest
 ├── issue_actions_digest
@@ -708,7 +617,7 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
                         <p>In case the transaction has no Issue Notes, ''issue_notes_digest'' is:</p>
                         <pre>BLAKE2b-256("ZTxIdIAcNoteHash", [])</pre>
                         <section id="t-5a-i-1-recipient"><h6><span class="section-heading">T.5a.i.1: recipient</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-1-recipient"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-27" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">22</a>.</p>
+                            <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-28" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">24</a>.</p>
                         </section>
                         <section id="t-5a-i-2-value"><h6><span class="section-heading">T.5a.i.2: value</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-2-value"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>Note value encoded as little-endian 8-byte representation of 64-bit unsigned integer (e.g. u64 in Rust) raw value.</p>
@@ -742,7 +651,7 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-28" class="footnote_reference" href="#zip-0244-sigdigest">14</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
+            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0244-sigdigest">16</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
             <p>The overall structure of the hash is as follows. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
             <pre>signature_digest
 ├── header_digest
@@ -757,14 +666,14 @@ S.2: transparent_sig_digest (32-byte hash output)
 S.3: sapling_digest         (32-byte hash output)
 S.4: orchard_digest         (32-byte hash output)
 S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0244">13</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0244">15</a>.</p>
                 <section id="s-5-issuance-digest"><h4><span class="section-heading">S.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>Identical to that specified for the transaction identifier.</p>
                 </section>
             </section>
         </section>
         <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0244-authcommitment">15</a> which commits to the authorizing data of a transaction is modified by the Orchard-ZSA protocol to have the following structure. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0244-authcommitment">17</a> which commits to the authorizing data of a transaction is modified by the Orchard-ZSA protocol to have the following structure. We highlight the changes for the Orchard-ZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the Orchard-ZSA protocol:</p>
             <pre>auth_digest
 ├── transparent_scripts_digest
 ├── sapling_auth_digest
@@ -805,7 +714,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 </ul>
             </section>
             <section id="bridging-assets"><h3><span class="section-heading">Bridging Assets</span><span class="section-anchor"> <a rel="bookmark" href="#bridging-assets"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0226">10</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
+                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-32" class="footnote_reference" href="#zip-0226">10</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
             </section>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -819,7 +728,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                  in order to properly keep track of the total supply for different Asset Identifiers. This is useful for wallets and other applications that need to keep track of the total supply of Assets.</p>
             </section>
             <section id="fee-structures"><h3><span class="section-heading">Fee Structures</span><span class="section-anchor"> <a rel="bookmark" href="#fee-structures"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317 <a id="footnote-reference-32" class="footnote_reference" href="#zip-0317b">16</a>.</p>
+                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317 <a id="footnote-reference-33" class="footnote_reference" href="#zip-0317b">18</a>.</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -933,10 +842,26 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0244" class="footnote">
+            <table id="zip-0230-issuance-action-description" class="footnote">
                 <tbody>
                     <tr>
                         <th>13</th>
+                        <td><a href="zip-0230.html#issuance-action-description-issueaction">ZIP 230: Version 6 Transaction Format: Issuance Action Description (IssueAction)</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0230-transaction-format" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>14</th>
+                        <td><a href="zip-0230.html#transaction-format">ZIP 230: Version 6 Transaction Format: Transaction Format</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0244" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>15</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -944,7 +869,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244-sigdigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>14</th>
+                        <th>16</th>
                         <td><a href="zip-0244.html#signature-digest">ZIP 244: Transaction Identifier Non-Malleability: Signature Digest</a></td>
                     </tr>
                 </tbody>
@@ -952,7 +877,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244-authcommitment" class="footnote">
                 <tbody>
                     <tr>
-                        <th>15</th>
+                        <th>17</th>
                         <td><a href="zip-0244.html#authorizing-data-commitment">ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
@@ -960,7 +885,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0317b" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>18</th>
                         <td><a href="https://github.com/zcash/zips/pull/667">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
                     </tr>
                 </tbody>
@@ -968,7 +893,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="bip-0340" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
+                        <th>19</th>
                         <td><a href="https://github.com/bitcoin/bips/blob/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb/bip-0340.mediawiki">BIP 340: Schnorr Signatures for secp256k1</a></td>
                     </tr>
                 </tbody>
@@ -976,7 +901,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-notation" class="footnote">
                 <tbody>
                     <tr>
-                        <th>18</th>
+                        <th>20</th>
                         <td><a href="protocol/protocol.pdf#notation">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 2: Notation</a></td>
                     </tr>
                 </tbody>
@@ -984,7 +909,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-addressesandkeys" class="footnote">
                 <tbody>
                     <tr>
-                        <th>19</th>
+                        <th>21</th>
                         <td><a href="protocol/protocol.pdf#addressesandkeys">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.1: Payment Addresses and Keys</a></td>
                     </tr>
                 </tbody>
@@ -992,7 +917,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-orchardkeycomponents" class="footnote">
                 <tbody>
                     <tr>
-                        <th>20</th>
+                        <th>22</th>
                         <td><a href="protocol/protocol.pdf#orchardkeycomponents">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.2.3: Orchard Key Components</a></td>
                     </tr>
                 </tbody>
@@ -1000,7 +925,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-concretegrouphashpallasandvesta" class="footnote">
                 <tbody>
                     <tr>
-                        <th>21</th>
+                        <th>23</th>
                         <td><a href="protocol/protocol.pdf#concretegrouphashpallasandvesta">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.8: Group Hash into Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
@@ -1008,7 +933,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-orchardpaymentaddrencoding" class="footnote">
                 <tbody>
                     <tr>
-                        <th>22</th>
+                        <th>24</th>
                         <td><a href="protocol/protocol.pdf#orchardpaymentaddrencoding">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.6.4.2: Orchard Raw Payment Addresses</a></td>
                     </tr>
                 </tbody>
@@ -1016,7 +941,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-txnencoding" class="footnote">
                 <tbody>
                     <tr>
-                        <th>23</th>
+                        <th>25</th>
                         <td><a href="protocol/protocol.pdf#txnencoding">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.1: Transaction Encoding and Consensus</a></td>
                     </tr>
                 </tbody>

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -255,7 +255,7 @@ Issuance Action Description
 
 An issuance action, ``IssueAction``, is the instance of issuing a specific Custom Asset, and contains the following fields:
 
-- ``assetDescSize``: the size of the Asset description, a number between :math:`0` and :math:`512\!`, stored in two bytes.
+- ``assetDescSize``: the size of the Asset description, a number between :math:`0` and :math:`512\!`.
 - ``asset_desc``: the Asset description, a byte string of up to 512 bytes as defined in the `Specification: Asset Identifier`_ section.
 - ``vNotes``: an array of ``Note`` containing the unencrypted output notes of the recipients of the Asset.
 - ``flagsIssuance``: a byte that stores the :math:`\mathsf{finalize}` boolean that defines whether the issuance of that specific Custom Asset is finalized or not.
@@ -263,24 +263,7 @@ An issuance action, ``IssueAction``, is the instance of issuing a specific Custo
 The :math:`\mathsf{finalize}` boolean is set by the Issuer to signal that there will be no further issuance of the specific Custom Asset.
 As we will see in `Specification: Consensus Rule Changes`_, transactions that attempt to issue further amounts of a Custom Asset that has previously been finalized will be rejected.
 
-+-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
-| Bytes                       | Name                     | Data Type                                 | Description                                                         |
-+=============================+==========================+===========================================+=====================================================================+
-|``2``                        |``assetDescSize``         |``byte``                                   |The length of the ``asset_desc`` string in bytes.                    |
-+-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
-|``assetDescSize``            |``asset_desc``            |``byte[assetDescSize]``                    |A byte sequence of length ``assetDescSize`` bytes which SHOULD be a  |
-|                             |                          |                                           |well-formed UTF-8 code unit sequence according to Unicode 15.0.0     |
-|                             |                          |                                           |or later.                                                            |
-+-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
-|``varies``                   |``nNotes``                |``compactSize``                            |The number of notes in the issuance action.                          |
-+-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
-|``noteSize * nNotes``        |``vNotes``                |``Note[nNotes]``                           |A sequence of note descriptions within the issuance action,          |
-|                             |                          |                                           |where ``noteSize`` is the size, in bytes, of a Note.                 |
-+-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
-|``1``                        |``flagsIssuance``         |``byte``                                   |An 8-bit value representing a set of flags. Ordered from LSB to MSB: |
-|                             |                          |                                           | * :math:`\mathsf{finalize}`                                         |
-|                             |                          |                                           | * The remaining bits are set to :math:`0\!`.                        |
-+-----------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------+
+The complete encoding of these fields into an ``IssueAction`` is defined in ZIP 230 [#zip-0230-issuance-action-description]_.
 
 We note that the output note commitment of the recipient's notes are not included in the actual transaction, but when added to the global state of the chain, they will be added to the note commitment tree as a shielded note.
 This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.
@@ -288,7 +271,7 @@ This prevents future usage of the note from being linked to the issuance transac
 Issuance Bundle
 ---------------
 
-An issuance bundle, ``IssueBundle``, is the aggregate of all the issuance-related information.
+An issuance bundle is the aggregate of all the issuance-related information.
 Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself.
 It contains the following fields:
 
@@ -296,21 +279,8 @@ It contains the following fields:
 - ``vIssueActions``: an array of issuance actions, of type ``IssueAction``.
 - :math:`\mathsf{issueAuthSig}`: the signature of the transaction SIGHASH, signed by the issuance authorizing key, :math:`\mathsf{isk}\!`, that validates the issuance.
 
-The issuance bundle is then added within the transaction format as a new bundle. That is, issuance requires the addition of the following information to the transaction format [#protocol-txnencoding]_.
-
-+------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
-| Bytes                              | Name                     | Data Type                                 | Description                                                               |
-+====================================+==========================+===========================================+===========================================================================+
-|``varies``                          |``nIssueActions``         |``compactSize``                            |The number of issuance actions in the bundle.                              |
-+------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
-|``IssueActionSize * nIssueActions`` |``vIssueActions``         |``IssueAction[nIssueActions]``             |A sequence of issuance action descriptions, where IssueActionSize is       |
-|                                    |                          |                                           |the size, in bytes, of an IssueAction description.                         |
-+------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
-|``32``                              |``ik``                    |``byte[32]``                               |The issuance validating key of the issuer, used to validate the signature. |
-+------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
-|``64``                              |``issueAuthSig``          |``byte[64]``                               |The signature of the transaction SIGHASH, signed by the issuer,            |
-|                                    |                          |                                           |validated as in `Issuance Authorization Signature Scheme`_.                |
-+------------------------------------+--------------------------+-------------------------------------------+---------------------------------------------------------------------------+
+The issuance bundle is added within the transaction format as a new bundle. 
+The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 [#zip-0230-transaction-format]_.
 
 Issuance Protocol
 -----------------
@@ -639,6 +609,8 @@ References
 .. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zip-0226.html>`_
 .. [#zip-0226-notestructure] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Note Structure & Commitment <zip-0226.html#note-structure-commitment>`_
 .. [#zip-0226-txiddigest] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - TxId Digest <zip-0226.html#txid-digest>`_
+.. [#zip-0230-issuance-action-description] `ZIP 230: Version 6 Transaction Format: Issuance Action Description (IssueAction) <zip-0230.html#issuance-action-description-issueaction>`_
+.. [#zip-0230-transaction-format] `ZIP 230: Version 6 Transaction Format: Transaction Format <zip-0230.html#transaction-format>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0244-sigdigest] `ZIP 244: Transaction Identifier Non-Malleability: Signature Digest <zip-0244.html#signature-digest>`_
 .. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_


### PR DESCRIPTION
This PR removes the tables with the encoding of the issuance action description and issuance bundle from ZIP 227. This same material has been included in ZIP 230 as part of the V6 transaction format, and thus it is simpler to have it defined in a single place.

ZIP 227 has been updated with references to the relevant sections of ZIP 230 where necessary.

The base branch of this PR should be changed to `zsa1` once #81 is merged.