### PR TITLE
Improving the typing and consistency of OrchardZSA and Issue Notes

### DIFF
--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -103,7 +103,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <ul>
                     <li>
                         <span class="math">\(\mathsf{AssetBase} : \mathbb{P}^*\)</span>
-                     is the unique element of the Pallas group <a id="footnote-reference-23" class="footnote_reference" href="#protocol-pallasandvesta">29</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0227">5</a>, a valid group element that is not the identity and is not
+                     is the unique element of the Pallas group <a id="footnote-reference-23" class="footnote_reference" href="#protocol-pallasandvesta">29</a> that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0227-assetidentifier">7</a>, a valid group element that is not the identity and is not
                         <span class="math">\(\bot\!\)</span>
                     . The byte representation of the Asset Base is defined as
                         <span class="math">\(\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})\!\)</span>
@@ -673,7 +673,7 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
                 <tbody>
                     <tr>
                         <th>7</th>
-                        <td><a href="zip-0227.html#specification-asset-identifier">ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier</a></td>
+                        <td><a href="zip-0227.html#specification-asset-identifier-asset-digest-and-asset-base">ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -95,15 +95,10 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="note-structure-commitment"><h3><span class="section-heading">Note Structure &amp; Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#note-structure-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Let
-                    <span class="math">\(\mathsf{Note^{OrchardZSA}}\)</span>
-                 be the type of a OrchardZSA note, i.e.
-                    <span class="math">\(\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}^*\!\)</span>
-                .</p>
                 <p>An OrchardZSA note differs from an Orchard note <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">17</a> by additionally including the Asset Base,
                     <span class="math">\(\mathsf{AssetBase}\!\)</span>
                 . So an OrchardZSA note is a tuple
-                    <span class="math">\((\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})\!\)</span>
+                    <span class="math">\((\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \mathsf{AssetBase}, \text{ρ}, \text{ψ}, \mathsf{rcm})\!\)</span>
                 , where</p>
                 <ul>
                     <li>
@@ -113,8 +108,17 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     . The byte representation of the Asset Base is defined as
                         <span class="math">\(\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})\!\)</span>
                     .</li>
+                    <li>The remaining terms are as defined in §3.2 of the protocol specification <a id="footnote-reference-25" class="footnote_reference" href="#protocol-notes">17</a>.</li>
                 </ul>
                 <p>Note that the above assumes a canonical encoding, which is true for the Pallas group, but may not hold for future shielded protocols.</p>
+                <p>Let
+                    <span class="math">\(\mathsf{Note^{OrchardZSA}}\)</span>
+                 be the type of a OrchardZSA note, i.e.</p>
+                <div class="math">\(\mathsf{Note^{OrchardZSA}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. 2^{\ell_{\mathsf{value}}} - 1\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathsf{NoteCommit^{Orchard}.Trapdoor},\)</div>
+                <p>where
+                    <span class="math">\(\mathbb{P}^*\)</span>
+                 is the Pallas group excluding the identity element, and the other types are as defined in §3.2 of the protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-notes">17</a>.</p>
+                <p><strong>Non-normative note:</strong> The type and definition of the OrchardZSA note reflect that it is a tuple of all the components of an Orchard note, with the addition of the Asset Base into the tuple.</p>
                 <p>We define the note commitment scheme
                     <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\)</span>
                  as follows:</p>
@@ -131,9 +135,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </ul>
                 <p>where
                     <span class="math">\(\mathbb{P}, \ell_{\mathbb{P}}, q_{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-25" class="footnote_reference" href="#protocol-pallasandvesta">29</a>, and where
+                 are as defined for the Pallas curve <a id="footnote-reference-27" class="footnote_reference" href="#protocol-pallasandvesta">29</a>, and where
                     <span class="math">\(\mathsf{NoteCommit^{Orchard}.\{Trapdoor, Output\}}\)</span>
-                 are as defined in the Zcash protocol specification <a id="footnote-reference-26" class="footnote_reference" href="#protocol-abstractcommit">19</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-27" class="footnote_reference" href="#protocol-concretesinsemillacommit">28</a> as follows:</p>
+                 are as defined in the Zcash protocol specification <a id="footnote-reference-28" class="footnote_reference" href="#protocol-abstractcommit">19</a>. This note commitment scheme is instantiated using the Sinsemilla Commitment <a id="footnote-reference-29" class="footnote_reference" href="#protocol-concretesinsemillacommit">28</a> as follows:</p>
                 <div class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{g_d}\star, \mathsf{pk_d}\star, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase}) :=
   \begin{cases}
     \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{g_d}\star, \mathsf{pk_d}\star, \mathsf{v}, \text{ρ}, \text{ψ}), &amp;\!\!\text{if } \mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}} \\
@@ -152,21 +156,21 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{repr}_{\mathbb{P}}\)</span>
                  and
                     <span class="math">\(\mathsf{GroupHash}^{\mathbb{P}}\)</span>
-                 are as defined for the Pallas curve <a id="footnote-reference-28" class="footnote_reference" href="#protocol-pallasandvesta">29</a>,
+                 are as defined for the Pallas curve <a id="footnote-reference-30" class="footnote_reference" href="#protocol-pallasandvesta">29</a>,
                     <span class="math">\(\ell^{\mathsf{Orchard}}_{\mathsf{base}}\)</span>
-                 is as defined in §5.3 <a id="footnote-reference-29" class="footnote_reference" href="#protocol-constants">25</a>, and
+                 is as defined in §5.3 <a id="footnote-reference-31" class="footnote_reference" href="#protocol-constants">25</a>, and
                     <span class="math">\(\mathsf{I2LEBSP}\)</span>
-                 is as defined in §5.1 <a id="footnote-reference-30" class="footnote_reference" href="#protocol-endian">24</a> of the Zcash protocol specification.</p>
-                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-31" class="footnote_reference" href="#protocol-commitmentsandnullifiers">22</a>.</p>
-                <p>The OrchardZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-32" class="footnote_reference" href="#protocol-notept">30</a>. It consists of</p>
+                 is as defined in §5.1 <a id="footnote-reference-32" class="footnote_reference" href="#protocol-endian">24</a> of the Zcash protocol specification.</p>
+                <p>The nullifier is generated in the same manner as in the Orchard protocol <a id="footnote-reference-33" class="footnote_reference" href="#protocol-commitmentsandnullifiers">22</a>.</p>
+                <p>The OrchardZSA note plaintext also includes the Asset Base in addition to the components in the Orchard note plaintext <a id="footnote-reference-34" class="footnote_reference" href="#protocol-notept">30</a>. It consists of</p>
                 <div class="math">\((\mathsf{leadByte} : \mathbb{B}^{\mathbb{Y}}, \mathsf{d} : \mathbb{B}^{[\ell_{\mathsf{d}}]}, \mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}, \mathsf{rseed} : \mathbb{B}^{\mathbb{Y}[32]}, \mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}, \mathsf{memo} : \mathbb{B}^{\mathbb{Y}[512]})\)</div>
                 <section id="rationale-for-note-commitment"><h4><span class="section-heading">Rationale for Note Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-note-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>In the OrchardZSA protocol, the instance of the note commitment scheme,
                         <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}\!\)</span>
                     , differs from the Orchard note commitment
                         <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm}}\)</span>
-                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-33" class="footnote_reference" href="#protocol-concretesinsemillacommit">28</a> allows us to add the Asset Base as a final recursive step.</p>
-                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-34" class="footnote_reference" href="#protocol-concretesinsemillahash">26</a>. OrchardZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
+                     in that for Custom Assets, the Asset Base will be added as an input to the commitment computation. In the case where the Asset is the ZEC Asset, the commitment is computed identically to the Orchard note commitment, without making use of the ZEC Asset Base as an input. As we will see, the nested structure of the Sinsemilla-based commitment <a id="footnote-reference-35" class="footnote_reference" href="#protocol-concretesinsemillacommit">28</a> allows us to add the Asset Base as a final recursive step.</p>
+                    <p>The note commitment output is still indistinguishable from the original Orchard ZEC note commitments, by definition of the Sinsemilla hash function <a id="footnote-reference-36" class="footnote_reference" href="#protocol-concretesinsemillahash">26</a>. OrchardZSA note commitments will therefore be added to the same Orchard Note Commitment Tree. In essence, we have:</p>
                     <div class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase}) \in \mathsf{NoteCommit^{Orchard}.Output}\)</div>
                     <p>This definition can be viewed as a generalization of the Orchard note commitment, and will allow maintaining a single commitment instance for the note commitment, which will be used both for pre-ZSA Orchard and OrchardZSA notes.</p>
                 </section>
@@ -187,20 +191,20 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      respectively,</li>
                     <li>
                         <span class="math">\(\mathsf{AssetBase_{AssetId}}\)</span>
-                     is defined in ZIP 227 <a id="footnote-reference-35" class="footnote_reference" href="#zip-0227">5</a>, and</li>
+                     is defined in ZIP 227 <a id="footnote-reference-37" class="footnote_reference" href="#zip-0227">5</a>, and</li>
                     <li>
                         <span class="math">\(\mathcal{R}^{\mathsf{Orchard}} := \mathsf{GroupHash^{\mathbb{P}}}(\texttt{“z.cash:Orchard-cv”}, \texttt{“r”})\!\)</span>
                     , as in the Orchard protocol.</li>
                 </ul>
                 <p>For ZEC, we define
                     <span class="math">\(\mathsf{AssetBase}_{\mathsf{AssetId}} := \mathcal{V}^{\mathsf{Orchard}}\)</span>
-                 so that the value commitment for ZEC notes is computed identically to the Orchard protocol deployed in NU5 <a id="footnote-reference-36" class="footnote_reference" href="#zip-0224">4</a>. As such
+                 so that the value commitment for ZEC notes is computed identically to the Orchard protocol deployed in NU5 <a id="footnote-reference-38" class="footnote_reference" href="#zip-0224">4</a>. As such
                     <span class="math">\(\mathsf{ValueCommit^{Orchard}_{rcv}}(\mathsf{v})\)</span>
-                 as defined in <a id="footnote-reference-37" class="footnote_reference" href="#zip-0224">4</a> is used as
+                 as defined in <a id="footnote-reference-39" class="footnote_reference" href="#zip-0224">4</a> is used as
                     <span class="math">\(\mathsf{ValueCommit^{OrchardZSA}_{rcv}}(\mathcal{V}^{\mathsf{Orchard}}, \mathsf{v})\)</span>
                  here.</p>
                 <section id="rationale-for-value-commitment"><h4><span class="section-heading">Rationale for Value Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-value-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-38" class="footnote_reference" href="#protocol-concretehomomorphiccommit">27</a> to perform the value commitment, with fixed base points
+                    <p>The Orchard Protocol uses a Homomorphic Pedersen Commitment <a id="footnote-reference-40" class="footnote_reference" href="#protocol-concretehomomorphiccommit">27</a> to perform the value commitment, with fixed base points
                         <span class="math">\(\mathcal{V}^{\mathsf{Orchard}}\)</span>
                      and
                         <span class="math">\(\mathcal{R}^{\mathsf{Orchard}}\)</span>
@@ -242,12 +246,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                             <span class="math">\(\mathsf{assetBurn}\!\)</span>
                         .</li>
                     </ol>
-                    <p>The other consensus rule changes for the OrchardZSA protocol are specified in ZIP 227 <a id="footnote-reference-39" class="footnote_reference" href="#zip-0227-consensus">8</a>.</p>
+                    <p>The other consensus rule changes for the OrchardZSA protocol are specified in ZIP 227 <a id="footnote-reference-41" class="footnote_reference" href="#zip-0227-consensus">8</a>.</p>
                     <p><strong>Note:</strong> The transparent protocol will not be changed with this ZIP to adapt to a multiple Asset structure. This means that unless future consensus rules changes do allow it, unshielding will not be possible for Custom Assets.</p>
                 </section>
             </section>
             <section id="value-balance-verification"><h3><span class="section-heading">Value Balance Verification</span><span class="section-anchor"> <a rel="bookmark" href="#value-balance-verification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-40" class="footnote_reference" href="#protocol-orchardbalance">21</a>, with the addition of the burn information.</p>
+                <p>In order to verify the balance of the different Assets, the verifier MUST perform a similar process as for the Orchard protocol <a id="footnote-reference-42" class="footnote_reference" href="#protocol-orchardbalance">21</a>, with the addition of the burn information.</p>
                 <p>For a total of
                     <span class="math">\(n\)</span>
                  Actions in a transfer, the prover MUST still sign the SIGHASH transaction hash using the binding signature key
@@ -270,7 +274,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      the set of indices of Actions that are related to Custom Assets.</p>
                     <p>The right hand side of the value balance verification equation can be expanded to:</p>
                     <div class="math">\(((\sum_{i \in S_{\mathsf{ZEC}}} \mathsf{cv}^{\mathsf{net}}_i) + (\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j)) - ([\mathsf{v^{balanceOrchard}}]\,\mathcal{V}^{\mathsf{Orchard}} + [0]\,\mathcal{R}^{\mathsf{Orchard}}) - (\sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} + [0]\,\mathcal{R}^{\mathsf{Orchard}})\)</div>
-                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-41" class="footnote_reference" href="#protocol-orchardbalance">21</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
+                    <p>This equation contains the balance check of the Orchard protocol <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orchardbalance">21</a>. With ZSA, transfer Actions for Custom Assets must also be balanced across Asset Bases. All Custom Assets are contained within the shielded pool, and cannot be unshielded via a regular transfer. Custom Assets can be burnt, the mechanism for which reveals the amount and identifier of the Asset being burnt, within the
                         <span class="math">\(\mathsf{assetBurn}\)</span>
                      set. As such, for a correctly constructed transaction, we will get
                         <span class="math">\(\sum_{j \in S_{\mathsf{CA}}} \mathsf{cv}^{\mathsf{net}}_j - \sum_{(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}} [\mathsf{v}]\,\mathsf{AssetBase} = \sum_{j \in S_{\mathsf{CA}}} [\mathsf{rcv}^{\mathsf{net}}_j]\,\mathcal{R}^{\mathsf{Orchard}}\!\)</span>
@@ -319,11 +323,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathbb{F}_{q_{\mathbb{P}}}\!\)</span>
                 ,
                     <span class="math">\(\mathcal{K}^{\mathsf{Orchard}}\)</span>
-                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-42" class="footnote_reference" href="#protocol-commitmentsandnullifiers">22</a>, and
+                 is the Orchard Nullifier Base as defined in <a id="footnote-reference-44" class="footnote_reference" href="#protocol-commitmentsandnullifiers">22</a>, and
                     <span class="math">\(\mathcal{L}^{\mathsf{Orchard}} := \mathsf{GroupHash^{\mathbb{P}}}(\texttt{“z.cash:Orchard”}, \texttt{“L”})\!\)</span>
                 .</p>
                 <section id="rationale-for-split-notes"><h4><span class="section-heading">Rationale for Split Notes</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-split-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-43" class="footnote_reference" href="#protocol-orcharddummynotes">20</a> to the Actions that have not been assigned input notes.</p>
+                    <p>In the Orchard protocol, since each Action represents an input and an output, the transaction that wants to send one input to multiple outputs must have multiple inputs. The Orchard protocol gives <em>dummy spend notes</em> <a id="footnote-reference-45" class="footnote_reference" href="#protocol-orcharddummynotes">20</a> to the Actions that have not been assigned input notes.</p>
                     <p>The Orchard technique requires modification for the OrchardZSA protocol with multiple Asset Identifiers, as the output note of the split Actions <em>cannot</em> contain <em>just any</em> Asset Base. We must enforce it to be an actual output of a GroupHash computation (in fact, we want it to be of the same Asset Base as the original input note, but the binding signature takes care that the proper balancing is performed). Without this enforcement the prover could input a multiple (or linear combination) of an existing Asset Base, and thereby attack the network by overflowing the ZEC value balance and hence counterfeiting ZEC funds.</p>
                     <p>Therefore, for Custom Assets we enforce that <em>every</em> input note to an OrchardZSA Action must be proven to exist in the set of note commitments in the note commitment tree. We then enforce this real note to be “unspendable” in the sense that its value will be zeroed in split Actions and the nullifier will be randomized, making the note not spendable in the specific Action. Then, the proof itself ensures that the output note is of the same Asset Base as the input note. In the circuit, the split note functionality will be activated by a boolean private input to the proof (aka the
                         <span class="math">\(\mathsf{split\_flag}\)</span>
@@ -332,8 +336,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 </section>
             </section>
             <section id="circuit-statement"><h3><span class="section-heading">Circuit Statement</span><span class="section-anchor"> <a rel="bookmark" href="#circuit-statement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Every <em>OrchardZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-44" class="footnote_reference" href="#protocol-actionstatement">23</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
-                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-45" class="footnote_reference" href="#circuit-modifications">34</a>.</p>
+                <p>Every <em>OrchardZSA Action statement</em> is closely similar to the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">23</a>, except for a few additions that ensure the security of the Asset Identifier system. We detail these changes below.</p>
+                <p>All modifications in the Circuit are detailed in <a id="footnote-reference-47" class="footnote_reference" href="#circuit-modifications">34</a>.</p>
                 <section id="asset-base-equality"><h4><span class="section-heading">Asset Base Equality</span><span class="section-anchor"> <a rel="bookmark" href="#asset-base-equality"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>The following constraints must be added to ensure that the input and output note are of the same
                         <span class="math">\(\mathsf{AssetBase}\!\)</span>
@@ -342,12 +346,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <li>The Asset Base,
                             <span class="math">\(\mathsf{AssetBase_{AssetId}}\!\)</span>
                         , for the note is witnessed once, as an auxiliary input.</li>
-                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-46" class="footnote_reference" href="#protocol-actionstatement">23</a>,
+                        <li>In the Old note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-48" class="footnote_reference" href="#protocol-actionstatement">23</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
                         .</li>
-                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-47" class="footnote_reference" href="#protocol-actionstatement">23</a>,
+                        <li>In the New note commitment integrity constraint in the Orchard Action statement <a id="footnote-reference-49" class="footnote_reference" href="#protocol-actionstatement">23</a>,
                             <span class="math">\(\mathsf{NoteCommit^{Orchard}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}})\)</span>
                          is replaced with
                             <span class="math">\(\mathsf{NoteCommit^{OrchardZSA}_{rcm^{new}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{new}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{new}}), \mathsf{v^{new}}, \text{ρ}^{\mathsf{new}}, \text{ψ}^{\mathsf{new}}, \mathsf{AssetBase_{AssetId}})\!\)</span>
@@ -449,15 +453,15 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     </ul>
                 </section>
                 <section id="backwards-compatibility-with-zec-notes"><h4><span class="section-heading">Backwards Compatibility with ZEC Notes</span><span class="section-anchor"> <a rel="bookmark" href="#backwards-compatibility-with-zec-notes"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The input note in the old note commitment integrity check must either include an Asset Base (OrchardZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-48" class="footnote_reference" href="#protocol-abstractcommit">19</a>. If the note is an OrchardZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
+                    <p>The input note in the old note commitment integrity check must either include an Asset Base (OrchardZSA note) or not (pre-ZSA Orchard note). If the note is a pre-ZSA Orchard note, the note commitment is computed in the original Orchard fashion <a id="footnote-reference-50" class="footnote_reference" href="#protocol-abstractcommit">19</a>. If the note is an OrchardZSA note, the note commitment is computed as defined in the <a href="#note-structure-commitment">Note Structure &amp; Commitment</a> section.</p>
                 </section>
             </section>
         </section>
         <section id="orchardzsa-transaction-structure"><h2><span class="section-heading">OrchardZSA Transaction Structure</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-transaction-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-49" class="footnote_reference" href="#zip-0230">12</a>.</p>
+            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0230">12</a>.</p>
         </section>
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-50" class="footnote_reference" href="#zip-0244">14</a> is modified by the OrchardZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the OrchardZSA protocol.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0244">14</a> is modified by the OrchardZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the OrchardZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values:</p>
                 <pre>T.1: header_digest       (32-byte hash output)
@@ -465,13 +469,13 @@ T.2: transparent_digest  (32-byte hash output)
 T.3: sapling_digest      (32-byte hash output)
 T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
 T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-51" class="footnote_reference" href="#zip-0244">14</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0244">14</a>.</p>
                 <section id="t-4-orchard-digest"><h4><span class="section-heading">T.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>When OrchardZSA Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values:</p>
                     <pre>T.4a: orchard_action_groups_digest   (32-byte hash output)          [ADDED FOR ZSA]
 T.4b: orchard_zsa_burn_digest        (32-byte hash output)          [ADDED FOR ZSA]
 T.4c: valueBalanceOrchard            (64-bit signed little-endian)</pre>
-                    <p>The personalization field of this hash is the same as in ZIP 244 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0244">14</a></p>
+                    <p>The personalization field of this hash is the same as in ZIP 244 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0244">14</a></p>
                     <pre>"ZTxIdOrchardHash"</pre>
                     <p>In the case that the transaction has no OrchardZSA Action Groups, <code>orchard_digest</code> is</p>
                     <pre>BLAKE2b-256("ZTxIdOrchardHash", [])</pre>
@@ -486,7 +490,7 @@ T.4a.vi : nAGExpiryHeight                     (4 bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcActGHash"</pre>
                         <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0307">16</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0307">16</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.i.1 : nullifier            (field encoding bytes)
 T.4a.i.2 : cmx                  (field encoding bytes)
 T.4a.i.3 : ephemeralKey         (field encoding bytes)
@@ -501,7 +505,7 @@ T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR
                             <pre>"ZTxIdOrcActMHash"</pre>
                         </section>
                         <section id="t-4a-iii-orchard-actions-noncompact-digest"><h6><span class="section-heading">T.4a.iii: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iii-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0307">16</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
+                            <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-56" class="footnote_reference" href="#zip-0307">16</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.iii.1 : cv                    (field encoding bytes)
 T.4a.iii.2 : rk                    (field encoding bytes)
 T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
@@ -531,15 +535,15 @@ T.4b.ii: valueBurn    (field encoding bytes)</pre>
                     </section>
                 </section>
                 <section id="t-5-issuance-digest"><h4><span class="section-heading">T.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0227-txiddigest">9</a>.</p>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-57" class="footnote_reference" href="#zip-0227-txiddigest">9</a>.</p>
                 </section>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The details of the changes to this algorithm are in ZIP 227 <a id="footnote-reference-56" class="footnote_reference" href="#zip-0227-sigdigest">10</a>.</p>
+            <p>The details of the changes to this algorithm are in ZIP 227 <a id="footnote-reference-58" class="footnote_reference" href="#zip-0227-sigdigest">10</a>.</p>
         </section>
         <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-57" class="footnote_reference" href="#zip-0244-authcommitment">15</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section. There is a new branch added for issuance information, along with modifications within the <code>orchard_auth_digest</code> to account for the presence of Action Groups.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-59" class="footnote_reference" href="#zip-0244-authcommitment">15</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section. There is a new branch added for issuance information, along with modifications within the <code>orchard_auth_digest</code> to account for the presence of Action Groups.</p>
             <p>We highlight the changes for the OrchardZSA protocol via the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
             <pre>auth_digest
 ├── transparent_scripts_digest
@@ -571,7 +575,7 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
                     </section>
                 </section>
                 <section id="a-4-issuance-auth-digest"><h4><span class="section-heading">A.4: issuance_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-4-issuance-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-58" class="footnote_reference" href="#zip-0227-authcommitment">11</a>.</p>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-60" class="footnote_reference" href="#zip-0227-authcommitment">11</a>.</p>
                 </section>
             </section>
         </section>
@@ -586,7 +590,7 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 230 <a id="footnote-reference-59" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">13</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 230 <a id="footnote-reference-61" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">13</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and OrchardZSA notes. As we specify above, there are three main reasons we can do this:</p>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -359,6 +359,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      MUST be sampled uniformly at random by the issuer.</li>
                 </ul>
                 <p>The complete encoding of these fields into an <code>IssueNote</code> is defined in ZIP 230 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0230-issue-note">16</a>.</p>
+                <p>Let
+                    <span class="math">\(\mathsf{Note^{Issue}}\)</span>
+                 be the type of an Issue Note, i.e.</p>
+                <div class="math">\(\mathsf{Note^{Issue}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. \mathsf{MAX\_ISSUE}\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{B}^{[\mathbb{Y}^{32}]}.\)</div>
+                <p>The note commitment of the Issue Notes are computed in the same manner as for OrchardZSA Notes. They will be added to the note commitment tree as any other shielded note when the transaction issuing the Asset is included on chain. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
             </section>
             <section id="issuance-action"><h3><span class="section-heading">Issuance Action</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
@@ -378,7 +383,6 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{finalize}\)</span>
                  boolean is set by the Issuer to signal that there will be no further issuance of the specific Custom Asset. As we will see in <a href="#specification-consensus-rule-changes">Specification: Consensus Rule Changes</a>, transactions that attempt to issue further amounts of a Custom Asset that has previously been finalized will be rejected.</p>
                 <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0230-issuance-action-description">15</a>.</p>
-                <p>We note that when the issued note commitments are added to the global state of the chain, they will be added to the note commitment tree as any other shielded note. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
             </section>
             <section id="issuance-bundle"><h3><span class="section-heading">Issuance Bundle</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-bundle"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance bundle is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:</p>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -31,7 +31,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>The terms "Orchard" and "Action" in this document are to be interpreted as described in ZIP 224 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0224">9</a>.</p>
             <p>We define the following additional terms:</p>
             <ul>
-                <li>Asset: A type of note that can be transferred on the Zcash blockchain. Each Asset is identified by an Asset Identifier <a href="#specification-asset-identifier">Specification: Asset Identifier</a>.
+                <li>Asset: A type of note that can be transferred on the Zcash blockchain. Each Asset is identified by an Asset Identifier <a href="#specification-asset-identifier-asset-digest-and-asset-base">Specification: Asset Identifier, Asset Digest, and Asset Base</a>.
                     <ul>
                         <li>ZEC is the default (and currently the only defined) Asset for the Zcash mainnet.</li>
                         <li>TAZ is the default (and currently the only defined) Asset for the Zcash testnet.</li>
@@ -267,7 +267,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                  algorithm is defined in BIP 340 <a id="footnote-reference-20" class="footnote_reference" href="#bip-0340">23</a>.</p>
             </section>
         </section>
-        <section id="specification-asset-identifier"><h2><span class="section-heading">Specification: Asset Identifier</span><span class="section-anchor"> <a rel="bookmark" href="#specification-asset-identifier"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+        <section id="specification-asset-identifier-asset-digest-and-asset-base"><h2><span class="section-heading">Specification: Asset Identifier, Asset Digest, and Asset Base</span><span class="section-anchor"> <a rel="bookmark" href="#specification-asset-identifier-asset-digest-and-asset-base"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>For every new Asset, there MUST be a new and unique Asset Identifier, denoted
                 <span class="math">\(\mathsf{AssetId}\!\)</span>
             . We define this to be a globally unique pair
@@ -363,7 +363,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{Note^{Issue}}\)</span>
                  be the type of an Issue Note, i.e.</p>
                 <div class="math">\(\mathsf{Note^{Issue}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. \mathsf{MAX\_ISSUE}\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{B}^{[\mathbb{Y}^{32}]}.\)</div>
-                <p>The note commitment of the Issue Notes are computed in the same manner as for OrchardZSA Notes. They will be added to the note commitment tree as any other shielded note when the transaction issuing the Asset is included on chain. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
+                <p>The note commitments of Issue Notes are computed in the same manner as for OrchardZSA Notes. They will be added to the note commitment tree as any other shielded note when the transaction issuing the Asset is included on chain. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
             </section>
             <section id="issuance-action"><h3><span class="section-heading">Issuance Action</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance action, <code>IssueAction</code>, is the instance of issuing a specific Custom Asset, and contains the following fields:</p>
@@ -373,7 +373,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                      and
                         <span class="math">\(512\!\)</span>
                     .</li>
-                    <li><code>asset_desc</code>: the Asset description, a byte string of up to 512 bytes as defined in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
+                    <li><code>asset_desc</code>: the Asset description, a byte string of up to 512 bytes as defined in the <a href="#specification-asset-identifier-asset-digest-and-asset-base">Specification: Asset Identifier, Asset Digest, and Asset Base</a> section.</li>
                     <li><code>vNotes</code>: an array of Issue Notes containing the unencrypted output notes to the recipients of the Asset.</li>
                     <li><code>flagsIssuance</code>: a byte that stores the
                         <span class="math">\(\mathsf{finalize}\)</span>
@@ -444,12 +444,12 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{ik}\)</span>
                      and
                         <span class="math">\(\mathsf{asset\_desc}\)</span>
-                     as decribed in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
+                     as decribed in the <a href="#specification-asset-identifier-asset-digest-and-asset-base">Specification: Asset Identifier, Asset Digest, and Asset Base</a> section.</li>
                     <li>compute
                         <span class="math">\(\mathsf{AssetBase}\)</span>
                      from
                         <span class="math">\(\mathsf{AssetDigest}\)</span>
-                     as decribed in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
+                     as decribed in the <a href="#specification-asset-identifier-asset-digest-and-asset-base">Specification: Asset Identifier, Asset Digest, and Asset Base</a> section.</li>
                     <li>set the
                         <span class="math">\(\mathsf{finalize}\)</span>
                      boolean as desired (if more issuance actions are to be created for this
@@ -604,7 +604,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         .</li>
                         <li>This
                             <span class="math">\(\mathsf{AssetBase}\)</span>
-                         MUST satisfy the derivation from the issuance validating key and asset description described in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</li>
+                         MUST satisfy the derivation from the issuance validating key and asset description described in the <a href="#specification-asset-identifier-asset-digest-and-asset-base">Specification: Asset Identifier, Asset Digest, and Asset Base</a> section.</li>
                         <li>It MUST be the case that
                             <span class="math">\(\mathsf{issued\_assets}_{\mathsf{OUT}}(\mathsf{AssetBase}).\mathsf{final} \neq 1\!\)</span>
                         .</li>
@@ -896,7 +896,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
         </section>
         <section id="security-and-privacy-considerations"><h2><span class="section-heading">Security and Privacy Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="displaying-asset-identifier-information-to-users"><h3><span class="section-heading">Displaying Asset Identifier information to users</span><span class="section-anchor"> <a rel="bookmark" href="#displaying-asset-identifier-information-to-users"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Wallets need to communicate the names of the Assets in a non-confusing way to users, since the byte representation of the Asset Identifier would be hard to read for an end user. Possible solutions are provided in the <a href="#specification-asset-identifier">Specification: Asset Identifier</a> section.</p>
+                <p>Wallets need to communicate the names of the Assets in a non-confusing way to users, since the byte representation of the Asset Identifier would be hard to read for an end user. Possible solutions are provided in the <a href="#specification-asset-identifier-asset-digest-and-asset-base">Specification: Asset Identifier, Asset Digest, and Asset Base</a> section.</p>
             </section>
             <section id="issuance-key-compromise"><h3><span class="section-heading">Issuance Key Compromise</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-key-compromise"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The design of this protocol does not currently allow for rotation of the issuance validating key that would allow for replacing the key of a specific Asset. In case of compromise, the following actions are recommended:</p>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -291,9 +291,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathsf{ik}\)</span>
                  be the issuance validating key of the issuer, a public key used to verify the signature on the issuance transaction's SIGHASH.</li>
             </ul>
-            <p>Define
-                <span class="math">\(\mathsf{AssetDigest_{AssetId}} := \textsf{BLAKE2b-512}(\texttt{“ZSA-Asset-Digest”},\; \mathsf{EncodeAssetId}(\mathsf{AssetId}))\!\)</span>
-            , where</p>
+            <p>Define</p>
+            <div class="math">\(\mathsf{AssetDigest_{AssetId}} := \textsf{BLAKE2b-512}(\texttt{“ZSA-Asset-Digest”},\; \mathsf{EncodeAssetId}(\mathsf{AssetId})),\)</div>
+            <p>where</p>
             <ul>
                 <li>
                     <span class="math">\(\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathtt{0x00} || \mathsf{ik} || \mathsf{asset\_desc}\!\!\)</span>
@@ -302,14 +302,13 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                     <span class="math">\(\mathtt{0x00}\)</span>
                  byte is a version byte.</li>
             </ul>
-            <p>Define
-                <span class="math">\(\mathsf{AssetBase_{AssetId}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}})\)</span>
-            </p>
-            <p>In the case of the OrchardZSA protocol, we define
-                <span class="math">\(\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})\)</span>
-             where
+            <p>Define</p>
+            <div class="math">\(\mathsf{AssetBase_{AssetId}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}})\)</div>
+            <p>In the case of the OrchardZSA protocol, we define</p>
+            <div class="math">\(\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})\)</div>
+            <p>where
                 <span class="math">\(\mathsf{GroupHash}^\mathbb{P}\)</span>
-             is defined as in <a id="footnote-reference-21" class="footnote_reference" href="#protocol-concretegrouphashpallasandvesta">29</a>.</p>
+             is defined as in <a id="footnote-reference-21" class="footnote_reference" href="#protocol-concretegrouphashpallasandvesta">30</a>.</p>
             <p>The relations between the Asset Identifier, Asset Digest, and Asset Base are shown in the following diagram:</p>
             <figure class="align-center" align="center">
                 <img width="600" src="assets/images/zip-0227-asset-identifier-relation.png" alt="" />
@@ -330,23 +329,22 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
         </section>
         <section id="specification-issue-note-issuance-action-issuance-bundle-and-issuance-protocol"><h2><span class="section-heading">Specification: Issue Note, Issuance Action, Issuance Bundle and Issuance Protocol</span><span class="section-anchor"> <a rel="bookmark" href="#specification-issue-note-issuance-action-issuance-bundle-and-issuance-protocol"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="issue-note"><h3><span class="section-heading">Issue Note</span><span class="section-anchor"> <a rel="bookmark" href="#issue-note"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The maximum total supply of any issued Custom Asset is denoted by the constant
-                    <span class="math">\(\mathsf{MAX\_ISSUE} := 2^{64} - 1\!\)</span>
-                .</p>
-                <p>An Issue Note represents that a value
-                    <span class="math">\(\mathsf{v} : \{0 .. \mathsf{MAX\_ISSUE}\}\)</span>
+                <p>Let
+                    <span class="math">\(\ell_{\mathsf{value}}\)</span>
+                 be as defined in §5.3 of the protocol specification <a id="footnote-reference-22" class="footnote_reference" href="#protocol-constants">29</a>. An Issue Note represents that a value
+                    <span class="math">\(\mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}\)</span>
                  of a specific Custom Asset is issued to a recipient. An Issue Note is a tuple
                     <span class="math">\((\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \mathsf{AssetBase}, \text{ρ}, \mathsf{rseed})\!\)</span>
                 , where:</p>
                 <ul>
                     <li>
                         <span class="math">\(\mathsf{d}: \mathbb{B}^{[\ell_{\mathsf{d}}]}\)</span>
-                     is the diversifier of the recipient's shielded payment address, as in §3.2 of the protocol specification <a id="footnote-reference-22" class="footnote_reference" href="#protocol-notes">26</a>.</li>
+                     is the diversifier of the recipient's shielded payment address, as in §3.2 of the protocol specification <a id="footnote-reference-23" class="footnote_reference" href="#protocol-notes">26</a>.</li>
                     <li>
                         <span class="math">\(\mathsf{pk_d}: \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public}\)</span>
-                     is the recipient's diversified transmission key, as in §3.2 of the protocol specification <a id="footnote-reference-23" class="footnote_reference" href="#protocol-notes">26</a>.</li>
+                     is the recipient's diversified transmission key, as in §3.2 of the protocol specification <a id="footnote-reference-24" class="footnote_reference" href="#protocol-notes">26</a>.</li>
                     <li>
-                        <span class="math">\(\mathsf{v} : \{0 .. \mathsf{MAX\_ISSUE}\}\)</span>
+                        <span class="math">\(\mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}\)</span>
                      is the value of the note in terms of the number of Asset tokens.</li>
                     <li>
                         <span class="math">\(\mathsf{AssetBase}: \mathbb{P}^*\)</span>
@@ -358,11 +356,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{rseed}: \mathbb{B}^{[\mathbb{Y}^{32}]}\)</span>
                      MUST be sampled uniformly at random by the issuer.</li>
                 </ul>
-                <p>The complete encoding of these fields into an <code>IssueNote</code> is defined in ZIP 230 <a id="footnote-reference-24" class="footnote_reference" href="#zip-0230-issue-note">16</a>.</p>
+                <p>The complete encoding of these fields into an <code>IssueNote</code> is defined in ZIP 230 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0230-issue-note">16</a>.</p>
                 <p>Let
                     <span class="math">\(\mathsf{Note^{Issue}}\)</span>
                  be the type of an Issue Note, i.e.</p>
-                <div class="math">\(\mathsf{Note^{Issue}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. \mathsf{MAX\_ISSUE}\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{B}^{[\mathbb{Y}^{32}]}.\)</div>
+                <div class="math">\(\mathsf{Note^{Issue}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. 2^{\ell_{\mathsf{value}}} - 1\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{B}^{[\mathbb{Y}^{32}]}.\)</div>
                 <p>The note commitments of Issue Notes are computed in the same manner as for OrchardZSA Notes. They will be added to the note commitment tree as any other shielded note when the transaction issuing the Asset is included on chain. This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.</p>
             </section>
             <section id="issuance-action"><h3><span class="section-heading">Issuance Action</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-action"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -382,7 +380,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <p>The
                     <span class="math">\(\mathsf{finalize}\)</span>
                  boolean is set by the Issuer to signal that there will be no further issuance of the specific Custom Asset. As we will see in <a href="#specification-consensus-rule-changes">Specification: Consensus Rule Changes</a>, transactions that attempt to issue further amounts of a Custom Asset that has previously been finalized will be rejected.</p>
-                <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0230-issuance-action-description">15</a>.</p>
+                <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0230-issuance-action-description">15</a>.</p>
             </section>
             <section id="issuance-bundle"><h3><span class="section-heading">Issuance Bundle</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-bundle"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance bundle is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:</p>
@@ -399,7 +397,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{isk}\!\)</span>
                     , that validates the issuance.</li>
                 </ul>
-                <p>The issuance bundle is added within the transaction format as a new bundle. The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0230-transaction-format">17</a>.</p>
+                <p>The issuance bundle is added within the transaction format as a new bundle. The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0230-transaction-format">17</a>.</p>
             </section>
             <section id="computation-of"><h3><span class="section-heading">Computation of ρ</span><span class="section-anchor"> <a rel="bookmark" href="#computation-of"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>We define a function
@@ -489,7 +487,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="specification-global-issuance-state"><h2><span class="section-heading">Specification: Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#specification-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>Issuance requires the following additions to the global state:</p>
+            <p>The maximum total supply of any issued Custom Asset is denoted by the constant
+                <span class="math">\(\mathsf{MAX\_ISSUE} := 2^{64} - 1\!\)</span>
+            . Issuance requires the following additions to the global state:</p>
             <p>A map,
                 <span class="math">\(\mathsf{issued\_assets} : \mathbb{P}^* \to \{0 .. \mathsf{MAX\_ISSUE}\} \times \mathbb{B}\!\)</span>
             , from the Asset Base,
@@ -560,7 +560,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 .</li>
                 <li>The
                     <span class="math">\(\mathsf{assetBurn}\)</span>
-                 set MUST satisfy the consensus rules specified in ZIP 226 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0226-assetburn">12</a>.</li>
+                 set MUST satisfy the consensus rules specified in ZIP 226 <a id="footnote-reference-28" class="footnote_reference" href="#zip-0226-assetburn">12</a>.</li>
                 <li>It MUST be the case that for all
                     <span class="math">\((\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}\!\)</span>
                 ,
@@ -574,7 +574,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 .</li>
                 <li>Let
                     <span class="math">\(\mathsf{SigHash}\)</span>
-                 be the SIGHASH transaction hash of this transaction, as defined in §4.10 of the protocol specification <a id="footnote-reference-28" class="footnote_reference" href="#protocol-sighash">28</a> with the modifications described in ZIP 226 <a id="footnote-reference-29" class="footnote_reference" href="#zip-0226-txiddigest">13</a>, using
+                 be the SIGHASH transaction hash of this transaction, as defined in §4.10 of the protocol specification <a id="footnote-reference-29" class="footnote_reference" href="#protocol-sighash">28</a> with the modifications described in ZIP 226 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0226-txiddigest">13</a>, using
                     <span class="math">\(\mathsf{SIGHASH\_ALL}\!\)</span>
                 .</li>
                 <li>If the transaction contains an Issuance Bundle, it MUST also contain at least one OrchardZSA Action.</li>
@@ -626,7 +626,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                                 .</li>
                                 <li>The node MUST compute the note commitment,
                                     <span class="math">\(\mathsf{cm}_{\mathsf{i,j}}\!\)</span>
-                                , as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-30" class="footnote_reference" href="#zip-0226-notestructure">11</a>.</li>
+                                , as defined in the Note Structure and Commitment section of ZIP 226 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0226-notestructure">11</a>.</li>
                             </ul>
                         </li>
                         <li>If
@@ -663,7 +663,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <li>We require non-zero fees in the presence of an issue bundle, in order to preclude the possibility of a transaction containing only an issue bundle. If a transaction includes only an issue bundle, the SIGHASH transaction hash would be computed solely based on the issue bundle. A duplicate bundle would have the same SIGHASH transaction hash, potentially allowing for a replay attack.</li>
             </ul>
             <section id="rationale-for-global-issuance-state"><h3><span class="section-heading">Rationale for Global Issuance State</span><span class="section-anchor"> <a rel="bookmark" href="#rationale-for-global-issuance-state"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 <a id="footnote-reference-31" class="footnote_reference" href="#zip-0209">8</a>. However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issued and burnt amounts for a given Asset. Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record based on the issuance and burn transactions processed. This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the transaction or block.</p>
+                <p>It is necessary to ensure that the balance of any issued Custom Asset never becomes negative within a shielded pool, along the lines of ZIP 209 <a id="footnote-reference-32" class="footnote_reference" href="#zip-0209">8</a>. However, unlike for the shielded ZEC pools, there is no individual transaction field that directly corresponds to both the issued and burnt amounts for a given Asset. Therefore, we require that all nodes maintain a record of the current amount in circulation for every issued Custom Asset, and update this record based on the issuance and burn transactions processed. This allows for efficient detection of balance violations for any Asset, in which scenario we specify a consensus rule to reject the transaction or block.</p>
                 <p>We limit the total issuance of any Asset to a maximum of
                     <span class="math">\(\mathsf{MAX\_ISSUE}\!\)</span>
                 . This is a practical limit that also allows an issuer to issue the complete supply of an Asset in a single transaction.</p>
@@ -676,7 +676,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <ul>
                     <li>By using the
                         <span class="math">\(\mathsf{finalize}\)</span>
-                     boolean and the burning mechanism defined in <a id="footnote-reference-32" class="footnote_reference" href="#zip-0226">10</a>, issuers can control the supply production of any Asset associated to their issuer keys. For example,
+                     boolean and the burning mechanism defined in <a id="footnote-reference-33" class="footnote_reference" href="#zip-0226">10</a>, issuers can control the supply production of any Asset associated to their issuer keys. For example,
                         <ul>
                             <li>by setting
                                 <span class="math">\(\mathsf{finalize} = 1\)</span>
@@ -709,7 +709,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="txid-digest-issuance"><h2><span class="section-heading">TxId Digest - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-33" class="footnote_reference" href="#zip-0226-txiddigest">13</a>. As in ZIP 244 <a id="footnote-reference-34" class="footnote_reference" href="#zip-0244">19</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
+            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-34" class="footnote_reference" href="#zip-0226-txiddigest">13</a>. As in ZIP 244 <a id="footnote-reference-35" class="footnote_reference" href="#zip-0244">19</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
             <p>A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below:</p>
             <pre>issuance_digest
 ├── issue_actions_digest
@@ -745,7 +745,7 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
                         <p>In case the transaction has no Issue Notes, ''issue_notes_digest'' is:</p>
                         <pre>BLAKE2b-256("ZTxIdIAcNoteHash", [])</pre>
                         <section id="t-5a-i-1-recipient"><h6><span class="section-heading">T.5a.i.1: recipient</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-1-recipient"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
-                            <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-35" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">30</a>.</p>
+                            <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-36" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">31</a>.</p>
                         </section>
                         <section id="t-5a-i-2-value"><h6><span class="section-heading">T.5a.i.2: value</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-2-value"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>Note value encoded as little-endian 8-byte representation of 64-bit unsigned integer (e.g. u64 in Rust) raw value.</p>
@@ -779,7 +779,7 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-36" class="footnote_reference" href="#zip-0244-sigdigest">20</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
+            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-37" class="footnote_reference" href="#zip-0244-sigdigest">20</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
             <p>The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
             <pre>signature_digest
 ├── header_digest
@@ -794,14 +794,14 @@ S.2: transparent_sig_digest (32-byte hash output)
 S.3: sapling_digest         (32-byte hash output)
 S.4: orchard_digest         (32-byte hash output)
 S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-37" class="footnote_reference" href="#zip-0244">19</a>.</p>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-38" class="footnote_reference" href="#zip-0244">19</a>.</p>
                 <section id="s-5-issuance-digest"><h4><span class="section-heading">S.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>Identical to that specified for the transaction identifier.</p>
                 </section>
             </section>
         </section>
         <section id="authorizing-data-commitment-issuance"><h2><span class="section-heading">Authorizing Data Commitment - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section covers the construction of the subtree of hashes in the authorizing data commitment that corresponds to issuance transaction data. Details of the overall changes to the authorizing data commitment due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-38" class="footnote_reference" href="#zip-0226-authcommitment">14</a>.</p>
+            <p>This section covers the construction of the subtree of hashes in the authorizing data commitment that corresponds to issuance transaction data. Details of the overall changes to the authorizing data commitment due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-39" class="footnote_reference" href="#zip-0226-authcommitment">14</a>.</p>
             <section id="a-4-issuance-auth-digest"><h3><span class="section-heading">A.4: issuance_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-4-issuance-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In the case that Issuance Actions are present, this is a BLAKE2b-256 hash of the field encoding of the <code>issueAuthSig</code> field of the transaction:</p>
                 <pre>A.4a: issueAuthSig            (field encoding bytes)</pre>
@@ -812,7 +812,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             </section>
         </section>
         <section id="orchardzsa-fee-calculation"><h2><span class="section-heading">OrchardZSA Fee Calculation</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-39" class="footnote_reference" href="#zip-0317-fee-calc">21</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
+            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-40" class="footnote_reference" href="#zip-0317-fee-calc">21</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
             <table>
                 <thead>
                     <tr>
@@ -866,7 +866,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-40" class="footnote_reference" href="#protocol-txnencoding">31</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-41" class="footnote_reference" href="#zip-0317-fee-calc">21</a>. Note that
+            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-41" class="footnote_reference" href="#protocol-txnencoding">32</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-42" class="footnote_reference" href="#zip-0317-fee-calc">21</a>. Note that
                 <span class="math">\(nOrchardActions\!\)</span>
             , that is used in the computation of
                 <span class="math">\(logical\_actions\!\)</span>
@@ -911,7 +911,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 </ul>
             </section>
             <section id="bridging-assets"><h3><span class="section-heading">Bridging Assets</span><span class="section-anchor"> <a rel="bookmark" href="#bridging-assets"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-42" class="footnote_reference" href="#zip-0226">10</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
+                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-43" class="footnote_reference" href="#zip-0226">10</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
             </section>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -925,7 +925,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                  in order to properly keep track of the total supply for different Asset Identifiers. This is useful for wallets and other applications that need to keep track of the total supply of Assets.</p>
             </section>
             <section id="fee-structures"><h3><span class="section-heading">Fee Structures</span><span class="section-anchor"> <a rel="bookmark" href="#fee-structures"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 <a id="footnote-reference-43" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">18</a>.</p>
+                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 <a id="footnote-reference-44" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">18</a>.</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -1167,10 +1167,18 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="protocol-concretegrouphashpallasandvesta" class="footnote">
+            <table id="protocol-constants" class="footnote">
                 <tbody>
                     <tr>
                         <th>29</th>
+                        <td><a href="protocol/protocol.pdf#constants">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.3: Constants</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol-concretegrouphashpallasandvesta" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>30</th>
                         <td><a href="protocol/protocol.pdf#concretegrouphashpallasandvesta">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.8: Group Hash into Pallas and Vesta</a></td>
                     </tr>
                 </tbody>
@@ -1178,7 +1186,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-orchardpaymentaddrencoding" class="footnote">
                 <tbody>
                     <tr>
-                        <th>30</th>
+                        <th>31</th>
                         <td><a href="protocol/protocol.pdf#orchardpaymentaddrencoding">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.6.4.2: Orchard Raw Payment Addresses</a></td>
                     </tr>
                 </tbody>
@@ -1186,7 +1194,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="protocol-txnencoding" class="footnote">
                 <tbody>
                     <tr>
-                        <th>31</th>
+                        <th>32</th>
                         <td><a href="protocol/protocol.pdf#txnencoding">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.1: Transaction Encoding and Consensus</a></td>
                     </tr>
                 </tbody>

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -86,15 +86,22 @@ In future network and protocol upgrades, the same Asset description string can b
 Note Structure & Commitment
 ---------------------------
 
-Let $\mathsf{Note^{OrchardZSA}}$ be the type of a OrchardZSA note, i.e.
-$\mathsf{Note^{OrchardZSA}} := \mathsf{Note^{Orchard}} \times \mathbb{P}^*$.
-
-An OrchardZSA note differs from an Orchard note [#protocol-notes]_ by additionally including the Asset Base, $\mathsf{AssetBase}$. So an OrchardZSA note is a tuple $(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \text{ρ}, \text{ψ}, \mathsf{AssetBase})$,
+An OrchardZSA note differs from an Orchard note [#protocol-notes]_ by additionally including the Asset Base, $\mathsf{AssetBase}$. So an OrchardZSA note is a tuple $(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \mathsf{AssetBase}, \text{ρ}, \text{ψ}, \mathsf{rcm})$,
 where
 
 - $\mathsf{AssetBase} : \mathbb{P}^*$ is the unique element of the Pallas group [#protocol-pallasandvesta]_ that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 [#zip-0227]_, a valid group element that is not the identity and is not $\bot$. The byte representation of the Asset Base is defined as $\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
+- The remaining terms are as defined in §3.2 of the protocol specification [#protocol-notes]_.
 
 Note that the above assumes a canonical encoding, which is true for the Pallas group, but may not hold for future shielded protocols.
+
+Let $\mathsf{Note^{OrchardZSA}}$ be the type of a OrchardZSA note, i.e.
+
+.. math:: \mathsf{Note^{OrchardZSA}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. 2^{\ell_{\mathsf{value}}} - 1\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathsf{NoteCommit^{Orchard}.Trapdoor}, 
+
+where $\mathbb{P}^*$ is the Pallas group excluding the identity element, and the other types are as defined in §3.2 of the protocol specification [#protocol-notes]_.
+
+**Non-normative note:** 
+The type and definition of the OrchardZSA note reflect that it is a tuple of all the components of an Orchard note, with the addition of the Asset Base into the tuple. 
 
 We define the note commitment scheme $\mathsf{NoteCommit^{OrchardZSA}_{rcm}}$ as follows:
 

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -89,7 +89,7 @@ Note Structure & Commitment
 An OrchardZSA note differs from an Orchard note [#protocol-notes]_ by additionally including the Asset Base, $\mathsf{AssetBase}$. So an OrchardZSA note is a tuple $(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \mathsf{AssetBase}, \text{ρ}, \text{ψ}, \mathsf{rcm})$,
 where
 
-- $\mathsf{AssetBase} : \mathbb{P}^*$ is the unique element of the Pallas group [#protocol-pallasandvesta]_ that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 [#zip-0227]_, a valid group element that is not the identity and is not $\bot$. The byte representation of the Asset Base is defined as $\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
+- $\mathsf{AssetBase} : \mathbb{P}^*$ is the unique element of the Pallas group [#protocol-pallasandvesta]_ that identifies each Asset in the Orchard protocol, defined as the Asset Base in ZIP 227 [#zip-0227-assetidentifier]_, a valid group element that is not the identity and is not $\bot$. The byte representation of the Asset Base is defined as $\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]} := \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
 - The remaining terms are as defined in §3.2 of the protocol specification [#protocol-notes]_.
 
 Note that the above assumes a canonical encoding, which is true for the Pallas group, but may not hold for future shielded protocols.
@@ -598,7 +598,7 @@ References
 .. [#zip-0224] `ZIP 224: Orchard <zip-0224.html>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.html>`_
 .. [#zip-0227-specification-global-issuance-state] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Global Issuance State <zip-0227.html#specification-global-issuance-state>`_
-.. [#zip-0227-assetidentifier] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier <zip-0227.html#specification-asset-identifier>`_
+.. [#zip-0227-assetidentifier] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Asset Identifier <zip-0227.html#specification-asset-identifier-asset-digest-and-asset-base>`_
 .. [#zip-0227-consensus] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Consensus Rule Changes <zip-0227.html#specification-consensus-rule-changes>`_
 .. [#zip-0227-txiddigest] `ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance <zip-0227.html#txid-digest-issuance>`_
 .. [#zip-0227-sigdigest] `ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest <zip-0227.html#signature-digest>`_

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -30,7 +30,7 @@ ZIP 224 [#zip-0224]_.
 
 We define the following additional terms:
 
-- Asset: A type of note that can be transferred on the Zcash blockchain. Each Asset is identified by an Asset Identifier `Specification: Asset Identifier`_.
+- Asset: A type of note that can be transferred on the Zcash blockchain. Each Asset is identified by an Asset Identifier `Specification: Asset Identifier, Asset Digest, and Asset Base`_.
 
   - ZEC is the default (and currently the only defined) Asset for the Zcash mainnet.
   - TAZ is the default (and currently the only defined) Asset for the Zcash testnet.
@@ -182,8 +182,8 @@ Define $\mathsf{IssueAuthSig.Validate} \;{\small â¦‚}\; (\mathsf{ik} \;{\small â
 
 where the $\mathsf{Verify}$ algorithm is defined in BIP 340 [#bip-0340]_.
 
-Specification: Asset Identifier
-===============================
+Specification: Asset Identifier, Asset Digest, and Asset Base
+=============================================================
 
 For every new Asset, there MUST be a new and unique Asset Identifier, denoted $\mathsf{AssetId}$. We define this to be a globally unique pair $\mathsf{AssetId} := (\mathsf{ik}, \mathsf{asset\_desc})$, where $\mathsf{ik}$ is the issuance key and $\mathsf{asset\_desc}$ is a byte string.
 
@@ -259,7 +259,7 @@ Issuance Action
 An issuance action, ``IssueAction``, is the instance of issuing a specific Custom Asset, and contains the following fields:
 
 - ``assetDescSize``: the size of the Asset description, a number between $0$ and $512$.
-- ``asset_desc``: the Asset description, a byte string of up to 512 bytes as defined in the `Specification: Asset Identifier`_ section.
+- ``asset_desc``: the Asset description, a byte string of up to 512 bytes as defined in the `Specification: Asset Identifier, Asset Digest, and Asset Base`_ section.
 - ``vNotes``: an array of Issue Notes containing the unencrypted output notes to the recipients of the Asset.
 - ``flagsIssuance``: a byte that stores the $\mathsf{finalize}$ boolean that defines whether the issuance of that specific Custom Asset is finalized or not.
 
@@ -309,8 +309,8 @@ The issuer program performs the following operations:
 For all actions ``IssueAction``:
 
 - encode $\mathsf{asset\_desc}$ as a UTF-8 byte string of size up to 512.
-- compute $\mathsf{AssetDigest}$ from the issuance validating key $\mathsf{ik}$ and $\mathsf{asset\_desc}$ as decribed in the `Specification: Asset Identifier`_ section.
-- compute $\mathsf{AssetBase}$ from $\mathsf{AssetDigest}$ as decribed in the `Specification: Asset Identifier`_ section.
+- compute $\mathsf{AssetDigest}$ from the issuance validating key $\mathsf{ik}$ and $\mathsf{asset\_desc}$ as decribed in the `Specification: Asset Identifier, Asset Digest, and Asset Base`_ section.
+- compute $\mathsf{AssetBase}$ from $\mathsf{AssetDigest}$ as decribed in the `Specification: Asset Identifier, Asset Digest, and Asset Base`_ section.
 - set the $\mathsf{finalize}$ boolean as desired (if more issuance actions are to be created for this $\mathsf{AssetBase}$, set $\mathsf{finalize} = 0$, otherwise set $\mathsf{finalize} = 1$).
 - for each recipient $i$:
 
@@ -376,7 +376,7 @@ For every transaction:
   - It MUST be the case that $0 < \mathtt{assetDescSize} \leq 512$.
   - It MUST be the case that $\mathsf{asset\_desc}$ is a string of length $\mathtt{assetDescSize}$ bytes.
   - Elements of every Issue Note in ``IssueAction`` MUST be valid encodings of the types given in the `Issue Note`_ section, and MUST encode the same $\mathsf{AssetBase}$. 
-  - This $\mathsf{AssetBase}$ MUST satisfy the derivation from the issuance validating key and asset description described in the `Specification: Asset Identifier`_ section.
+  - This $\mathsf{AssetBase}$ MUST satisfy the derivation from the issuance validating key and asset description described in the `Specification: Asset Identifier, Asset Digest, and Asset Base`_ section.
   - It MUST be the case that $\mathsf{issued\_assets}_{\mathsf{OUT}}(\mathsf{AssetBase}).\mathsf{final} \neq 1$.
   - For every issue note description ($\mathsf{note}_{\mathsf{j}},\ 1 \leq j \leq \mathtt{nNotes}$) in ``IssueAction``:
 
@@ -663,7 +663,7 @@ Security and Privacy Considerations
 Displaying Asset Identifier information to users
 ------------------------------------------------
 
-Wallets need to communicate the names of the Assets in a non-confusing way to users, since the byte representation of the Asset Identifier would be hard to read for an end user. Possible solutions are provided in the `Specification: Asset Identifier`_ section.
+Wallets need to communicate the names of the Assets in a non-confusing way to users, since the byte representation of the Asset Identifier would be hard to read for an end user. Possible solutions are provided in the `Specification: Asset Identifier, Asset Digest, and Asset Base`_ section.
 
 Issuance Key Compromise
 -----------------------

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -244,6 +244,14 @@ An Issue Note is a tuple $(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \mathsf{AssetB
 
 The complete encoding of these fields into an ``IssueNote`` is defined in ZIP 230 [#zip-0230-issue-note]_.
 
+Let $\mathsf{Note^{Issue}}$ be the type of an Issue Note, i.e.
+
+.. math:: \mathsf{Note^{Issue}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. \mathsf{MAX\_ISSUE}\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{B}^{[\mathbb{Y}^{32}]}. 
+
+The note commitments of Issue Notes are computed in the same manner as for OrchardZSA Notes.
+They will be added to the note commitment tree as any other shielded note when the transaction issuing the Asset is included on chain. 
+This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.
+
 
 Issuance Action
 ---------------
@@ -260,8 +268,6 @@ As we will see in `Specification: Consensus Rule Changes`_, transactions that at
 
 The complete encoding of these fields into an ``IssueAction`` is defined in ZIP 230 [#zip-0230-issuance-action-description]_.
 
-We note that when the issued note commitments are added to the global state of the chain, they will be added to the note commitment tree as any other shielded note. 
-This prevents future usage of the note from being linked to the issuance transaction, as the nullifier key is not known to the validators and chain observers.
 
 Issuance Bundle
 ---------------

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -195,15 +195,23 @@ Let
 - $\mathsf{asset\_desc}$ be the asset description, which includes any information pertaining to the issuance, and is a byte sequence of up to 512 bytes which SHOULD be a well-formed UTF-8 code unit sequence according to Unicode 15.0.0 or later.
 - $\mathsf{ik}$ be the issuance validating key of the issuer, a public key used to verify the signature on the issuance transaction's SIGHASH.
 
-Define $\mathsf{AssetDigest_{AssetId}} := \textsf{BLAKE2b-512}(\texttt{“ZSA-Asset-Digest”},\; \mathsf{EncodeAssetId}(\mathsf{AssetId}))$,
+Define 
+
+.. math:: \mathsf{AssetDigest_{AssetId}} := \textsf{BLAKE2b-512}(\texttt{“ZSA-Asset-Digest”},\; \mathsf{EncodeAssetId}(\mathsf{AssetId})),
+
 where
 
 - $\mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{ik}, \mathsf{asset\_desc})) := \mathtt{0x00} || \mathsf{ik} || \mathsf{asset\_desc}\!$.
 - Note that the initial $\mathtt{0x00}$ byte is a version byte.
 
-Define $\mathsf{AssetBase_{AssetId}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}})$
+Define 
 
-In the case of the OrchardZSA protocol, we define $\mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})$
+.. math:: \mathsf{AssetBase_{AssetId}} := \mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}})
+
+In the case of the OrchardZSA protocol, we define 
+
+.. math:: \mathsf{ZSAValueBase}(\mathsf{AssetDigest_{AssetId}}) := \mathsf{GroupHash}^\mathbb{P}(\texttt{"z.cash:OrchardZSA"}, \mathsf{AssetDigest_{AssetId}})
+
 where $\mathsf{GroupHash}^\mathbb{P}$ is defined as in [#protocol-concretegrouphashpallasandvesta]_.
 
 The relations between the Asset Identifier, Asset Digest, and Asset Base are shown in the following diagram:
@@ -230,14 +238,13 @@ Specification: Issue Note, Issuance Action, Issuance Bundle and Issuance Protoco
 Issue Note
 ----------
 
-The maximum total supply of any issued Custom Asset is denoted by the constant $\mathsf{MAX\_ISSUE} := 2^{64} - 1$. 
-
-An Issue Note represents that a value $\mathsf{v} : \{0 .. \mathsf{MAX\_ISSUE}\}$ of a specific Custom Asset is issued to a recipient.
+Let $\ell_{\mathsf{value}}$ be as defined in §5.3 of the protocol specification [#protocol-constants]_.
+An Issue Note represents that a value $\mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}$ of a specific Custom Asset is issued to a recipient.
 An Issue Note is a tuple $(\mathsf{d}, \mathsf{pk_d}, \mathsf{v}, \mathsf{AssetBase}, \text{ρ}, \mathsf{rseed})$, where:
 
 - $\mathsf{d}: \mathbb{B}^{[\ell_{\mathsf{d}}]}$ is the diversifier of the recipient's shielded payment address, as in §3.2 of the protocol specification [#protocol-notes]_.
 - $\mathsf{pk_d}: \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public}$ is the recipient's diversified transmission key, as in §3.2 of the protocol specification [#protocol-notes]_.
-- $\mathsf{v} : \{0 .. \mathsf{MAX\_ISSUE}\}$ is the value of the note in terms of the number of Asset tokens.
+- $\mathsf{v} : \{0 .. 2^{\ell_{\mathsf{value}}} - 1\}$ is the value of the note in terms of the number of Asset tokens.
 - $\mathsf{AssetBase}: \mathbb{P}^*$ is the Asset Base corresponding to the ZSA being issued in the Issue Note.
 - $\text{ρ}: \mathbb{F}_{q_{\mathbb{P}}}$ is used to derive the nullifier of the note, and is computed as in `Computation of ρ`_.
 - $\mathsf{rseed}: \mathbb{B}^{[\mathbb{Y}^{32}]}$ MUST be sampled uniformly at random by the issuer.
@@ -246,7 +253,7 @@ The complete encoding of these fields into an ``IssueNote`` is defined in ZIP 23
 
 Let $\mathsf{Note^{Issue}}$ be the type of an Issue Note, i.e.
 
-.. math:: \mathsf{Note^{Issue}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. \mathsf{MAX\_ISSUE}\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{B}^{[\mathbb{Y}^{32}]}. 
+.. math:: \mathsf{Note^{Issue}} := \mathbb{B}^{[\ell_{\mathsf{d}}]} \times \mathsf{KA}^{\mathsf{Orchard}}.\mathsf{Public} \times \{0 .. 2^{\ell_{\mathsf{value}}} - 1\} \times \mathbb{P}^* \times \mathbb{F}_{q_{\mathbb{P}}} \times \mathbb{B}^{[\mathbb{Y}^{32}]}. 
 
 The note commitments of Issue Notes are computed in the same manner as for OrchardZSA Notes.
 They will be added to the note commitment tree as any other shielded note when the transaction issuing the Asset is included on chain. 
@@ -331,6 +338,7 @@ For the ``IssueBundle``:
 Specification: Global Issuance State
 ====================================
 
+The maximum total supply of any issued Custom Asset is denoted by the constant $\mathsf{MAX\_ISSUE} := 2^{64} - 1$. 
 Issuance requires the following additions to the global state:
 
 A map, $\mathsf{issued\_assets} : \mathbb{P}^* \to \{0 .. \mathsf{MAX\_ISSUE}\} \times \mathbb{B}$, from the Asset Base, $\mathsf{AssetBase} : \mathbb{P}^*$, to a tuple $(\mathsf{balance}, \mathsf{final})$, for every Asset that has been issued.
@@ -739,6 +747,7 @@ References
 .. [#protocol-notes] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
 .. [#protocol-orchardkeycomponents] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.2.3: Orchard Key Components <protocol/protocol.pdf#orchardkeycomponents>`_
 .. [#protocol-sighash] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.10: SIGHASH Transaction Hashing <protocol/protocol.pdf#sighash>`_
+.. [#protocol-constants] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.3: Constants <protocol/protocol.pdf#constants>`_
 .. [#protocol-concretegrouphashpallasandvesta] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.4.9.8: Group Hash into Pallas and Vesta <protocol/protocol.pdf#concretegrouphashpallasandvesta>`_
 .. [#protocol-orchardpaymentaddrencoding] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 5.6.4.2: Orchard Raw Payment Addresses <protocol/protocol.pdf#orchardpaymentaddrencoding>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_


### PR DESCRIPTION
This adjusts the type and specification of the notes to mirror the implementation, specifically that the Asset Base occurs in the middle of the tuple, and not at the end.