### PR TITLE
Limiting the `valueBurn` to `u63`

### DIFF
--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -229,7 +229,7 @@ Rationale for MAX_BURN_VALUE
 ````````````````````````````
 
 The maximum amount of any Custom Asset allowed to be burnt in a transaction is set to $\mathsf{MAX\_BURN\_VALUE}$ in order to prevent it from being incompatible with other valueBalance fields, which are signed 64-bit integers.
-It will also allow for compatibility with future asset-specific value balances in subsequent pools that support ZSAs via a turnstile.
+It will also allow for compatibility with future Custom-asset-specific value balances in subsequent pools that support transferring ZSAs from the Orchard pool via a turnstile.
 
 Value Balance Verification
 --------------------------

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -228,7 +228,7 @@ This means that unless future consensus rules changes do allow it, unshielding w
 Rationale for MAX_BURN_VALUE
 ````````````````````````````
 
-The maximum amount of any Custom Asset allowed to be burnt in a transaction is set to $2^{63} - 1$ in order to prevent it from being incompatible with other valueBalance fields, which are signed 64-bit integers.
+The maximum amount of any Custom Asset allowed to be burnt in a transaction is set to $\mathsf{MAX\_BURN\_VALUE}$ in order to prevent it from being incompatible with other valueBalance fields, which are signed 64-bit integers.
 It will also allow for compatibility with future asset-specific value balances in subsequent pools that support ZSAs via a turnstile.
 
 Value Balance Verification

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -207,6 +207,7 @@ Note that the OrchardZSA Protocol does not allow for the burning of the Native A
 
 In the `OrchardZSA Transaction Structure`_, there is now an $\mathsf{assetBurn}$ set. 
 For every Custom Asset (represented by its $\mathsf{AssetBase}$) that is burnt in the transaction, the sender adds to $\mathsf{assetBurn}$ the tuple $(\mathsf{AssetBase}, \mathsf{v})$, where $\mathsf{v}$ is the amount of the Custom Asset the sender wants to burn. 
+We define a constant $\mathsf{MAX\_BURN\_VALUE} := 2^{63} - 1$, which denotes the maximum amount of a given Custom Asset that can be burnt in a transaction.
 We denote by $L$ the cardinality of the $\mathsf{assetBurn}$ set in a transaction.
 
 As described in `Value Balance Verification`_, this provides the information for the validator of the transaction to compute the value commitment with the corresponding Asset Base. 
@@ -216,13 +217,19 @@ Additional Consensus Rules for the assetBurn set
 ````````````````````````````````````````````````
 
 1. It MUST be the case that for every $(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{AssetBase} \neq \mathcal{V}^{\mathsf{Orchard}}$. That is, the Native Asset is not allowed to be burnt by this mechanism.
-2. It MUST be that for every $(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{v} \neq 0$.
+2. It MUST be that for every $(\mathsf{AssetBase}, \mathsf{v}) \in \mathsf{assetBurn}, \mathsf{v} > 0$ and $\mathsf{v} \leq \mathsf{MAX\_BURN\_VALUE}$.
 3. There MUST be no duplication of Custom Assets in the $\mathsf{assetBurn}$ set. That is, every $\mathsf{AssetBase}$ has at most one entry in $\mathsf{assetBurn}$.
 
 The other consensus rule changes for the OrchardZSA protocol are specified in ZIP 227 [#zip-0227-consensus]_.
 
 **Note:** The transparent protocol will not be changed with this ZIP to adapt to a multiple Asset structure. 
 This means that unless future consensus rules changes do allow it, unshielding will not be possible for Custom Assets.
+
+Rationale for MAX_BURN_VALUE
+````````````````````````````
+
+The maximum amount of any Custom Asset allowed to be burnt in a transaction is set to $2^{63} - 1$ in order to prevent it from being incompatible with other valueBalance fields, which are signed 64-bit integers.
+It will also allow for compatibility with future asset-specific value balances in subsequent pools that support ZSAs via a turnstile.
 
 Value Balance Verification
 --------------------------

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -364,7 +364,8 @@ An OrchardZSA Asset Burn description is encoded in a transaction as an instance 
 |                             |                              |                                                |:math:`\mathsf{AssetBase^{Orchard}}\!`.                              |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | 8                           |``valueBurn``                 |``uint64``                                      |The amount being burnt. The value is checked by consensus to be      |
-|                             |                              |                                                |non-zero, and less than $\mathsf{MAX\_BURN\_VALUE}$.                 |
+|                             |                              |                                                |non-zero, and less than :math:`\mathsf{MAX\_BURN\_VALUE}`            |
+|                             |                              |                                                |[#zip-0226-burn-mechanism]_.                                         |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 
 The encodings of each of these elements are defined in ZIP 226 [#zip-0226]_.
@@ -698,6 +699,7 @@ References
 .. [#zip-0225] `ZIP 225: Version 5 Transaction Format <zip-0225.rst>`_
 .. [#zip-0225-transaction-format] `ZIP 225: Version 5 Transaction Format. Specification: Transaction Format <zip-0225.rst#transaction-format>`_
 .. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zip-0226.rst>`_
+.. [#zip-0226-burn-mechanism] `ZIP 226: Transfer and Burn of Zcash Shielded Assets - Burn Mechanism <zip-0226.rst#burn-mechanism>`_
 .. [#zip-0226-orchardzsa-transaction-structure] `ZIP 226: Transfer and Burn of Zcash Shielded Assets — OrchardZSA Transaction Structure <zip-0226.rst#orchardzsa-transaction-structure>`_
 .. [#zip-0226-note-structure-and-commitment] `ZIP 226: Transfer and Burn of Zcash Shielded Assets — Note Structure and Commitment <zip-0226#note-structure-and-commitment>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.rst>`_

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -368,7 +368,7 @@ An OrchardZSA Asset Burn description is encoded in a transaction as an instance 
 |                             |                              |                                                |[#zip-0226-burn-mechanism]_.                                         |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 
-The encodings of each of these elements are defined in ZIP 226 [#zip-0226]_.
+The encodings of each of these elements are defined in ZIP 226 [#zip-0226-burn-mechanism]_.
 
 Transparent Sighash Information (``TransparentSighashInfo``)
 ------------------------------------------------------------

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -364,7 +364,7 @@ An OrchardZSA Asset Burn description is encoded in a transaction as an instance 
 |                             |                              |                                                |:math:`\mathsf{AssetBase^{Orchard}}\!`.                              |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | 8                           |``valueBurn``                 |``uint64``                                      |The amount being burnt. The value is checked by consensus to be      |
-|                             |                              |                                                |non-zero.                                                            |
+|                             |                              |                                                |non-zero, and less than $\mathsf{MAX\_BURN\_VALUE}$.                 |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 
 The encodings of each of these elements are defined in ZIP 226 [#zip-0226]_.


### PR DESCRIPTION
As requested in https://github.com/zcash/orchard/pull/471#discussion_r2543702226, this limits the value of the number of a Custom Asset that can be burnt in a transaction to a value that can fit inside a `u63`.

This is a local copy of https://github.com/zcash/zips/pull/1168 in order to view the rendering.