### PR TITLE
Simplification of encoding in the computation of rho

### DIFF
--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -412,7 +412,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <li>
                         <span class="math">\(\mathsf{PRF}^{\mathsf{Rho}} : \mathbb{B}^{256} \times \mathbb{B}^{\mathbb{Y}^{[\mathbb{N}]}} \to \mathbb{B}^{512}\)</span>
                      is defined as
-                        <span class="math">\(\mathsf{PRF}^{\mathsf{Rho}}(\mathsf{k},t) := \textsf{BLAKE2b-512}(\mathtt{"ZSA\_IssueNoteRho"}, \mathsf{LEBS2OSP}_{256}(\mathsf{k}) \| t)\)</span>
+                        <span class="math">\(\mathsf{PRF}^{\mathsf{Rho}}(\mathsf{k},t) := \textsf{BLAKE2b-512}(\mathtt{"ZSA\_IssueNoteRho"}, \mathsf{k} \| t)\)</span>
                     </li>
                 </ul>
                 <p>The

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -287,7 +287,7 @@ We define a function $\mathsf{DeriveIssuedRho} : \mathbb{F}_{q_{\mathbb{P}}} \ti
 where 
 
 - $\mathsf{ToBase}^{\mathsf{Rho}} : \mathbb{B}^{512} \to \mathbb{F}_{q_{\mathbb{P}}}$ is defined as $\mathsf{ToBase}^{\mathsf{Rho}}(x) := \mathsf{LEOS2IP}_{512}(x) \mod q_{\mathbb{P}}$ 
-- $\mathsf{PRF}^{\mathsf{Rho}} : \mathbb{B}^{256} \times \mathbb{B}^{\mathbb{Y}^{[\mathbb{N}]}} \to \mathbb{B}^{512}$ is defined as $\mathsf{PRF}^{\mathsf{Rho}}(\mathsf{k},t) := \textsf{BLAKE2b-512}(\mathtt{"ZSA\_IssueNoteRho"}, \mathsf{LEBS2OSP}_{256}(\mathsf{k}) \| t)$
+- $\mathsf{PRF}^{\mathsf{Rho}} : \mathbb{B}^{256} \times \mathbb{B}^{\mathbb{Y}^{[\mathbb{N}]}} \to \mathbb{B}^{512}$ is defined as $\mathsf{PRF}^{\mathsf{Rho}}(\mathsf{k},t) := \textsf{BLAKE2b-512}(\mathtt{"ZSA\_IssueNoteRho"}, \mathsf{k} \| t)$
 
 The $\text{ρ}$ field of an Issue Note is computed as 
 


### PR DESCRIPTION
This PR simplifies the encoding of the $\mathsf{nf}$ argument in the computation of $\rho$, so that it avoids the double use of $\mathsf{LEBS2OSP(I2LEOSP(...))}$.