### PR TITLE
Updating digest names

### DIFF
--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -586,7 +586,7 @@ A.3b: bindingSigOrchard                      (field encoding bytes)</pre>
                     <p>In case that the transaction has no OrchardZSA Action Groups, <code>orchard_zsa_auth_digest</code> is:</p>
                     <pre>BLAKE2b-256("ZTxAuthOrchaHash", [])</pre>
                     <section id="a-3a-orchard-zsa-action-groups-auth-digest"><h5><span class="section-heading">A.3a: orchard_zsa_action_groups_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-3a-orchard-zsa-action-groups-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>This is a BLAKE2b-256 hash of the <code>proofsOrchard</code> and <code>spendAuthSigsOrchard</code> fields of all OrchardZSA Action Groups belonging to the transaction:</p>
+                        <p>This is a BLAKE2b-256 hash of the <code>proofsOrchard</code> field of all OrchardZSA Action Groups belonging to the transaction; followed by the <code>spendAuthSigsOrchard</code> fields corresponding to every OrchardZSA Action in the OrchardZSA Action Group, for all OrchardZSA Action Groups belonging to the transaction:</p>
                         <pre>A.3a.i:  proofsOrchard               (field encoding bytes)
 A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -459,59 +459,59 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="orchardzsa-transaction-structure"><h2><span class="section-heading">OrchardZSA Transaction Structure</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-transaction-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0230">14</a>.</p>
+            <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0230">13</a>.</p>
         </section>
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0244">15</a> is modified by the OrchardZSA protocol to add a new branch for issuance information, along with modifications within the <code>orchard_digest</code> to account for the inclusion of the Asset Base. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the OrchardZSA protocol.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0244">14</a> is modified by the OrchardZSA protocol to add a new branch for issuance information, along with replacement of the <code>orchard_digest</code> with a new <code>orchard_zsa_digest</code> to account for the inclusion of the Asset Base and the updated transaction format. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the OrchardZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values:</p>
                 <pre>T.1: header_digest       (32-byte hash output)
 T.2: transparent_digest  (32-byte hash output)
 T.3: sapling_digest      (32-byte hash output)
-T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
+T.4: orchard_zsa_digest  (32-byte hash output)  [ADDED FOR ZSA]
 T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0244">15</a>.</p>
-                <section id="t-4-orchard-digest"><h4><span class="section-heading">T.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-54" class="footnote_reference" href="#zip-0244">14</a>.</p>
+                <section id="t-4-orchard-zsa-digest"><h4><span class="section-heading">T.4: orchard_zsa_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4-orchard-zsa-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>When OrchardZSA Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values:</p>
-                    <pre>T.4a: orchard_action_groups_digest   (32-byte hash output)          [ADDED FOR ZSA]
-T.4c: valueBalanceOrchard            (64-bit signed little-endian)</pre>
-                    <p>The personalization field of this hash is the same as in ZIP 244 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0244">15</a></p>
+                    <pre>T.4a: orchard_zsa_action_groups_digest   (32-byte hash output)
+T.4b: valueBalanceOrchard                (64-bit signed little-endian)</pre>
+                    <p>The personalization field of this hash is the same as for <code>orchard_digest</code> in ZIP 244 <a id="footnote-reference-55" class="footnote_reference" href="#zip-0244">14</a></p>
                     <pre>"ZTxIdOrchardHash"</pre>
-                    <p>In the case that the transaction has no OrchardZSA Action Groups, <code>orchard_digest</code> is</p>
+                    <p>In the case that the transaction has no OrchardZSA Action Groups, <code>orchard_zsa_digest</code> is</p>
                     <pre>BLAKE2b-256("ZTxIdOrchardHash", [])</pre>
-                    <section id="t-4a-orchard-action-groups-digest"><h5><span class="section-heading">T.4a: orchard_action_groups_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-action-groups-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                    <section id="t-4a-orchard-zsa-action-groups-digest"><h5><span class="section-heading">T.4a: orchard_zsa_action_groups_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-orchard-zsa-action-groups-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action Groups information for all OrchardZSA Action Groups belonging to the transaction. For each Action Group, the following elements are included in the hash:</p>
-                        <pre>T.4a.i   : orchard_actions_compact_digest      (32-byte hash output)
-T.4a.ii  : orchard_actions_memos_digest        (32-byte hash output)
-T.4a.iii : orchard_actions_noncompact_digest   (32-byte hash output)
+                        <pre>T.4a.i   : orchard_zsa_actions_compact_digest      (32-byte hash output)
+T.4a.ii  : orchard_zsa_actions_memos_digest        (32-byte hash output)
+T.4a.iii : orchard_zsa_actions_noncompact_digest   (32-byte hash output)
 T.4a.iv  : orchard_zsa_burn_digest             (32-byte hash output)
-T.4a.v   : flagsOrchard                        (1 byte)
-T.4a.vi  : anchorOrchard                       (32 bytes)
-T.4a.vii : nAGExpiryHeight                     (4 bytes)</pre>
+T.4a.v   : flagsOrchard                            (1 byte)
+T.4a.vi  : anchorOrchard                           (32 bytes)
+T.4a.vii : nAGExpiryHeight                         (4 bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcActGHash"</pre>
-                        <section id="t-4a-i-orchard-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                        <section id="t-4a-i-orchard-zsa-actions-compact-digest"><h6><span class="section-heading">T.4a.i: orchard_zsa_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-i-orchard-zsa-actions-compact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in an updated version of the ZIP-307 <a id="footnote-reference-56" class="footnote_reference" href="#zip-0307">17</a> <code>CompactBlock</code> format for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.i.1 : nullifier            (field encoding bytes)
 T.4a.i.2 : cmx                  (field encoding bytes)
 T.4a.i.3 : ephemeralKey         (field encoding bytes)
-T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR ZSA]</pre>
-                            <p>The personalization field of this hash is the same as in ZIP 244:</p>
+T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)</pre>
+                            <p>The personalization field of this hash is the same as for <code>orchard_actions_compact_digest</code> in ZIP 244:</p>
                             <pre>"ZTxIdOrcActCHash"</pre>
                         </section>
-                        <section id="t-4a-ii-orchard-actions-memos-digest"><h6><span class="section-heading">T.4a.ii: orchard_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-ii-orchard-actions-memos-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                        <section id="t-4a-ii-orchard-zsa-actions-memos-digest"><h6><span class="section-heading">T.4a.ii: orchard_zsa_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-ii-orchard-zsa-actions-memos-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
-                            <pre>T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]</pre>
-                            <p>The personalization field of this hash remains identical to ZIP 244:</p>
+                            <pre>T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)</pre>
+                            <p>The personalization field of this hash is identical to that for <code>orchard_actions_memos_digest</code> in ZIP 244:</p>
                             <pre>"ZTxIdOrcActMHash"</pre>
                         </section>
-                        <section id="t-4a-iii-orchard-actions-noncompact-digest"><h6><span class="section-heading">T.4a.iii: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iii-orchard-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
+                        <section id="t-4a-iii-orchard-zsa-actions-noncompact-digest"><h6><span class="section-heading">T.4a.iii: orchard_zsa_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iii-orchard-zsa-actions-noncompact-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="footnote-reference-57" class="footnote_reference" href="#zip-0307">17</a> <code>CompactBlock</code> format, for all OrchardZSA Actions belonging to the Action Group. For each Action, the following elements are included in the hash:</p>
                             <pre>T.4a.iii.1 : cv                    (field encoding bytes)
 T.4a.iii.2 : rk                    (field encoding bytes)
-T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
+T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)
 T.4a.iii.4 : outCiphertext         (field encoding bytes)</pre>
-                            <p>The personalization field of this hash is defined identically to ZIP 244:</p>
+                            <p>The personalization field of this hash is defined just as for <code>orchard_actions_noncompact_digest</code> in ZIP 244:</p>
                             <pre>"ZTxIdOrcActNHash"</pre>
                         </section>
                         <section id="t-4a-iv-orchard-zsa-burn-digest"><h6><span class="section-heading">T.4a.iv: orchard_zsa_burn_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4a-iv-orchard-zsa-burn-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
@@ -524,7 +524,7 @@ T.4a.iv.2 : valueBurn    (field encoding bytes)</pre>
                             <pre>"ZTxIdOrcBurnHash"</pre>
                             <p>In case the transaction does not perform the burning of any Assets (i.e. the
                                 <span class="math">\(\mathsf{assetBurn}\)</span>
-                             set is empty), the ''orchard_zsa_burn_digest'' is:</p>
+                             set is empty), the <code>orchard_zsa_burn_digest</code> is:</p>
                             <pre>BLAKE2b-256("ZTxIdOrcBurnHash", [])</pre>
                         </section>
                     </section>
@@ -535,10 +535,34 @@ T.4a.iv.2 : valueBurn    (field encoding bytes)</pre>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The details of the changes to this algorithm are in ZIP 227 <a id="footnote-reference-59" class="footnote_reference" href="#zip-0227-sigdigest">11</a>.</p>
+            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-59" class="footnote_reference" href="#zip-0244-sigdigest">15</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each OrchardZSA Action, and additionally for each Issuance Action. The modifications replace the <code>orchard_digest</code> in ZIP 244 with a new <code>orchard_zsa_digest</code>, and add a new branch, <code>issuance_digest</code>, for the Issuance Action information.</p>
+            <p>The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
+            <pre>signature_digest
+├── header_digest
+├── transparent_sig_digest
+├── sapling_digest
+├── orchard_zsa_digest      [ADDED FOR ZSA]
+└── issuance_digest         [ADDED FOR ZSA]</pre>
+            <section id="signature-digest-1"><h3><span class="section-heading">signature_digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>A BLAKE2b-256 hash of the following values</p>
+                <pre>S.1: header_digest          (32-byte hash output)
+S.2: transparent_sig_digest (32-byte hash output)
+S.3: sapling_digest         (32-byte hash output)
+S.4: orchard_zsa_digest     (32-byte hash output)  [ADDED FOR ZSA]
+S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
+                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-60" class="footnote_reference" href="#zip-0244">14</a>, namely:</p>
+                <pre>"ZcashTxHash_" || CONSENSUS_BRANCH_ID</pre>
+                <p><code>ZcashTxHash_</code> has 1 underscore character.</p>
+                <section id="s-4-orchard-zsa-digest"><h4><span class="section-heading">S.4: orchard_zsa_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-4-orchard-zsa-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>Identical to that specified for the transaction identifier.</p>
+                </section>
+                <section id="s-5-issuance-digest"><h4><span class="section-heading">S.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>Identical to the <code>issuance_digest</code> specified for the transaction identifier in ZIP 227 <a id="citation-reference-1" class="citation_reference" href="#zip-0227-txiddigest">zip-0227-txiddigest</a>.</p>
+                </section>
+            </section>
         </section>
         <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-60" class="footnote_reference" href="#zip-0244-authcommitment">16</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section. There is a new branch added for issuance information, along with modifications within the <code>orchard_auth_digest</code> to account for the presence of Action Groups.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-61" class="footnote_reference" href="#zip-0244-authcommitment">16</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section. There is a new branch added for issuance information, along with modifications within the <code>orchard_auth_digest</code> to account for the presence of Action Groups.</p>
             <p>We highlight the changes for the OrchardZSA protocol via the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
             <pre>auth_digest
 ├── transparent_scripts_digest
@@ -570,7 +594,7 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
                     </section>
                 </section>
                 <section id="a-4-issuance-auth-digest"><h4><span class="section-heading">A.4: issuance_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-4-issuance-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-61" class="footnote_reference" href="#zip-0227-authcommitment">12</a>.</p>
+                    <p>The details of the computation of this value are in ZIP 227 <a id="footnote-reference-62" class="footnote_reference" href="#zip-0227-authcommitment">11</a>.</p>
                 </section>
             </section>
         </section>
@@ -585,7 +609,7 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="transaction-fees"><h3><span class="section-heading">Transaction Fees</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-fees"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 227 <a id="footnote-reference-62" class="footnote_reference" href="#zip-0227-orchardzsa-fee-calculation">13</a>.</p>
+                <p>The fee mechanism for the upgrades proposed in this ZIP will follow the mechanism described in ZIP 317 for the OrchardZSA protocol upgrade, and are described in ZIP 227 <a id="footnote-reference-63" class="footnote_reference" href="#zip-0227-orchardzsa-fee-calculation">12</a>.</p>
             </section>
             <section id="backward-compatibility"><h3><span class="section-heading">Backward Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In order to have backward compatibility with the ZEC notes, we have designed the circuit to support both ZEC and OrchardZSA notes. As we specify above, there are three main reasons we can do this:</p>
@@ -696,18 +720,10 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0227-sigdigest" class="footnote">
-                <tbody>
-                    <tr>
-                        <th>11</th>
-                        <td><a href="zip-0227.html#signature-digest">ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest</a></td>
-                    </tr>
-                </tbody>
-            </table>
             <table id="zip-0227-authcommitment" class="footnote">
                 <tbody>
                     <tr>
-                        <th>12</th>
+                        <th>11</th>
                         <td><a href="zip-0227.html#authorizing-data-commitment-issuance">ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
@@ -715,7 +731,7 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
             <table id="zip-0227-orchardzsa-fee-calculation" class="footnote">
                 <tbody>
                     <tr>
-                        <th>13</th>
+                        <th>12</th>
                         <td><a href="zip-0227.html#orchardzsa-fee-calculation">ZIP 227: Issuance of Zcash Shielded Assets: OrchardZSA Fee Calculation</a></td>
                     </tr>
                 </tbody>
@@ -723,7 +739,7 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
             <table id="zip-0230" class="footnote">
                 <tbody>
                     <tr>
-                        <th>14</th>
+                        <th>13</th>
                         <td><a href="zip-0230.html">ZIP 230: Version 6 Transaction Format</a></td>
                     </tr>
                 </tbody>
@@ -731,8 +747,16 @@ A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>15</th>
+                        <th>14</th>
                         <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0244-sigdigest" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>15</th>
+                        <td><a href="zip-0244.html#signature-digest">ZIP 244: Transaction Identifier Non-Malleability: Signature Digest</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -484,7 +484,7 @@ T.4b: valueBalanceOrchard                (64-bit signed little-endian)</pre>
                         <pre>T.4a.i   : orchard_zsa_actions_compact_digest      (32-byte hash output)
 T.4a.ii  : orchard_zsa_actions_memos_digest        (32-byte hash output)
 T.4a.iii : orchard_zsa_actions_noncompact_digest   (32-byte hash output)
-T.4a.iv  : orchard_zsa_burn_digest             (32-byte hash output)
+T.4a.iv  : orchard_zsa_burn_digest                 (32-byte hash output)
 T.4a.v   : flagsOrchard                            (1 byte)
 T.4a.vi  : anchorOrchard                           (32 bytes)
 T.4a.vii : nAGExpiryHeight                         (4 bytes)</pre>

--- a/rendered/zip-0226.html
+++ b/rendered/zip-0226.html
@@ -462,7 +462,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             <p>The transaction format for v6 transactions is described in ZIP 230 <a id="footnote-reference-52" class="footnote_reference" href="#zip-0230">13</a>.</p>
         </section>
         <section id="txid-digest"><h2><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0244">14</a> is modified by the OrchardZSA protocol to add a new branch for issuance information, along with replacement of the <code>orchard_digest</code> with a new <code>orchard_zsa_digest</code> to account for the inclusion of the Asset Base and the updated transaction format. The details of these changes are described in this section, and highlighted using the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the OrchardZSA protocol.</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-53" class="footnote_reference" href="#zip-0244">14</a> is modified by the OrchardZSA protocol to add a new branch for issuance information, along with replacement of the <code>orchard_digest</code> with a new <code>orchard_zsa_digest</code> to account for the inclusion of the Asset Base and the updated transaction format. The details of these changes are described in this section, and highlighted using the <code>[ADDED FOR ZSA]</code> text label. We omit the details of the sections that do not change for the OrchardZSA protocol.</p>
             <section id="txid-digest-1"><h3><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values:</p>
                 <pre>T.1: header_digest       (32-byte hash output)
@@ -562,30 +562,30 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             </section>
         </section>
         <section id="authorizing-data-commitment"><h2><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-61" class="footnote_reference" href="#zip-0244-authcommitment">16</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section. There is a new branch added for issuance information, along with modifications within the <code>orchard_auth_digest</code> to account for the presence of Action Groups.</p>
-            <p>We highlight the changes for the OrchardZSA protocol via the <code>[UPDATED FOR ZSA]</code> or <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
+            <p>The transaction digest algorithm defined in ZIP 244 <a id="footnote-reference-61" class="footnote_reference" href="#zip-0244-authcommitment">16</a> which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section. There is a new branch added for issuance information, and the <code>orchard_auth_digest</code> in ZIP 244 is replaced with <code>orchard_zsa_auth_digest</code> to account for the presence of Action Groups.</p>
+            <p>We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
             <pre>auth_digest
 ├── transparent_scripts_digest
 ├── sapling_auth_digest
-├── orchard_auth_digest         [UPDATED FOR ZSA]
+├── orchard_zsa_auth_digest     [ADDED FOR ZSA]
 └── issuance_auth_digest        [ADDED FOR ZSA]</pre>
             <p>The pair (Transaction Identifier, Auth Commitment) constitutes a commitment to all the data of a serialized transaction that may be included in a block.</p>
             <section id="auth-digest"><h3><span class="section-heading">auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A BLAKE2b-256 hash of the following values</p>
                 <pre>A.1: transparent_scripts_digest (32-byte hash output)
 A.2: sapling_auth_digest        (32-byte hash output)
-A.3: orchard_auth_digest        (32-byte hash output)  [UPDATED FOR ZSA]
+A.3: orchard_zsa_auth_digest    (32-byte hash output)  [ADDED FOR ZSA]
 A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 <p>The personalization field of this hash remains the same as in ZIP 244.</p>
-                <section id="a-3-orchard-auth-digest"><h4><span class="section-heading">A.3: orchard_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-3-orchard-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                <section id="a-3-orchard-zsa-auth-digest"><h4><span class="section-heading">A.3: orchard_zsa_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-3-orchard-zsa-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>In the case that OrchardZSA Action Groups are present, this is a BLAKE2b-256 hash of the following values:</p>
-                    <pre>A.3a: orchard_action_groups_auth_digest  (32-byte hash output)  [ADDED FOR ZSA]
-A.3b: bindingSigOrchard                  (field encoding bytes)</pre>
+                    <pre>A.3a: orchard_zsa_action_groups_auth_digest  (32-byte hash output)
+A.3b: bindingSigOrchard                      (field encoding bytes)</pre>
                     <p>The personalization field of this hash is the same as in ZIP 244, that is:</p>
                     <pre>"ZTxAuthOrchaHash"</pre>
-                    <p>In case that the transaction has no OrchardZSA Action Groups, <code>orchard_auth_digest</code> is:</p>
+                    <p>In case that the transaction has no OrchardZSA Action Groups, <code>orchard_zsa_auth_digest</code> is:</p>
                     <pre>BLAKE2b-256("ZTxAuthOrchaHash", [])</pre>
-                    <section id="a-3a-orchard-action-groups-auth-digest"><h5><span class="section-heading">A.3a: orchard_action_groups_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-3a-orchard-action-groups-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                    <section id="a-3a-orchard-zsa-action-groups-auth-digest"><h5><span class="section-heading">A.3a: orchard_zsa_action_groups_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-3a-orchard-zsa-action-groups-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>This is a BLAKE2b-256 hash of the <code>proofsOrchard</code> and <code>spendAuthSigsOrchard</code> fields of all OrchardZSA Action Groups belonging to the transaction:</p>
                         <pre>A.3a.i:  proofsOrchard               (field encoding bytes)
 A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)</pre>

--- a/rendered/zip-0227.html
+++ b/rendered/zip-0227.html
@@ -356,7 +356,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{rseed}: \mathbb{B}^{[\mathbb{Y}^{32}]}\)</span>
                      MUST be sampled uniformly at random by the issuer.</li>
                 </ul>
-                <p>The complete encoding of these fields into an <code>IssueNote</code> is defined in ZIP 230 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0230-issue-note">16</a>.</p>
+                <p>The complete encoding of these fields into an <code>IssueNote</code> is defined in ZIP 230 <a id="footnote-reference-25" class="footnote_reference" href="#zip-0230-issue-note">17</a>.</p>
                 <p>Let
                     <span class="math">\(\mathsf{Note^{Issue}}\)</span>
                  be the type of an Issue Note, i.e.</p>
@@ -378,7 +378,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                 <p>The
                     <span class="math">\(\mathsf{finalize}\)</span>
                  boolean is set by the Issuer to signal that there will be no further issuance of the specific Custom Asset. As we will see in <a href="#specification-consensus-rule-changes">Specification: Consensus Rule Changes</a>, transactions that attempt to issue further amounts of a Custom Asset that has previously been finalized will be rejected.</p>
-                <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0230-issuance-action-description">15</a>.</p>
+                <p>The complete encoding of these fields into an <code>IssueAction</code> is defined in ZIP 230 <a id="footnote-reference-26" class="footnote_reference" href="#zip-0230-issuance-action-description">16</a>.</p>
             </section>
             <section id="issuance-bundle"><h3><span class="section-heading">Issuance Bundle</span><span class="section-anchor"> <a rel="bookmark" href="#issuance-bundle"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>An issuance bundle is the aggregate of all the issuance-related information. Specifically, contains all the issuance actions and the issuer signature on the transaction SIGHASH that validates the issuance itself. It contains the following fields:</p>
@@ -395,7 +395,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
                         <span class="math">\(\mathsf{isk}\!\)</span>
                     , that validates the issuance.</li>
                 </ul>
-                <p>The issuance bundle is added within the transaction format as a new bundle. The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0230-transaction-format">17</a>.</p>
+                <p>The issuance bundle is added within the transaction format as a new bundle. The detailed encoding of the issuance bundle as a part of the V6 transaction format is defined in ZIP 230 <a id="footnote-reference-27" class="footnote_reference" href="#zip-0230-transaction-format">18</a>.</p>
             </section>
             <section id="computation-of"><h3><span class="section-heading">Computation of ρ</span><span class="section-anchor"> <a rel="bookmark" href="#computation-of"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>We define a function
@@ -760,7 +760,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
             </section>
         </section>
         <section id="txid-digest-issuance"><h2><span class="section-heading">TxId Digest - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-37" class="footnote_reference" href="#zip-0226-txiddigest">13</a>. As in ZIP 244 <a id="footnote-reference-38" class="footnote_reference" href="#zip-0244">19</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
+            <p>This section details the construction of the subtree of hashes in the transaction digest that corresponds to issuance transaction data. Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-37" class="footnote_reference" href="#zip-0226-txiddigest">13</a>. As in ZIP 244 <a id="footnote-reference-38" class="footnote_reference" href="#zip-0244">20</a>, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.</p>
             <p>A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below:</p>
             <pre>issuance_digest
 ├── issue_actions_digest
@@ -775,7 +775,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/680">https://githu
 T.5b: issuanceValidatingKey   (32 bytes)</pre>
                 <p>The personalization field of this hash is set to:</p>
                 <pre>"ZTxIdSAIssueHash"</pre>
-                <p>In case the transaction has no issuance components, ''issuance_digest'' is:</p>
+                <p>In case the transaction has no issuance components, <code>issuance_digest</code> is:</p>
                 <pre>BLAKE2b-256("ZTxIdSAIssueHash", [])</pre>
                 <section id="t-5a-issue-actions-digest"><h4><span class="section-heading">T.5a: issue_actions_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-issue-actions-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>A BLAKE2b-256 hash of Issue Action information for all Issuance Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
@@ -793,7 +793,7 @@ T.5a.i.4: rho                          (field encoding bytes)
 T.5a.i.5: rseed                        (field encoding bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdIAcNoteHash"</pre>
-                        <p>In case the transaction has no Issue Notes, ''issue_notes_digest'' is:</p>
+                        <p>In case the transaction has no Issue Notes, <code>issue_notes_digest</code> is:</p>
                         <pre>BLAKE2b-256("ZTxIdIAcNoteHash", [])</pre>
                         <section id="t-5a-i-1-recipient"><h6><span class="section-heading">T.5a.i.1: recipient</span><span class="section-anchor"> <a rel="bookmark" href="#t-5a-i-1-recipient"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h6>
                             <p>This is the raw encoding of an Orchard shielded payment address as defined in the protocol specification <a id="footnote-reference-39" class="footnote_reference" href="#protocol-orchardpaymentaddrencoding">32</a>.</p>
@@ -830,29 +830,10 @@ T.5a.i.5: rseed                        (field encoding bytes)</pre>
             </section>
         </section>
         <section id="signature-digest"><h2><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The per-input transaction digest algorithm to generate the signature digest in ZIP 244 <a id="footnote-reference-40" class="footnote_reference" href="#zip-0244-sigdigest">20</a> is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action. For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.</p>
-            <p>The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the <code>[ADDED FOR ZSA]</code> text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol:</p>
-            <pre>signature_digest
-├── header_digest
-├── transparent_sig_digest
-├── sapling_digest
-├── orchard_digest
-└── issuance_digest         [ADDED FOR ZSA]</pre>
-            <section id="signature-digest-1"><h3><span class="section-heading">signature_digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest-1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>A BLAKE2b-256 hash of the following values</p>
-                <pre>S.1: header_digest          (32-byte hash output)
-S.2: transparent_sig_digest (32-byte hash output)
-S.3: sapling_digest         (32-byte hash output)
-S.4: orchard_digest         (32-byte hash output)
-S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
-                <p>The personalization field remains the same as in ZIP 244 <a id="footnote-reference-41" class="footnote_reference" href="#zip-0244">19</a>.</p>
-                <section id="s-5-issuance-digest"><h4><span class="section-heading">S.5: issuance_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-issuance-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>Identical to that specified for the transaction identifier.</p>
-                </section>
-            </section>
+            <p>The changes to the signature digest are specified in ZIP 226 <a id="footnote-reference-40" class="footnote_reference" href="#zip-0226-sigdigest">14</a>.</p>
         </section>
         <section id="authorizing-data-commitment-issuance"><h2><span class="section-heading">Authorizing Data Commitment - Issuance</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment-issuance"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This section covers the construction of the subtree of hashes in the authorizing data commitment that corresponds to issuance transaction data. Details of the overall changes to the authorizing data commitment due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-42" class="footnote_reference" href="#zip-0226-authcommitment">14</a>.</p>
+            <p>This section covers the construction of the subtree of hashes in the authorizing data commitment that corresponds to issuance transaction data. Details of the overall changes to the authorizing data commitment due to the OrchardZSA protocol can be found in ZIP 226 <a id="footnote-reference-41" class="footnote_reference" href="#zip-0226-authcommitment">15</a>.</p>
             <section id="a-4-issuance-auth-digest"><h3><span class="section-heading">A.4: issuance_auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#a-4-issuance-auth-digest"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>In the case that Issuance Actions are present, this is a BLAKE2b-256 hash of the field encoding of the <code>issueAuthSig</code> field of the transaction:</p>
                 <pre>A.4a: issueAuthSig            (field encoding bytes)</pre>
@@ -863,7 +844,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             </section>
         </section>
         <section id="orchardzsa-fee-calculation"><h2><span class="section-heading">OrchardZSA Fee Calculation</span><span class="section-anchor"> <a rel="bookmark" href="#orchardzsa-fee-calculation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-43" class="footnote_reference" href="#zip-0317-fee-calc">21</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
+            <p>In addition to the parameters defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-42" class="footnote_reference" href="#zip-0317-fee-calc">21</a>, the OrchardZSA protocol upgrade defines the following additional parameters:</p>
             <table>
                 <thead>
                     <tr>
@@ -917,7 +898,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-44" class="footnote_reference" href="#protocol-txnencoding">33</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-45" class="footnote_reference" href="#zip-0317-fee-calc">21</a>. Note that
+            <p>The other inputs to this formula are taken from transaction fields defined in the Zcash protocol specification <a id="footnote-reference-43" class="footnote_reference" href="#protocol-txnencoding">33</a> and the global state. They are defined in the Fee calculation section of ZIP 317 <a id="footnote-reference-44" class="footnote_reference" href="#zip-0317-fee-calc">21</a>. Note that
                 <span class="math">\(nOrchardActions\!\)</span>
             , that is used in the computation of
                 <span class="math">\(logical\_actions\!\)</span>
@@ -962,7 +943,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                 </ul>
             </section>
             <section id="bridging-assets"><h3><span class="section-heading">Bridging Assets</span><span class="section-anchor"> <a rel="bookmark" href="#bridging-assets"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-46" class="footnote_reference" href="#zip-0226">10</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
+                <p>For bridging purposes, the secure method of off-boarding Assets is to burn an Asset with the burning mechanism in ZIP 226 <a id="footnote-reference-45" class="footnote_reference" href="#zip-0226">10</a>. Users should be aware of issuers that demand the Assets be sent to a specific address on the Zcash chain to be redeemed elsewhere, as this may not reflect the real reserve value of the specific Wrapped Asset.</p>
             </section>
         </section>
         <section id="other-considerations"><h2><span class="section-heading">Other Considerations</span><span class="section-anchor"> <a rel="bookmark" href="#other-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -976,7 +957,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                  in order to properly keep track of the total supply for different Asset Identifiers. This is useful for wallets and other applications that need to keep track of the total supply of Assets.</p>
             </section>
             <section id="fee-structures"><h3><span class="section-heading">Fee Structures</span><span class="section-anchor"> <a rel="bookmark" href="#fee-structures"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 <a id="footnote-reference-47" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">18</a>.</p>
+                <p>The fee mechanism described in this ZIP will follow the mechanism described in ZIP 317, and is described in ZIP 230 <a id="footnote-reference-46" class="footnote_reference" href="#zip-0230-orchardzsa-fee-calculation">19</a>.</p>
             </section>
         </section>
         <section id="test-vectors"><h2><span class="section-heading">Test Vectors</span><span class="section-anchor"> <a rel="bookmark" href="#test-vectors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -1098,10 +1079,18 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0226-authcommitment" class="footnote">
+            <table id="zip-0226-sigdigest" class="footnote">
                 <tbody>
                     <tr>
                         <th>14</th>
+                        <td><a href="zip-0226.html#signature-digest">ZIP 226: Transfer and Burn of Zcash Shielded Assets: Signature Digest</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0226-authcommitment" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>15</th>
                         <td><a href="zip-0226.html#authorizing-data-commitment">ZIP 226: Transfer and Burn of Zcash Shielded Assets - Authorizing Data Commitment</a></td>
                     </tr>
                 </tbody>
@@ -1109,7 +1098,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0230-issuance-action-description" class="footnote">
                 <tbody>
                     <tr>
-                        <th>15</th>
+                        <th>16</th>
                         <td><a href="zip-0230.html#issuance-action-description-issueaction">ZIP 230: Version 6 Transaction Format: Issuance Action Description (IssueAction)</a></td>
                     </tr>
                 </tbody>
@@ -1117,7 +1106,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0230-issue-note" class="footnote">
                 <tbody>
                     <tr>
-                        <th>16</th>
+                        <th>17</th>
                         <td><a href="zip-0230.html#issue-note-description-issuenote">ZIP 230: Version 6 Transaction Format: Issue Note (IssueNote)</a></td>
                     </tr>
                 </tbody>
@@ -1125,7 +1114,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0230-transaction-format" class="footnote">
                 <tbody>
                     <tr>
-                        <th>17</th>
+                        <th>18</th>
                         <td><a href="zip-0230.html#transaction-format">ZIP 230: Version 6 Transaction Format: Transaction Format</a></td>
                     </tr>
                 </tbody>
@@ -1133,7 +1122,7 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0230-orchardzsa-fee-calculation" class="footnote">
                 <tbody>
                     <tr>
-                        <th>18</th>
+                        <th>19</th>
                         <td><a href="zip-0230.html#orchardzsa-fee-calculation">ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation</a></td>
                     </tr>
                 </tbody>
@@ -1141,16 +1130,8 @@ S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]</pre>
             <table id="zip-0244" class="footnote">
                 <tbody>
                     <tr>
-                        <th>19</th>
-                        <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
-                    </tr>
-                </tbody>
-            </table>
-            <table id="zip-0244-sigdigest" class="footnote">
-                <tbody>
-                    <tr>
                         <th>20</th>
-                        <td><a href="zip-0244.html#signature-digest">ZIP 244: Transaction Identifier Non-Malleability: Signature Digest</a></td>
+                        <td><a href="zip-0244.html">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -349,7 +349,7 @@ TxId Digest
 ===========
 
 The transaction digest algorithm defined in ZIP 244 [#zip-0244]_ is modified by the OrchardZSA protocol to add a new branch for issuance information, along with replacement of the ``orchard_digest`` with a new ``orchard_zsa_digest`` to account for the inclusion of the Asset Base and the updated transaction format.
-The details of these changes are described in this section, and highlighted using the ``[UPDATED FOR ZSA]`` or ``[ADDED FOR ZSA]`` text label. We omit the details of the sections that do not change for the OrchardZSA protocol.
+The details of these changes are described in this section, and highlighted using the ``[ADDED FOR ZSA]`` text label. We omit the details of the sections that do not change for the OrchardZSA protocol.
 
 txid_digest
 -----------
@@ -514,14 +514,14 @@ Authorizing Data Commitment
 ===========================
 
 The transaction digest algorithm defined in ZIP 244 [#zip-0244-authcommitment]_ which commits to the authorizing data of a transaction is modified by the OrchardZSA protocol to have the structure specified in this section.
-There is a new branch added for issuance information, along with modifications within the ``orchard_auth_digest`` to account for the presence of Action Groups.
+There is a new branch added for issuance information, and the ``orchard_auth_digest`` in ZIP 244 is replaced with ``orchard_zsa_auth_digest`` to account for the presence of Action Groups.
 
-We highlight the changes for the OrchardZSA protocol via the ``[UPDATED FOR ZSA]`` or ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
+We highlight the changes for the OrchardZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
 
     auth_digest
     ├── transparent_scripts_digest
     ├── sapling_auth_digest
-    ├── orchard_auth_digest         [UPDATED FOR ZSA]
+    ├── orchard_zsa_auth_digest     [ADDED FOR ZSA]
     └── issuance_auth_digest        [ADDED FOR ZSA]
 
 The pair (Transaction Identifier, Auth Commitment) constitutes a commitment to all the data of a serialized transaction that may be included in a block.
@@ -532,30 +532,30 @@ A BLAKE2b-256 hash of the following values ::
 
    A.1: transparent_scripts_digest (32-byte hash output)
    A.2: sapling_auth_digest        (32-byte hash output)
-   A.3: orchard_auth_digest        (32-byte hash output)  [UPDATED FOR ZSA]
+   A.3: orchard_zsa_auth_digest    (32-byte hash output)  [ADDED FOR ZSA]
    A.4: issuance_auth_digest       (32-byte hash output)  [ADDED FOR ZSA]
 
 The personalization field of this hash remains the same as in ZIP 244.
 
 
-A.3: orchard_auth_digest
-````````````````````````
+A.3: orchard_zsa_auth_digest
+````````````````````````````
 
 In the case that OrchardZSA Action Groups are present, this is a BLAKE2b-256 hash of the following values::
 
-    A.3a: orchard_action_groups_auth_digest  (32-byte hash output)  [ADDED FOR ZSA]
-    A.3b: bindingSigOrchard                  (field encoding bytes)
+    A.3a: orchard_zsa_action_groups_auth_digest  (32-byte hash output)
+    A.3b: bindingSigOrchard                      (field encoding bytes)
 
 The personalization field of this hash is the same as in ZIP 244, that is::
 
     "ZTxAuthOrchaHash"
 
-In case that the transaction has no OrchardZSA Action Groups, ``orchard_auth_digest`` is::
+In case that the transaction has no OrchardZSA Action Groups, ``orchard_zsa_auth_digest`` is::
 
     BLAKE2b-256("ZTxAuthOrchaHash", [])
 
-A.3a: orchard_action_groups_auth_digest
-'''''''''''''''''''''''''''''''''''''''
+A.3a: orchard_zsa_action_groups_auth_digest
+'''''''''''''''''''''''''''''''''''''''''''
 
 This is a BLAKE2b-256 hash of the ``proofsOrchard`` and ``spendAuthSigsOrchard`` fields of all OrchardZSA Action Groups belonging to the transaction::
 

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -387,7 +387,7 @@ For each Action Group, the following elements are included in the hash::
     T.4a.i   : orchard_zsa_actions_compact_digest      (32-byte hash output)
     T.4a.ii  : orchard_zsa_actions_memos_digest        (32-byte hash output)
     T.4a.iii : orchard_zsa_actions_noncompact_digest   (32-byte hash output)
-    T.4a.iv  : orchard_zsa_burn_digest             (32-byte hash output)
+    T.4a.iv  : orchard_zsa_burn_digest                 (32-byte hash output)
     T.4a.v   : flagsOrchard                            (1 byte)
     T.4a.vi  : anchorOrchard                           (32 bytes)
     T.4a.vii : nAGExpiryHeight                         (4 bytes)

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -348,7 +348,7 @@ The transaction format for v6 transactions is described in ZIP 230 [#zip-0230]_.
 TxId Digest
 ===========
 
-The transaction digest algorithm defined in ZIP 244 [#zip-0244]_ is modified by the OrchardZSA protocol to add a new branch for issuance information, along with modifications within the ``orchard_digest`` to account for the inclusion of the Asset Base.
+The transaction digest algorithm defined in ZIP 244 [#zip-0244]_ is modified by the OrchardZSA protocol to add a new branch for issuance information, along with replacement of the ``orchard_digest`` with a new ``orchard_zsa_digest`` to account for the inclusion of the Asset Base and the updated transaction format.
 The details of these changes are described in this section, and highlighted using the ``[UPDATED FOR ZSA]`` or ``[ADDED FOR ZSA]`` text label. We omit the details of the sections that do not change for the OrchardZSA protocol.
 
 txid_digest
@@ -358,47 +358,47 @@ A BLAKE2b-256 hash of the following values::
    T.1: header_digest       (32-byte hash output)
    T.2: transparent_digest  (32-byte hash output)
    T.3: sapling_digest      (32-byte hash output)
-   T.4: orchard_digest      (32-byte hash output)  [UPDATED FOR ZSA]
+   T.4: orchard_zsa_digest  (32-byte hash output)  [ADDED FOR ZSA]
    T.5: issuance_digest     (32-byte hash output)  [ADDED FOR ZSA]
 
 The personalization field remains the same as in ZIP 244 [#zip-0244]_.
 
-T.4: orchard_digest
-```````````````````
+T.4: orchard_zsa_digest
+```````````````````````
 When OrchardZSA Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the following values::
 
-    T.4a: orchard_action_groups_digest   (32-byte hash output)          [ADDED FOR ZSA]
-    T.4c: valueBalanceOrchard            (64-bit signed little-endian)
+    T.4a: orchard_zsa_action_groups_digest   (32-byte hash output)
+    T.4b: valueBalanceOrchard                (64-bit signed little-endian)
 
-The personalization field of this hash is the same as in ZIP 244 [#zip-0244]_ ::
+The personalization field of this hash is the same as for ``orchard_digest`` in ZIP 244 [#zip-0244]_ ::
 
     "ZTxIdOrchardHash"
 
-In the case that the transaction has no OrchardZSA Action Groups, ``orchard_digest`` is ::
+In the case that the transaction has no OrchardZSA Action Groups, ``orchard_zsa_digest`` is ::
 
     BLAKE2b-256("ZTxIdOrchardHash", [])
 
-T.4a: orchard_action_groups_digest
-''''''''''''''''''''''''''''''''''
+T.4a: orchard_zsa_action_groups_digest
+''''''''''''''''''''''''''''''''''''''
 
 A BLAKE2b-256 hash of the subset of OrchardZSA Action Groups information for all OrchardZSA Action Groups belonging to the transaction.
 For each Action Group, the following elements are included in the hash::
 
-    T.4a.i   : orchard_actions_compact_digest      (32-byte hash output)
-    T.4a.ii  : orchard_actions_memos_digest        (32-byte hash output)
-    T.4a.iii : orchard_actions_noncompact_digest   (32-byte hash output)
+    T.4a.i   : orchard_zsa_actions_compact_digest      (32-byte hash output)
+    T.4a.ii  : orchard_zsa_actions_memos_digest        (32-byte hash output)
+    T.4a.iii : orchard_zsa_actions_noncompact_digest   (32-byte hash output)
     T.4a.iv  : orchard_zsa_burn_digest             (32-byte hash output)
-    T.4a.v   : flagsOrchard                        (1 byte)
-    T.4a.vi  : anchorOrchard                       (32 bytes)
-    T.4a.vii : nAGExpiryHeight                     (4 bytes)
+    T.4a.v   : flagsOrchard                            (1 byte)
+    T.4a.vi  : anchorOrchard                           (32 bytes)
+    T.4a.vii : nAGExpiryHeight                         (4 bytes)
 
 The personalization field of this hash is set to::
 
     "ZTxIdOrcActGHash"
 
 
-T.4a.i: orchard_actions_compact_digest
-......................................
+T.4a.i: orchard_zsa_actions_compact_digest
+..........................................
 
 A BLAKE2b-256 hash of the subset of OrchardZSA Action information intended to be included in
 an updated version of the ZIP-307 [#zip-0307]_ ``CompactBlock`` format for all OrchardZSA
@@ -408,29 +408,29 @@ in the hash::
    T.4a.i.1 : nullifier            (field encoding bytes)
    T.4a.i.2 : cmx                  (field encoding bytes)
    T.4a.i.3 : ephemeralKey         (field encoding bytes)
-   T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)  [UPDATED FOR ZSA]
+   T.4a.i.4 : encCiphertext[..84]  (First 84 bytes of field encoding)
 
-The personalization field of this hash is the same as in ZIP 244::
+The personalization field of this hash is the same as for ``orchard_actions_compact_digest`` in ZIP 244::
 
   "ZTxIdOrcActCHash"
 
 
-T.4a.ii: orchard_actions_memos_digest
-.....................................
+T.4a.ii: orchard_zsa_actions_memos_digest
+.........................................
 
 A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all OrchardZSA
 Actions belonging to the Action Group. For each Action, the following elements are included
 in the hash::
 
-    T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  [UPDATED FOR ZSA]
+    T.4a.ii.1: encCiphertext[84..596] (contents of the encrypted memo field)  
 
-The personalization field of this hash remains identical to ZIP 244::
+The personalization field of this hash is identical to that for ``orchard_actions_memos_digest`` in ZIP 244::
 
   "ZTxIdOrcActMHash"
 
 
-T.4a.iii: orchard_actions_noncompact_digest
-...........................................
+T.4a.iii: orchard_zsa_actions_noncompact_digest
+...............................................
 
 A BLAKE2b-256 hash of the remaining subset of OrchardZSA Action information **not** intended
 for inclusion in an updated version of the the ZIP 307 [#zip-0307]_ ``CompactBlock``
@@ -439,10 +439,10 @@ the following elements are included in the hash::
 
    T.4a.iii.1 : cv                    (field encoding bytes)
    T.4a.iii.2 : rk                    (field encoding bytes)
-   T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)  [UPDATED FOR ZSA]
+   T.4a.iii.3 : encCiphertext[596..]  (post-memo suffix of field encoding)
    T.4a.iii.4 : outCiphertext         (field encoding bytes)
 
-The personalization field of this hash is defined identically to ZIP 244::
+The personalization field of this hash is defined just as for ``orchard_actions_noncompact_digest`` in ZIP 244::
 
     "ZTxIdOrcActNHash"
 
@@ -461,7 +461,7 @@ The personalization field of this hash is set to::
     "ZTxIdOrcBurnHash"
 
 In case the transaction does not perform the burning of any Assets (i.e. the 
-$\mathsf{assetBurn}$ set is empty), the ''orchard_zsa_burn_digest'' is::
+$\mathsf{assetBurn}$ set is empty), the ``orchard_zsa_burn_digest`` is::
 
     BLAKE2b-256("ZTxIdOrcBurnHash", [])
 
@@ -473,7 +473,42 @@ The details of the computation of this value are in ZIP 227 [#zip-0227-txiddiges
 Signature Digest 
 ================
 
-The details of the changes to this algorithm are in ZIP 227 [#zip-0227-sigdigest]_.
+The per-input transaction digest algorithm to generate the signature digest in ZIP 244 [#zip-0244-sigdigest]_ is modified so that a signature digest is produced for each transparent input, each Sapling input, each OrchardZSA Action, and additionally for each Issuance Action.
+The modifications replace the ``orchard_digest`` in ZIP 244 with a new ``orchard_zsa_digest``, and add a new branch, ``issuance_digest``, for the Issuance Action information.
+
+The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
+
+    signature_digest
+    ├── header_digest
+    ├── transparent_sig_digest
+    ├── sapling_digest
+    ├── orchard_zsa_digest      [ADDED FOR ZSA]
+    └── issuance_digest         [ADDED FOR ZSA]
+
+signature_digest
+----------------
+A BLAKE2b-256 hash of the following values ::
+
+   S.1: header_digest          (32-byte hash output)
+   S.2: transparent_sig_digest (32-byte hash output)
+   S.3: sapling_digest         (32-byte hash output)
+   S.4: orchard_zsa_digest     (32-byte hash output)  [ADDED FOR ZSA]
+   S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]
+
+The personalization field remains the same as in ZIP 244 [#zip-0244]_, namely::
+
+  "ZcashTxHash_" || CONSENSUS_BRANCH_ID
+
+``ZcashTxHash_`` has 1 underscore character.
+
+S.4: orchard_zsa_digest
+```````````````````````
+Identical to that specified for the transaction identifier.
+
+S.5: issuance_digest
+````````````````````
+Identical to the ``issuance_digest`` specified for the transaction identifier in ZIP 227 [zip-0227-txiddigest]_.
+
 
 Authorizing Data Commitment
 ===========================
@@ -594,11 +629,11 @@ References
 .. [#zip-0227-consensus] `ZIP 227: Issuance of Zcash Shielded Assets: Specification: Consensus Rule Changes <zip-0227.html#specification-consensus-rule-changes>`_
 .. [#zip-0227-note-commitment-order] `ZIP 227: Issuance of Zcash Shielded Assets: Addition to the Note Commitment Tree <zip-0227.html#addition-to-the-note-commitment-tree>`_
 .. [#zip-0227-txiddigest] `ZIP 227: Issuance of Zcash Shielded Assets: TxId Digest - Issuance <zip-0227.html#txid-digest-issuance>`_
-.. [#zip-0227-sigdigest] `ZIP 227: Issuance of Zcash Shielded Assets: Signature Digest <zip-0227.html#signature-digest>`_
 .. [#zip-0227-authcommitment] `ZIP 227: Issuance of Zcash Shielded Assets: Authorizing Data Commitment <zip-0227.html#authorizing-data-commitment-issuance>`_
 .. [#zip-0227-orchardzsa-fee-calculation] `ZIP 227: Issuance of Zcash Shielded Assets: OrchardZSA Fee Calculation <zip-0227.html#orchardzsa-fee-calculation>`_
 .. [#zip-0230] `ZIP 230: Version 6 Transaction Format <zip-0230.html>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
+.. [#zip-0244-sigdigest] `ZIP 244: Transaction Identifier Non-Malleability: Signature Digest <zip-0244.html#signature-digest>`_
 .. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_
 .. [#protocol-notes] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.2: Notes <protocol/protocol.pdf#notes>`_

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -557,7 +557,7 @@ In case that the transaction has no OrchardZSA Action Groups, ``orchard_zsa_auth
 A.3a: orchard_zsa_action_groups_auth_digest
 '''''''''''''''''''''''''''''''''''''''''''
 
-This is a BLAKE2b-256 hash of the ``proofsOrchard`` and ``spendAuthSigsOrchard`` fields of all OrchardZSA Action Groups belonging to the transaction::
+This is a BLAKE2b-256 hash of the ``proofsOrchard`` field of all OrchardZSA Action Groups belonging to the transaction; followed by the ``spendAuthSigsOrchard`` fields corresponding to every OrchardZSA Action in the OrchardZSA Action Group, for all OrchardZSA Action Groups belonging to the transaction::
 
     A.3a.i:  proofsOrchard               (field encoding bytes)
     A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -488,7 +488,9 @@ This section details the construction of the subtree of hashes in the transactio
 Details of the overall changes to the transaction digest due to the OrchardZSA protocol can be found in ZIP 226 [#zip-0226-txiddigest]_.
 As in ZIP 244 [#zip-0244]_, the digests are all personalized BLAKE2b-256 hashes, and in cases where no elements are available for hashing, a personalized hash of the empty byte array is used.
 
-A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. Each branch of the subtree will correspond to a specific subset of issuance transaction data. The overall structure of the hash is as follows; each name referenced here will be described in detail below::
+A new issuance transaction digest algorithm is defined that constructs the subtree of the transaction digest tree of hashes for the issuance portion of a transaction. 
+Each branch of the subtree will correspond to a specific subset of issuance transaction data. 
+The overall structure of the hash is as follows; each name referenced here will be described in detail below::
 
     issuance_digest
     ├── issue_actions_digest
@@ -510,7 +512,7 @@ The personalization field of this hash is set to::
 
   "ZTxIdSAIssueHash"
 
-In case the transaction has no issuance components, ''issuance_digest'' is::
+In case the transaction has no issuance components, ``issuance_digest`` is::
 
     BLAKE2b-256("ZTxIdSAIssueHash", [])
 
@@ -540,7 +542,7 @@ The personalization field of this hash is set to::
 
   "ZTxIdIAcNoteHash"
 
-In case the transaction has no Issue Notes, ''issue_notes_digest'' is::
+In case the transaction has no Issue Notes, ``issue_notes_digest`` is::
 
     BLAKE2b-256("ZTxIdIAcNoteHash", [])
 
@@ -583,33 +585,7 @@ A byte encoding of issuance validating key for the bundle as defined in the `Iss
 Signature Digest
 ================
 
-The per-input transaction digest algorithm to generate the signature digest in ZIP 244 [#zip-0244-sigdigest]_ is modified so that a signature digest is produced for each transparent input, each Sapling input, each Orchard action, and additionally for each Issuance Action.
-For Issuance Actions, this algorithm has the exact same output as the transaction digest algorithm, thus the txid may be signed directly.
-
-The overall structure of the hash is as follows. We highlight the changes for the OrchardZSA protocol via the ``[ADDED FOR ZSA]`` text label, and we omit the descriptions of the sections that do not change for the OrchardZSA protocol::
-
-    signature_digest
-    ├── header_digest
-    ├── transparent_sig_digest
-    ├── sapling_digest
-    ├── orchard_digest
-    └── issuance_digest         [ADDED FOR ZSA]
-
-signature_digest
-----------------
-A BLAKE2b-256 hash of the following values ::
-
-   S.1: header_digest          (32-byte hash output)
-   S.2: transparent_sig_digest (32-byte hash output)
-   S.3: sapling_digest         (32-byte hash output)
-   S.4: orchard_digest         (32-byte hash output)
-   S.5: issuance_digest        (32-byte hash output)  [ADDED FOR ZSA]
-
-The personalization field remains the same as in ZIP 244 [#zip-0244]_.
-
-S.5: issuance_digest
-````````````````````
-Identical to that specified for the transaction identifier.
+The changes to the signature digest are specified in ZIP 226 [#zip-0226-sigdigest]_.
 
 Authorizing Data Commitment - Issuance
 ======================================
@@ -765,13 +741,13 @@ References
 .. [#zip-0226-notestructure] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Note Structure & Commitment <zip-0226.html#note-structure-commitment>`_
 .. [#zip-0226-assetburn] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Additional Consensus Rules for the assetBurn set <zip-0226.html#additional-consensus-rules-for-the-assetburn-set>`_
 .. [#zip-0226-txiddigest] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - TxId Digest <zip-0226.html#txid-digest>`_
+.. [#zip-0226-sigdigest] `ZIP 226: Transfer and Burn of Zcash Shielded Assets: Signature Digest <zip-0226.html#signature-digest>`_
 .. [#zip-0226-authcommitment] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Authorizing Data Commitment <zip-0226.html#authorizing-data-commitment>`_
 .. [#zip-0230-issuance-action-description] `ZIP 230: Version 6 Transaction Format: Issuance Action Description (IssueAction) <zip-0230.html#issuance-action-description-issueaction>`_
 .. [#zip-0230-issue-note] `ZIP 230: Version 6 Transaction Format: Issue Note (IssueNote) <zip-0230.html#issue-note-description-issuenote>`_
 .. [#zip-0230-transaction-format] `ZIP 230: Version 6 Transaction Format: Transaction Format <zip-0230.html#transaction-format>`_
 .. [#zip-0230-orchardzsa-fee-calculation] `ZIP 230: Version 6 Transaction Format: OrchardZSA Fee Calculation <zip-0230.html#orchardzsa-fee-calculation>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
-.. [#zip-0244-sigdigest] `ZIP 244: Transaction Identifier Non-Malleability: Signature Digest <zip-0244.html#signature-digest>`_
 .. [#zip-0317-fee-calc] `ZIP 317: Proportional Transfer Fee Mechanism, Fee calculation <zip-0317.html#fee-calculation>`_
 .. [#bip-0043] `BIP 43: Purpose Field for Deterministic Wallets <https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki>`_
 .. [#bip-0340] `BIP 340: Schnorr Signatures for secp256k1 <https://github.com/bitcoin/bips/blob/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb/bip-0340.mediawiki>`_


### PR DESCRIPTION
This PR performs various improvements to the naming of the branches of the TxID and Signature Digests, and the Authorizing Data Commitment, as initially suggested in the review of https://github.com/QED-it/zcash-test-vectors/pull/24. 