### PR TITLE
Fixing the specification of the digests due to the introduction of Action Groups

### DIFF
--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -487,7 +487,7 @@ T.4a.vi : nAGExpiryHeight                     (4 bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcActGHash"</pre>
                         <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">15</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">15</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.i.1 : nullifier            (field encoding bytes)
 T.4a.i.2 : cmx                  (field encoding bytes)
 T.4a.i.3 : ephemeralKey         (field encoding bytes)
@@ -496,13 +496,13 @@ T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR
                             <pre>"ZTxIdOrcActCHash"</pre>
                         </section>
                         <section id="t-4a-ii-orchard-actions-memos-digest"><h6><span class="section-heading">T.4a.ii: orchard_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-ii-orchard-actions-memos-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all OrchardZSA Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]</pre>
                             <p>The personalization field of this hash remains identical to ZIP 244:</p>
                             <pre>"ZTxIdOrcActMHash"</pre>
                         </section>
                         <section id="t-4a-iii-orchard-actions-noncompact-digest"><h6><span class="section-heading">T.4a.iii: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iii-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">15</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">15</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.iii.1 : cv                    (field encoding bytes)
 T.4a.iii.2 : rk                    (field encoding bytes)
 T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -48,18 +48,18 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             . This Asset Identifier maps to an Asset Base
                 <span class="math">\(\mathsf{AssetBase}\)</span>
              that is stored in OrchardZSA notes. These terms are formally defined in ZIP 227 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0227">5</a>.</p>
-            <p>The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description <a id="footnote-reference-10" class="footnote_reference" href="#protocol-actions">17</a> <a id="footnote-reference-11" class="footnote_reference" href="#protocol-actionencodingandconsensus">30</a> is preserved across Assets (see the Orchard Binding Signature <a id="footnote-reference-12" class="footnote_reference" href="#protocol-orchardbalance">20</a>), and by extension the balance of an Orchard transaction. That is, the sum of all the
+            <p>The Asset Identifier (via means of the Asset Digest and Asset Base) will be used to enforce that the balance of an Action Description <a id="footnote-reference-10" class="footnote_reference" href="#protocol-actions">18</a> <a id="footnote-reference-11" class="footnote_reference" href="#protocol-actionencodingandconsensus">31</a> is preserved across Assets (see the Orchard Binding Signature <a id="footnote-reference-12" class="footnote_reference" href="#protocol-orchardbalance">21</a>), and by extension the balance of an Orchard transaction. That is, the sum of all the
                 <span class="math">\(\mathsf{value^{net}}\)</span>
              from each Action Description, computed as
                 <span class="math">\(\mathsf{value^{old}} - \mathsf{value^{new}}\!\)</span>
             , must be balanced <strong>only with respect to the same Asset Identifier</strong>. This is especially important since we will allow different Action Descriptions to transfer notes of different Asset Identifiers, where the overall balance is checked without revealing which (or how many distinct) Assets are being transferred.</p>
-            <p>As was initially proposed by Jack Grigg and Daira-Emma Hopwood <a id="footnote-reference-13" class="footnote_reference" href="#initial-zsa-issue">31</a> <a id="footnote-reference-14" class="footnote_reference" href="#generalized-value-commitments">32</a>, we propose to make this happen by changing the value base point,
+            <p>As was initially proposed by Jack Grigg and Daira-Emma Hopwood <a id="footnote-reference-13" class="footnote_reference" href="#initial-zsa-issue">32</a> <a id="footnote-reference-14" class="footnote_reference" href="#generalized-value-commitments">33</a>, we propose to make this happen by changing the value base point,
                 <span class="math">\(\mathcal{V}^{\mathsf{Orchard}}\!\)</span>
             , in the Homomorphic Pedersen Commitment that derives the value commitment,
                 <span class="math">\(\mathsf{cv^{net}}\!\)</span>
             , of the <em>net value</em> in an Orchard Action.</p>
-            <p>Because in a single transaction all value commitments are balanced, there must be as many different value base points as there are Asset Identifiers for a given shielded protocol used in a transaction. We propose to make the Asset Base an auxiliary input to the proof for each Action statement <a id="footnote-reference-15" class="footnote_reference" href="#protocol-actionstatement">22</a>, represented already as a point on the Pallas curve. The circuit then should check that the same Asset Base is used in the old note commitment and the new note commitment <a id="footnote-reference-16" class="footnote_reference" href="#protocol-concretesinsemillacommit">27</a>, <strong>and</strong> as the base point in the value commitment <a id="footnote-reference-17" class="footnote_reference" href="#protocol-concretehomomorphiccommit">26</a>. This ensures (1) that the input and output notes are of the same Asset Base, and (2) that only Actions with the same Asset Base will balance out in the Orchard binding signature.</p>
-            <p>In order to ensure the security of the transfers, and as we will explain below, we are redefining input dummy notes <a id="footnote-reference-18" class="footnote_reference" href="#protocol-orcharddummynotes">19</a> for Custom Assets, as we need to enforce that the
+            <p>Because in a single transaction all value commitments are balanced, there must be as many different value base points as there are Asset Identifiers for a given shielded protocol used in a transaction. We propose to make the Asset Base an auxiliary input to the proof for each Action statement <a id="footnote-reference-15" class="footnote_reference" href="#protocol-actionstatement">23</a>, represented already as a point on the Pallas curve. The circuit then should check that the same Asset Base is used in the old note commitment and the new note commitment <a id="footnote-reference-16" class="footnote_reference" href="#protocol-concretesinsemillacommit">28</a>, <strong>and</strong> as the base point in the value commitment <a id="footnote-reference-17" class="footnote_reference" href="#protocol-concretehomomorphiccommit">27</a>. This ensures (1) that the input and output notes are of the same Asset Base, and (2) that only Actions with the same Asset Base will balance out in the Orchard binding signature.</p>
+            <p>In order to ensure the security of the transfers, and as we will explain below, we are redefining input dummy notes <a id="footnote-reference-18" class="footnote_reference" href="#protocol-orcharddummynotes">20</a> for Custom Assets, as we need to enforce that the
                 <span class="math">\(\mathsf{AssetBase}\)</span>
              of the output note of that Split Action is the output of a valid
                 <span class="math">\(\mathsf{ZSAValueBase}\)</span>
@@ -98,7 +98,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  be the type of a OrchardZSA note, i.e.
                     <span class="math">\(\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}^*\!\)</span>
                 .</p>
-                <p>An OrchardZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">16</a> by additionally including the Asset Base,
+                <p>An OrchardZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">17</a> by additionally including the Asset Base,
                     <span class="math">\(\mathsf{AssetBase}\!\)</span>
                 . So an OrchardZSA note is a tuple
                     <span class="math">\((\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!\)</span>
@@ -106,7 +106,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <ul>
                     <li>
                         <span class="math">\(\mathsf{AssetBase} : \mathbb{P}^*\)</span>
-                     is the unique element of the Pallas group <a id="footnote-reference-23" class="footnote_reference" href="#protocol-pallasandvesta">28</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0227">5</a>, a valid group element that is not the identity and is not
+                     is the unique element of the Pallas group <a id="footnote-reference-23" class="footnote_reference" href="#protocol-pallasandvesta">29</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0227">5</a>, a valid group element that is not the identity and is not
                         <span class="math">\(\bot\!\)</span>
                     . The byte representation of the Asset Base is defined as
                         <span class="math">\(\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})\!\)</span>
@@ -119,11 +119,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <div class="math">\(\mathsf{NoteCommit}^{\mathsf{OrchardZSA}} : \mathsf{NoteCommit}^{\mathsf{Orchard}}.\!\mathsf{Trapdoor} \times \mathbb{B}^{[\ell_{\mathbb{P}}]} \times \mathbb{B}^{[\ell_{\mathbb{P}}]} \times \{0 .. 2^{\ell_{\mathsf{value}}} - 1\} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{P}^* \to \mathsf{NoteCommit}^{\mathsf{Orchard}}.\!\mathsf{Output}\)</div>
                 <p>where
                     <span class="math">\(\mathbb{P}, \ell_{\mathbb{P}}, q_{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-25" class="footnote_reference" href="#protocol-pallasandvesta">28</a>, and where
+                 are as defined for the Pallas curve <a id="footnote-reference-25" class="footnote_reference" href="#protocol-pallasandvesta">29</a>, and where
                     <span class="math">\(\mathsf{NoteCommit^{Orchard}}.\!\mathsf{Trapdoor}\)</span>
                  and
                     <span class="math">\(\mathsf{Orchard}.\!\mathsf{Output}\)</span>
-                 are as defined in the Zcash protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-abstractcommit">18</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-27" class="footnote_reference" href="#protocol-concretesinsemillacommit">27</a> as follows:</p>
+                 are as defined in the Zcash protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-abstractcommit">19</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-27" class="footnote_reference" href="#protocol-concretesinsemillacommit">28</a> as follows:</p>
                 <div class="math">\(\begin{align}
 \mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{g_d}\star, \mathsf{pk_d}\star, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})
 := \begin{cases}
@@ -141,21 +141,21 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{repr}_{\mathbb{P}}\)</span>
                  and
                     <span class="math">\(\mathsf{GroupHash}^{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-28" class="footnote_reference" href="#protocol-pallasandvesta">28</a>,
+                 are as defined for the Pallas curve <a id="footnote-reference-28" class="footnote_reference" href="#protocol-pallasandvesta">29</a>,
                     <span class="math">\(\ell^{\mathsf{Orchard}}_{\mathsf{base}}\)</span>
-                 is as defined in §5.3 <a id="footnote-reference-29" class="footnote_reference" href="#protocol-constants">24</a>, and
+                 is as defined in §5.3 <a id="footnote-reference-29" class="footnote_reference" href="#protocol-constants">25</a>, and
                     <span class="math">\(\mathsf{I2LEBSP}\)</span>
-                 is as defined in §5.1 <a id="footnote-reference-30" class="footnote_reference" href="#protocol-endian">23</a> of the Zcash protocol specification.</p>
-                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-31" class="footnote_reference" href="#protocol-commitmentsandnullifiers">21</a>.</p>
-                <p>The OrchardZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-32" class="footnote_reference" href="#protocol-notept">29</a>. It consists of</p>
+                 is as defined in §5.1 <a id="footnote-reference-30" class="footnote_reference" href="#protocol-endian">24</a> of the Zcash protocol specification.</p>
+                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-31" class="footnote_reference" href="#protocol-commitmentsandnullifiers">22</a>.</p>
+                <p>The OrchardZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-32" class="footnote_reference" href="#protocol-notept">30</a>. It consists of</p>
                 <div class="math">\((\mathsf{leadByte} : \mathbb{B}^{\mathbb{Y}}, \mathsf{d} : \mathbb{B}^{[\ell_{\mathsf{d}}]}, \mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}, \mathsf{rseed} : \mathbb{B}^{\mathbb{Y}[32]}, \mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}, \mathsf{memo} : \mathbb{B}^{\mathbb{Y}[512]})\)</div>
                 <section id="rationale-for-note-commitment"><h4><span class="section-heading">Rationale for Note Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-note-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>In the OrchardZSA protocol, the instance of the note commitment scheme,
                         <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\!\)</span>
                     , differs from the Orchard note commitment
                         <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm}}\)</span>
-                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretesinsemillacommit">27</a> allows us to add the Asset Base as a final recursive step.</p>
-                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-34" class="footnote_reference" href="#protocol-concretesinsemillahash">25</a>. OrchardZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
+                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretesinsemillacommit">28</a> allows us to add the Asset Base as a final recursive step.</p>
+                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-34" class="footnote_reference" href="#protocol-concretesinsemillahash">26</a>. OrchardZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
                     <div class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase}) \in \mathsf{NoteCommit^{Orchard}}.\!\mathsf{Output}\)</div>
                     <p>This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and OrchardZSA notes.</p>
                 </section>
@@ -186,7 +186,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{ValueCommit^{OrchardZSA}_{rcv}}(\mathcal{V}^{\mathsf{Orchard}}, \mathsf{v})\)</span>
                  here.</p>
                 <section id="rationale-for-value-commitment"><h4><span class="section-heading">Rationale for Value Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-value-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-38" class="footnote_reference" href="#protocol-concretehomomorphiccommit">26</a> to perform the value commitment, with fixed base points
+                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-38" class="footnote_reference" href="#protocol-concretehomomorphiccommit">27</a> to perform the value commitment, with fixed base points
                         <span class="math">\(\mathcal{V}^{\mathsf{Orchard}}\)</span>
                      and
                         <span class="math">\(\mathcal{R}^{\mathsf{Orchard}}\)</span>
@@ -233,7 +233,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="value-balance-verification"><h3><span class="section-heading">Value Balance Verification</span><span class="section-anchor"> <a rel="bookmark" href="#value-balance-verification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-40" class="footnote_reference" href="#protocol-orchardbalance">20</a>, with the addition of the burn information.</p>
+                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-40" class="footnote_reference" href="#protocol-orchardbalance">21</a>, with the addition of the burn information.</p>
                 <p>For a total of
                     <span class="math">\(n\)</span>
                  Actions in a transfer, the prover MUST still sign the SIGHASH transaction hash using the binding signature key
@@ -256,7 +256,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      the set of indices of Actions that are related to Custom Assets.</p>
                     <p>The right hand side of the value balance verification equation can be expanded to:</p>
                     <div class="math">\(((\sum_{i \in S_{\mathsf{ZEC}}} \mathsf{cv}^{\mathsf{net}}_i) + (\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j)) - ([\mathsf{v^{balanceOrchard}}]\,\mathcal{V}^{\mathsf{Orchard}} + [0]\,\mathcal{R}^{\mathsf{Orchard}}) - (\sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} + [0]\,\mathcal{R}^{\mathsf{Orchard}})\)</div>
-                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-41" class="footnote_reference" href="#protocol-orchardbalance">20</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
+                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-41" class="footnote_reference" href="#protocol-orchardbalance">21</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
                         <span class="math">\(\mathsf{assetBurn}\)</span>
                      set. As such, for a correctly constructed transaction, we will get
                         <span class="math">\(\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j - \sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} = \sum_{j \in S_{\mathsf{CA}}} [\mathsf{rcv}^{\mathsf{net}}_j]\,\mathcal{R}^{\mathsf{Orchard}}\!\)</span>
@@ -305,11 +305,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathbb{F}_{q_{\mathbb{P}}}\!\)</span>
                 ,
                     <span class="math">\(\mathcal{K}^{\mathsf{Orchard}}\)</span>
-                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-42" class="footnote_reference" href="#protocol-commitmentsandnullifiers">21</a>, and
+                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-42" class="footnote_reference" href="#protocol-commitmentsandnullifiers">22</a>, and
                     <span class="math">\(\mathcal{L}^{\mathsf{Orchard}} := \mathsf{GroupHash^{\mathbb{P}}}(\texttt{"z.cash:Orchard"}, \texttt{"L"})\!\)</span>
                 .</p>
                 <section id="rationale-for-split-notes"><h4><span class="section-heading">Rationale for Split Notes</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-split-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orcharddummynotes">19</a> to the Actions that have not been assigned input notes.</p>
+                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orcharddummynotes">20</a> to the Actions that have not been assigned input notes.</p>
                     <p>The Orchard technique requires modification for the OrchardZSA protocol with multiple Asset Identifiers, as the output note of the split Actions <em>cannot</em> contain <em>just any</em> Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.</p>
                     <p>Therefore, for Custom Assets we enforce that <em>every</em> input note to an OrchardZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the
                         <span class="math">\(\mathsf{split\_flag}\)</span>
@@ -318,8 +318,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="circuit-statement"><h3><span class="section-heading">Circuit Statement</span><span class="section-anchor"> <a rel="bookmark" href="#circuit-statement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Every <em>OrchardZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">22</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
-                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-45" class="footnote_reference" href="#circuit-modifications">33</a>.</p>
+                <p>Every <em>OrchardZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">23</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
+                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-45" class="footnote_reference" href="#circuit-modifications">34</a>.</p>
                 <section id="asset-base-equality"><h4><span class="section-heading">Asset Base Equality</span><span class="section-anchor"> <a rel="bookmark" href="#asset-base-equality"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>The following constraints must be added to ensure that the input and output note are of the same
                         <span class="math">\(\mathsf{AssetBase}\!\)</span>
@@ -328,12 +328,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <li>The Asset Base,
                             <span class="math">\(\mathsf{AssetBase_{AssetId}}\!\)</span>
                         , for the note is witnessed once, as an auxiliary input.</li>
-                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">22</a>,
+                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">23</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
                         .</li>
-                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-47" class="footnote_reference" href="#protocol-actionstatement">22</a>,
+                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-47" class="footnote_reference" href="#protocol-actionstatement">23</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
@@ -450,7 +450,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                 </section>
                 <section id="backwards-compatibility-with-zec-notes"><h4><span class="section-heading">Backwards Compatibility with ZEC Notes</span><span class="section-anchor"> <a rel="bookmark" href="#backwards-compatibility-with-zec-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The input note in the old note commitment integrity check must either include an Asset Base (OrchardZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">18</a>. If the note is an OrchardZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
+                    <p>The input note in the old note commitment integrity check must either include an Asset Base (OrchardZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">19</a>. If the note is an OrchardZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
                 </section>
             </section>
         </section>
@@ -487,7 +487,7 @@ T.4a.vi : nAGExpiryHeight                     (4 bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcActGHash"</pre>
                         <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">15</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">16</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.i.1 : nullifier            (field encoding bytes)
 T.4a.i.2 : cmx                  (field encoding bytes)
 T.4a.i.3 : ephemeralKey         (field encoding bytes)
@@ -502,7 +502,7 @@ T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR
                             <pre>"ZTxIdOrcActMHash"</pre>
                         </section>
                         <section id="t-4a-iii-orchard-actions-noncompact-digest"><h6><span class="section-heading">T.4a.iii: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iii-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">15</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">16</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.iii.1 : cv                    (field encoding bytes)
 T.4a.iii.2 : rk                    (field encoding bytes)
 T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
@@ -536,8 +536,45 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
                 </section>
             </section>
         </section>
-        <section id="signature-digest-and-authorizing-data-commitment"><h2><span class="section-heading">Signature Digest and Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest-and-authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The details of the changes to these algorithms are in ZIP 227 <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-sigdigest">10</a> <a id="footnote-reference-57" class="footnote_reference" href="#zip-0227-authcommitment">11</a>.</p>
+        <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The details of the changes to this algorithm are in ZIP 227 <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-sigdigest">10</a>.</p>
+        </section>
+        <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-57" class="footnote_reference" href="#zip-0244-authcommitment">15</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section. There is a new branch added for issuance information, along with modifications within the <code>orchard_auth_digest</code> to account for the presence of Action Groups.</p>
+            <p>We highlight the changes for the OrchardZSA protocol via the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
+            <pre>auth_digest
+├── transparent_scripts_digest
+├── sapling_auth_digest
+├── orchard_auth_digest         [UPDATED FOR ZSA]
+└── issuance_auth_digest        [ADDED FOR ZSA]</pre>
+            <p>The pair (Transaction Identifier, Auth Commitment) constitutes a commitment to all the data of a serialized transaction that may be included in a block.</p>
+            <section id="auth-digest"><h3><span class="section-heading">auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>A BLAKE2b-256 hash of the following values</p>
+                <pre>A.1: transparent_scripts_digest (32-byte hash output)
+A.2: sapling_auth_digest        (32-byte hash output)
+A.3: orchard_auth_digest        (32-byte hash output)  [UPDATED FOR ZSA]
+A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
+                <p>The personalization field of this hash remains the same as in ZIP 244.</p>
+                <section id="a-3-orchard-auth-digest"><h4><span class="section-heading">A.3: orchard_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-3-orchard-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>In the case that OrchardZSA Action Groups are present, this is a BLAKE2b-256 hash of the following values:</p>
+                    <pre>A.3a: orchard_action_groups_auth_digest  (32-byte hash output)  [ADDED FOR ZSA]
+A.3b: bindingSigOrchard                  (field encoding bytes)</pre>
+                    <p>The personalization field of this hash is the same as in ZIP 244, that is:</p>
+                    <pre>"ZTxAuthOrchaHash"</pre>
+                    <p>In case that the transaction has no OrchardZSA Action Groups, <code>orchard_auth_digest</code> is:</p>
+                    <pre>BLAKE2b-256("ZTxAuthOrchaHash", [])</pre>
+                    <section id="a-3a-orchard-action-groups-auth-digest"><h5><span class="section-heading">A.3a: orchard_action_groups_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-3a-orchard-action-groups-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                        <p>This is a BLAKE2b-256 hash of the <code>proofsOrchard</code> and <code>spendAuthSigsOrchard</code> fields of all OrchardZSA Action Groups belonging to the transaction:</p>
+                        <pre>A.3a.i:  proofsOrchard               (field encoding bytes)
+A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
+                        <p>The personalization field of this hash is set to:</p>
+                        <pre>"ZTxAuthOrcAGHash"</pre>
+                    </section>
+                </section>
+                <section id="a-4-issuance-auth-digest"><h4><span class="section-heading">A.4: issuance_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-4-issuance-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-58" class="footnote_reference" href="#zip-0227-authcommitment">11</a>.</p>
+                </section>
+            </section>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
@@ -550,7 +587,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 230 <a id="footnote-reference-58" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">13</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 230 <a id="footnote-reference-59" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">13</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and OrchardZSA notes. As we specify above, there are three main reasons we can do this:</p>
@@ -665,7 +702,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>11</th>
-                        <td><a href="zip-0227.html#authorizing-data-commitment">ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment</a></td>
+                        <td><a href="zip-0227.html#authorizing-data-commitment-issuance">ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -693,10 +730,18 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0307" class="footnote">
+            <table id="zip-0244-authcommitment" class="footnote">
                 <tbody>
                     <tr>
                         <th>15</th>
+                        <td><a href="zip-0244.html#authorizing-data-commitment">ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0307" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>16</th>
                         <td><a href="zip-0307">ZIP 307: Light Client Protocol for Payment Detection</a></td>
                     </tr>
                 </tbody>
@@ -704,7 +749,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-notes" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>17</th>
                         <td><a href="protocol/protocol.pdf#notes">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.2: Notes</a></td>
                     </tr>
                 </tbody>
@@ -712,7 +757,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-actions" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
+                        <th>18</th>
                         <td><a href="protocol/protocol.pdf#actions">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.7: Action Transfers and their Descriptions</a></td>
                     </tr>
                 </tbody>
@@ -720,7 +765,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-abstractcommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>18</th>
+                        <th>19</th>
                         <td><a href="protocol/protocol.pdf#abstractcommit">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.1.8: Commitment</a></td>
                     </tr>
                 </tbody>
@@ -728,7 +773,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-orcharddummynotes" class="footnote">
                 <tbody>
                     <tr>
-                        <th>19</th>
+                        <th>20</th>
                         <td><a href="protocol/protocol.pdf#orcharddummynotes">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.8.3: Dummy Notes (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -736,7 +781,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-orchardbalance" class="footnote">
                 <tbody>
                     <tr>
-                        <th>20</th>
+                        <th>21</th>
                         <td><a href="protocol/protocol.pdf#orchardbalance">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.14: Balance and Binding Signature (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -744,7 +789,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-commitmentsandnullifiers" class="footnote">
                 <tbody>
                     <tr>
-                        <th>21</th>
+                        <th>22</th>
                         <td><a href="protocol/protocol.pdf#commitmentsandnullifiers">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.16: Computing ρ values and Nullifiers</a></td>
                     </tr>
                 </tbody>
@@ -752,7 +797,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-actionstatement" class="footnote">
                 <tbody>
                     <tr>
-                        <th>22</th>
+                        <th>23</th>
                         <td><a href="protocol/protocol.pdf#actionstatement">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.18.4: Action Statement (Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -760,7 +805,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-endian" class="footnote">
                 <tbody>
                     <tr>
-                        <th>23</th>
+                        <th>24</th>
                         <td><a href="protocol/protocol.pdf#endian">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.1: Integers, Bit Sequences, and Endianness</a></td>
                     </tr>
                 </tbody>
@@ -768,7 +813,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-constants" class="footnote">
                 <tbody>
                     <tr>
-                        <th>24</th>
+                        <th>25</th>
                         <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.3: Constants</a></td>
                     </tr>
                 </tbody>
@@ -776,7 +821,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-concretesinsemillahash" class="footnote">
                 <tbody>
                     <tr>
-                        <th>25</th>
+                        <th>26</th>
                         <td><a href="protocol/protocol.pdf#concretesinsemillahash">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.1.9: Sinsemilla hash function</a></td>
                     </tr>
                 </tbody>
@@ -784,7 +829,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-concretehomomorphiccommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>26</th>
+                        <th>27</th>
                         <td><a href="protocol/protocol.pdf#concretehomomorphiccommit">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)</a></td>
                     </tr>
                 </tbody>
@@ -792,7 +837,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-concretesinsemillacommit" class="footnote">
                 <tbody>
                     <tr>
-                        <th>27</th>
+                        <th>28</th>
                         <td><a href="protocol/protocol.pdf#concretesinsemillacommit">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.8.4: Sinsemilla commitments</a></td>
                     </tr>
                 </tbody>
@@ -800,7 +845,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-pallasandvesta" class="footnote">
                 <tbody>
                     <tr>
-                        <th>28</th>
+                        <th>29</th>
                         <td><a href="protocol/protocol.pdf#pallasandvesta">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.6: Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
@@ -808,7 +853,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-notept" class="footnote">
                 <tbody>
                     <tr>
-                        <th>29</th>
+                        <th>30</th>
                         <td><a href="protocol/protocol.pdf#notept">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.5: Encodings of Note Plaintexts and Memo Fields</a></td>
                     </tr>
                 </tbody>
@@ -816,7 +861,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="protocol-actionencodingandconsensus" class="footnote">
                 <tbody>
                     <tr>
-                        <th>30</th>
+                        <th>31</th>
                         <td><a href="protocol/protocol.pdf#actionencodingandconsensus">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.5: Action Description Encoding and Consensus</a></td>
                     </tr>
                 </tbody>
@@ -824,7 +869,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="initial-zsa-issue" class="footnote">
                 <tbody>
                     <tr>
-                        <th>31</th>
+                        <th>32</th>
                         <td><a href="https://github.com/str4d/zips/blob/zip-udas/drafts/zip-user-defined-assets.rst">User-Defined Assets and Wrapped Assets</a></td>
                     </tr>
                 </tbody>
@@ -832,7 +877,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="generalized-value-commitments" class="footnote">
                 <tbody>
                     <tr>
-                        <th>32</th>
+                        <th>33</th>
                         <td><a href="https://github.com/zcash/zcash/issues/2277#issuecomment-321106819">Comment on Generalized Value Commitments</a></td>
                     </tr>
                 </tbody>
@@ -840,7 +885,7 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
             <table id="circuit-modifications" class="footnote">
                 <tbody>
                     <tr>
-                        <th>33</th>
+                        <th>34</th>
                         <td><a href="https://docs.google.com/document/d/1DzXBqZl_l3aIs_gcelw3OuZz2OVMnYk6Xe_1lBsTji8/edit?usp=sharing">Modifications to the Orchard circuit for the OrchardZSA Protocol</a></td>
                     </tr>
                 </tbody>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -346,7 +346,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <p>The
                     <span class="math">\(\mathsf{finalize}\)</span>
                  boolean is set by the Issuer to signal that there will be no further issuance of the specific Custom Asset. As we will see in <a href="#specification-consensus-rule-changes">Specification: Consensus Rule Changes</a>, transactions that attempt to issue further amounts of a Custom Asset that has previously been finalized will be rejected.</p>
-                <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0230-issuance-action-description">14</a>.</p>
+                <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-21" class="footnote_reference" href="#zip-0230-issuance-action-description">15</a>.</p>
                 <p>We note that the output note commitment of the recipient's notes are not included in the actual transaction, but when added to the global state of the chain, they will be added to the note commitment tree as a shielded note. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
             </section>
             <section id="issuance-bundle"><h3><span class="section-heading">Issuance Bundle</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-bundle"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -364,7 +364,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{isk}\!\)</span>
                     , that validates the issuance.</li>
                 </ul>
-                <p>The issuance bundle is added within the transaction format as a new bundle. The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0230-transaction-format">15</a>.</p>
+                <p>The issuance bundle is added within the transaction format as a new bundle. The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 <a id="footnote-reference-22" class="footnote_reference" href="#zip-0230-transaction-format">16</a>.</p>
             </section>
             <section id="issuance-protocol"><h3><span class="section-heading">Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The issuer program performs the following operations:</p>
@@ -642,7 +642,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="txid-digest-issuance"><h2><span class="section-heading">TxId Digest - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0226-txiddigest">13</a>. As in ZIP 244 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0244">17</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
+            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0226-txiddigest">13</a>. As in ZIP 244 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0244">18</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
             <p>A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below:</p>
             <pre>issuance_digest
 ├── issue_actions_digest
@@ -712,7 +712,7 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-32" class="footnote_reference" href="#zip-0244-sigdigest">18</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
+            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-32" class="footnote_reference" href="#zip-0244-sigdigest">19</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
             <p>The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
             <pre>signature_digest
 ├── header_digest
@@ -727,35 +727,21 @@ S.2: transparent_sig_digest (32-byte hash output)
 S.3: sapling_digest         (32-byte hash output)
 S.4: orchard_digest         (32-byte hash output)
 S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-33" class="footnote_reference" href="#zip-0244">17</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-33" class="footnote_reference" href="#zip-0244">18</a>.</p>
                 <section id="s-5-issuance-digest"><h4><span class="section-heading">S.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>Identical to that specified for the transaction identifier.</p>
                 </section>
             </section>
         </section>
-        <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-34" class="footnote_reference" href="#zip-0244-authcommitment">19</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the following structure. We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
-            <pre>auth_digest
-├── transparent_scripts_digest
-├── sapling_auth_digest
-├── orchard_auth_digest
-└── issuance_auth_digest        [ADDED FOR ZSA]</pre>
-            <p>The pair (Transaction Identifier, Auth Commitment) constitutes a commitment to all the data of a serialized transaction that may be included in a block.</p>
-            <section id="auth-digest"><h3><span class="section-heading">auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>A BLAKE2b-256 hash of the following values</p>
-                <pre>A.1: transparent_scripts_digest (32-byte hash output)
-A.2: sapling_auth_digest        (32-byte hash output)
-A.3: orchard_auth_digest        (32-byte hash output)
-A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field of this hash remains the same as in ZIP 244.</p>
-                <section id="a-4-issuance-auth-digest"><h4><span class="section-heading">A.4: issuance_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-4-issuance-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In the case that Issuance Actions are present, this is a BLAKE2b-256 hash of the field encoding of the <code>issueAuthSig</code> field of the transaction:</p>
-                    <pre>A.4a: issueAuthSig            (field encoding bytes)</pre>
-                    <p>The personalization field of this hash is set to:</p>
-                    <pre>"ZTxAuthZSAOrHash"</pre>
-                    <p>In the case that the transaction has no Orchard Actions, <code>issuance_auth_digest</code> is</p>
-                    <pre>BLAKE2b-256("ZTxAuthZSAOrHash", [])</pre>
-                </section>
+        <section id="authorizing-data-commitment-issuance"><h2><span class="section-heading">Authorizing Data Commitment - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This section covers the construction of the subtree of hashes in the authorizing data commitment that corresponds to issuance transaction data. Details of the overall changes to the authorizing data commitment due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-34" class="footnote_reference" href="#zip-0226-authcommitment">14</a>.</p>
+            <section id="a-4-issuance-auth-digest"><h3><span class="section-heading">A.4: issuance_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-4-issuance-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>In the case that Issuance Actions are present, this is a BLAKE2b-256 hash of the field encoding of the <code>issueAuthSig</code> field of the transaction:</p>
+                <pre>A.4a: issueAuthSig            (field encoding bytes)</pre>
+                <p>The personalization field of this hash is set to:</p>
+                <pre>"ZTxAuthZSAOrHash"</pre>
+                <p>In the case that the transaction has no Orchard Actions, <code>issuance_auth_digest</code> is</p>
+                <pre>BLAKE2b-256("ZTxAuthZSAOrHash", [])</pre>
             </section>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -789,7 +775,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                  in order to properly keep track of the total supply for different Asset Identifiers. This is useful for wallets and other applications that need to keep track of the total supply of Assets.</p>
             </section>
             <section id="fee-structures"><h3><span class="section-heading">Fee Structures</span><span class="section-anchor"> <a rel="bookmark" href="#fee-structures"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 <a id="footnote-reference-36" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">16</a>.</p>
+                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 <a id="footnote-reference-36" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">17</a>.</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -911,10 +897,18 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0230-issuance-action-description" class="footnote">
+            <table id="zip-0226-authcommitment" class="footnote">
                 <tbody>
                     <tr>
                         <th>14</th>
+                        <td><a href="zip-0226.html#authorizing-data-commitment">ZIP 226: Transfer and Burn of Zcash Shielded Assets - Authorizing Data Commitment</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0230-issuance-action-description" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>15</th>
                         <td><a href="zip-0230.html#issuance-action-description-issueaction">ZIP 230: Version 6 Transaction Format: Issuance Action Description (IssueAction)</a></td>
                     </tr>
                 </tbody>
@@ -922,7 +916,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0230-transaction-format" class="footnote">
                 <tbody>
                     <tr>
-                        <th>15</th>
+                        <th>16</th>
                         <td><a href="zip-0230.html#transaction-format">ZIP 230: Version 6 Transaction Format: Transaction Format</a></td>
                     </tr>
                 </tbody>
@@ -930,7 +924,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0230-orchardzsa-fee-calculation" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>17</th>
                         <td><a href="zip-0230.html#orchardzsa-fee-calculation">ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation</a></td>
                     </tr>
                 </tbody>
@@ -938,7 +932,7 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
+                        <th>18</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -946,16 +940,8 @@ A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244-sigdigest" class="footnote">
                 <tbody>
                     <tr>
-                        <th>18</th>
-                        <td><a href="zip-0244.html#signature-digest">ZIP 244: Transaction Identifier Non-Malleability: Signature Digest</a></td>
-                    </tr>
-                </tbody>
-            </table>
-            <table id="zip-0244-authcommitment" class="footnote">
-                <tbody>
-                    <tr>
                         <th>19</th>
-                        <td><a href="zip-0244.html#authorizing-data-commitment">ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment</a></td>
+                        <td><a href="zip-0244.html#signature-digest">ZIP 244: Transaction Identifier Non-Malleability: Signature Digest</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -382,7 +382,7 @@ T.4a.i: orchard_actions_compact_digest
 
 A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in
 an updated version of the ZIP-307 [#zip-0307]_ ``CompactBlock`` format for all OrchardZSA
-Actions belonging to the transaction. For each Action, the following elements are included
+Actions belonging to the Action Group. For each Action, the following elements are included
 in the hash::
 
    T.4a.i.1 : nullifier            (field encoding bytes)
@@ -399,7 +399,7 @@ T.4a.ii: orchard_actions_memos_digest
 .....................................
 
 A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all OrchardZSA
-Actions belonging to the transaction. For each Action, the following elements are included
+Actions belonging to the Action Group. For each Action, the following elements are included
 in the hash::
 
     T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]
@@ -414,7 +414,7 @@ T.4a.iii: orchard_actions_noncompact_digest
 
 A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information **not** intended
 for inclusion in an updated version of the the ZIP 307 [#zip-0307]_ ``CompactBlock``
-format, for all OrchardZSA Actions belonging to the transaction. For each Action,
+format, for all OrchardZSA Actions belonging to the Action Group. For each Action,
 the following elements are included in the hash::
 
    T.4a.iii.1 : cv                    (field encoding bytes)

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -460,10 +460,72 @@ T.5: issuance_digest
 ````````````````````
 The details of the computation of this value are in ZIP 227 [#zip-0227-txiddigest]_.
 
-Signature Digest and Authorizing Data Commitment
-================================================
+Signature Digest 
+================
 
-The details of the changes to these algorithms are in ZIP 227 [#zip-0227-sigdigest]_ [#zip-0227-authcommitment]_.
+The details of the changes to this algorithm are in ZIP 227 [#zip-0227-sigdigest]_.
+
+Authorizing Data Commitment
+===========================
+
+The transaction digest algorithm defined in ZIP 244 [#zip-0244-authcommitment]_ which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section.
+There is a new branch added for issuance information, along with modifications within the ``orchard_auth_digest`` to account for the presence of Action Groups.
+
+We highlight the changes for the OrchardZSA protocol via the ``[UPDATED FOR ZSA]`` or ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
+
+    auth_digest
+    ├── transparent_scripts_digest
+    ├── sapling_auth_digest
+    ├── orchard_auth_digest         [UPDATED FOR ZSA]
+    └── issuance_auth_digest        [ADDED FOR ZSA]
+
+The pair (Transaction Identifier, Auth Commitment) constitutes a commitment to all the data of a serialized transaction that may be included in a block.
+
+auth_digest
+-----------
+A BLAKE2b-256 hash of the following values ::
+
+   A.1: transparent_scripts_digest (32-byte hash output)
+   A.2: sapling_auth_digest        (32-byte hash output)
+   A.3: orchard_auth_digest        (32-byte hash output)  [UPDATED FOR ZSA]
+   A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]
+
+The personalization field of this hash remains the same as in ZIP 244.
+
+
+A.3: orchard_auth_digest
+````````````````````````
+
+In the case that OrchardZSA Action Groups are present, this is a BLAKE2b-256 hash of the following values::
+
+    A.3a: orchard_action_groups_auth_digest  (32-byte hash output)  [ADDED FOR ZSA]
+    A.3b: bindingSigOrchard                  (field encoding bytes)
+
+The personalization field of this hash is the same as in ZIP 244, that is::
+
+    "ZTxAuthOrchaHash"
+
+In case that the transaction has no OrchardZSA Action Groups, ``orchard_auth_digest`` is::
+
+    BLAKE2b-256("ZTxAuthOrchaHash", [])
+
+A.3a: orchard_action_groups_auth_digest
+'''''''''''''''''''''''''''''''''''''''
+
+This is a BLAKE2b-256 hash of the ``proofsOrchard`` and ``spendAuthSigsOrchard`` fields of all OrchardZSA Action Groups belonging to the transaction::
+
+    A.3a.i:  proofsOrchard               (field encoding bytes)
+    A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)
+
+The personalization field of this hash is set to::
+
+    "ZTxAuthOrcAGHash"
+
+A.4: issuance_auth_digest
+`````````````````````````
+
+The details of the computation of this value are in ZIP 227 [#zip-0227-authcommitment]_.
+
 
 Security and Privacy Considerations
 ===================================
@@ -522,10 +584,11 @@ References
 .. [#zip-0227-consensus] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Consensus Rule Changes <zip-0227.html#specification-consensus-rule-changes>`_
 .. [#zip-0227-txiddigest] `ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance <zip-0227.html#txid-digest-issuance>`_
 .. [#zip-0227-sigdigest] `ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest <zip-0227.html#signature-digest>`_
-.. [#zip-0227-authcommitment] `ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment <zip-0227.html#authorizing-data-commitment>`_
+.. [#zip-0227-authcommitment] `ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment <zip-0227.html#authorizing-data-commitment-issuance>`_
 .. [#zip-0230] `ZIP 230: Version 6 Transaction Format <zip-0230.html>`_
 .. [#zip-0230-orchardzsa-fee-calculation] `ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation <zip-0230.html#orchardzsa-fee-calculation>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
+.. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_
 .. [#protocol-notes] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
 .. [#protocol-actions] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.7: Action Transfers and their Descriptions <protocol/protocol.pdf#actions>`_

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -530,33 +530,15 @@ S.5: issuance_digest
 ````````````````````
 Identical to that specified for the transaction identifier.
 
-Authorizing Data Commitment
-===========================
+Authorizing Data Commitment - Issuance
+======================================
 
-The transaction digest algorithm defined in ZIP 244 [#zip-0244-authcommitment]_ which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the following structure.
-We highlight the changes for the OrchardZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
-
-    auth_digest
-    ├── transparent_scripts_digest
-    ├── sapling_auth_digest
-    ├── orchard_auth_digest
-    └── issuance_auth_digest        [ADDED FOR ZSA]
-
-The pair (Transaction Identifier, Auth Commitment) constitutes a commitment to all the data of a serialized transaction that may be included in a block.
-
-auth_digest
------------
-A BLAKE2b-256 hash of the following values ::
-
-   A.1: transparent_scripts_digest (32-byte hash output)
-   A.2: sapling_auth_digest        (32-byte hash output)
-   A.3: orchard_auth_digest        (32-byte hash output)
-   A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]
-
-The personalization field of this hash remains the same as in ZIP 244.
+This section covers the construction of the subtree of hashes in the authorizing data commitment that corresponds to issuance transaction data.
+Details of the overall changes to the authorizing data commitment due to the OrchardZSA protocol can be found in ZIP 226 [#zip-0226-authcommitment]_.
 
 A.4: issuance_auth_digest
-`````````````````````````
+-------------------------
+
 In the case that Issuance Actions are present, this is a BLAKE2b-256 hash of the field encoding of the ``issueAuthSig`` field of the transaction::
 
    A.4a: issueAuthSig            (field encoding bytes)
@@ -636,12 +618,12 @@ References
 .. [#zip-0226-notestructure] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Note Structure & Commitment <zip-0226.html#note-structure-commitment>`_
 .. [#zip-0226-assetburn] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Additional Consensus Rules for the assetBurn set <zip-0226.html#additional-consensus-rules-for-the-assetburn-set>`_
 .. [#zip-0226-txiddigest] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - TxId Digest <zip-0226.html#txid-digest>`_
+.. [#zip-0226-authcommitment] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Authorizing Data Commitment <zip-0226.html#authorizing-data-commitment>`_
 .. [#zip-0230-issuance-action-description] `ZIP 230: Version 6 Transaction Format: Issuance Action Description (IssueAction) <zip-0230.html#issuance-action-description-issueaction>`_
 .. [#zip-0230-transaction-format] `ZIP 230: Version 6 Transaction Format: Transaction Format <zip-0230.html#transaction-format>`_
 .. [#zip-0230-orchardzsa-fee-calculation] `ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation <zip-0230.html#orchardzsa-fee-calculation>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0244-sigdigest] `ZIP 244: Transaction Identifier Non-Malleability: Signature Digest <zip-0244.html#signature-digest>`_
-.. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_
 .. [#bip-0340] `BIP 340: Schnorr Signatures for secp256k1 <https://github.com/bitcoin/bips/blob/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb/bip-0340.mediawiki>`_
 .. [#protocol-notation] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 2: Notation <protocol/protocol.pdf#notation>`_
 .. [#protocol-addressesandkeys] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.1: Payment Addresses and Keys <protocol/protocol.pdf#addressesandkeys>`_


### PR DESCRIPTION
This PR fixes the specification of the digests that are computed on the Actions, to specify that the computation is per Action Group, and not per transaction.

It also updates the computation of `orchard_auth_digest` to account for the Action Group structure.