### PR TITLE
Fixing the description for `flagsOrchard`

### DIFF
--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -274,8 +274,11 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | 372 × ``nActionsOrchard``   |``vActionsOrchard``           |``OrchardZSAAction[nActionsOrchard]``           |A sequence of OrchardZSA Action descriptions in the Action Group.    |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
-| 1                           |``flagsOrchard``              |``byte``                                        |As defined in §7.1 ‘Transaction Encoding and Consensus’              |
-|                             |                              |                                                |[#protocol-txnencoding]_.                                            |
+|``1``                        |``flagsOrchard``              |``byte``                                        |An 8-bit value representing a set of flags. Ordered from LSB to MSB: |
+|                             |                              |                                                | * ``enableSpendsOrchard``                                           |
+|                             |                              |                                                | * ``enableOutputsOrchard``                                          |
+|                             |                              |                                                | * ``enableZSAs``                                                    |
+|                             |                              |                                                | * The remaining bits are set to :math:`0\!`.                        |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | 32                          |``anchorOrchard``             |``byte[32]``                                    |As defined in §7.1 ‘Transaction Encoding and Consensus’              |
 |                             |                              |                                                |[#protocol-txnencoding]_.                                            |


### PR DESCRIPTION
I seem to have removed the correct description for the `flagsOrchard` field back in https://github.com/QED-it/zips/pull/78 while moving to the Action Groups Description. This removed the description of the `enableZSAs` flag from the spec, which is fixed in this PR.

This is available as upstream https://github.com/zcash/zips/pull/1159