### PR TITLE
Updating details of the `orchard_auth_digest`

### DIFF
--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -566,14 +566,28 @@ Note that this means the encoding of ``bindingSigOrchard`` differs from that use
 A.3a: orchard_action_groups_auth_digest
 '''''''''''''''''''''''''''''''''''''''
 
-This is a BLAKE2b-256 hash of the ``proofsOrchard`` field of all OrchardZSA Action Groups belonging to the transaction; followed by the ``spendAuthSigsOrchard`` fields corresponding to every OrchardZSA Action in the OrchardZSA Action Group, for all OrchardZSA Action Groups belonging to the transaction::
+A BLAKE2b-256 hash of the subset of OrchardZSA Action Group information for all OrchardZSA Action Groups belonging to the transaction.
+For each OrchardZSA Action Group, this is a BLAKE2b-256 hash of the following values::
 
-    A.3a.i:  proofsOrchard               (field encoding bytes)
-    A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)
+    A.3a.i:  proofsOrchard                              (field encoding bytes)
+    A.3a.ii: orchard_zsa_spend_auth_sigs_auth_digest    (32-byte hash output)
 
 The personalization field of this hash is set to::
 
     "ZTxAuthOrcAGHash"
+
+The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-group-field-encodings]_.
+
+A.3a.ii: orchard_zsa_spend_auth_sigs_auth_digest
+................................................
+
+This is a BLAKE2b-256 hash of the ``spendAuthSigsOrchard`` field of all OrchardZSA Actions belonging to the OrchardZSA Action Group::
+
+    A.3a.ii.1: spendAuthSigsOrchard    (field encoding bytes)
+
+The personalization field of this hash is set to::
+
+    "ZTxAuthOrSASHash"
 
 The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-group-field-encodings]_.
 Note that this means the encoding of ``spendAuthSigsOrchard`` differs from that used in ZIP 244.


### PR DESCRIPTION
This makes changes to the `orchard_auth_digest` to avoid nested for loops. 

It adds an additional `orchard_zsa_spend_auth_sigs_auth_digest` to aggregate the spend authorization signatures from each Action in the Action Group