### PR TITLE
Diagram update and minor improvements

### DIFF
--- a/zips/zip-0227-asset-identifier-relation-orchard-zsa.svg
+++ b/zips/zip-0227-asset-identifier-relation-orchard-zsa.svg
@@ -378,7 +378,7 @@
            x="605.17181"
            sodipodi:role="line"
            style="font-size:13.9668px;stroke-width:1.12713"
-           id="tspan310-1-3-3">[32 bytes]</tspan></text><text
+           id="tspan310-1-3-3">[33 bytes]</tspan></text><text
          id="text3759-9-8-1-3"
          y="906.77618"
          x="557.94751"
@@ -468,4 +468,4 @@
          sodipodi:role="line"
          id="tspan833"
          x="273.71552"
-         y="976.58667">[65 bytes]</tspan></text></g></svg>
+         y="976.58667">[66 bytes]</tspan></text></g></svg>

--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -161,7 +161,8 @@ Define $\mathsf{IssueAuthSig.DerivePublic} \;{\small ⦂}\; (\mathsf{isk} \;{\sm
 * Return $\bot$ if the $\textit{PubKey}$ algorithm invocation fails, otherwise return $\mathsf{ik}$.
 
 where the $\textit{PubKey}$ algorithm is defined in BIP 340 [#bip-0340]_, and the output of the algorithm is in big-endian order as defined in BIP 340.
-The encoding of $\mathsf{ik}$ begins with a version byte that is $\mathtt{0x00}$. This enables future ZIPs to specify alternative signature schemes.
+The encoding of $\mathsf{ik}$ begins with a byte indicating the signature scheme, which MUST be $\mathtt{0x00}$ indicating BIP 340. 
+This enables future ZIPs to specify alternative signature schemes.
 
 It is possible for the $\textit{PubKey}$ algorithm to fail with very low probability, which means that $\mathsf{IssueAuthSig.DerivePublic}$ could return $\bot$ with very low probability.
 If this happens, discard the keys and repeat with a different $\mathsf{isk}$.
@@ -179,9 +180,8 @@ Define $\mathsf{IssueAuthSig.Sign} \;{\small ⦂}\; (\mathsf{isk} \;{\small ⦂}
 
 where the $\mathsf{Sign}$ algorithm is defined in BIP 340 and $a$ denotes the auxiliary data used in BIP 340 [#bip-0340]_.
 Note that $\mathsf{IssueAuthSig.Sign}$ could return $\bot$ with very low probability.
-Note that the initial $\mathtt{0x00}$ byte in the signature is a version byte, enabling future ZIPs to
-specify alternative issuance authorization signature schemes.
-
+The encoding of the signature begins with a byte indicating the signature scheme, which MUST be $\mathtt{0x00}$ indicating BIP 340. 
+This enables future ZIPs to specify alternative signature schemes.
 
 Define $\mathsf{IssueAuthSig.Validate} \;{\small ⦂}\; (\mathsf{ik} \;{\small ⦂}\; \mathsf{IssueAuthSig.Public}) \times (M \;{\small ⦂}\; \mathsf{IssueAuthSig.Message}) \times (\text{σ} \;{\small ⦂}\; \mathsf{IssueAuthSig.Signature}) \to \mathbb{B}$ as:
 


### PR DESCRIPTION
This PR updates the diagram of the relation between the issuance validating key, asset description and asset identifier to correctly describe the changes made in zcash#1042. It also responds to two comments that were added post the merge of that PR.